### PR TITLE
Made parallel APIs for SetOperations in Theta, and Tuple (generics).

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 =================
 
-# Apache&reg; DataSketches&trade; Core Java Library Component
+# Apache<sup>&reg;</sup> DataSketches&trade; Core Java Library Component
 This is the core Java component of the DataSketches library.  It contains all of the sketching algorithms and can be accessed directly from user applications. 
 
 This component is also a dependency of other components of the library that create adaptors for target systems, such as Hadoop Pig and Hadoop Hive.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 =================
 
-# DataSketches Core Java Library Component
+# Apache&reg; DataSketches&trade; Core Java Library Component
 This is the core Java component of the DataSketches library.  It contains all of the sketching algorithms and can be accessed directly from user applications. 
 
 This component is also a dependency of other components of the library that create adaptors for target systems, such as Hadoop Pig and Hadoop Hive.

--- a/src/main/java/org/apache/datasketches/BinarySearch.java
+++ b/src/main/java/org/apache/datasketches/BinarySearch.java
@@ -30,7 +30,7 @@ public final class BinarySearch {
   /**
    * Binary Search for the index of the exact float value in the given search range.
    * If -1 is returned there are no values in the search range that equals the given value.
-   * @param arr The given array to search.
+   * @param arr The given ordered array to search.
    * @param low the index of the lowest value of the search range
    * @param high the index of the highest value of the search range
    * @param v the value to search for
@@ -53,7 +53,7 @@ public final class BinarySearch {
   /**
    * Binary Search for the index of the exact double value in the given search range.
    * If -1 is returned there are no values in the search range that equals the given value.
-   * @param arr The given array to search.
+   * @param arr The given ordered array to search.
    * @param low the index of the lowest value of the search range
    * @param high the index of the highest value of the search range
    * @param v the value to search for
@@ -76,7 +76,7 @@ public final class BinarySearch {
   /**
    * Binary Search for the index of the exact long value in the given search range.
    * If -1 is returned there are no values in the search range that equals the given value.
-   * @param arr The given array to search.
+   * @param arr The given ordered array to search.
    * @param low the index of the lowest value of the search range
    * @param high the index of the highest value of the search range
    * @param v the value to search for

--- a/src/main/java/org/apache/datasketches/GenericInequalitySearch.java
+++ b/src/main/java/org/apache/datasketches/GenericInequalitySearch.java
@@ -95,11 +95,6 @@ public class GenericInequalitySearch {
   }
 
   /**
-   * Constructs this class
-   */
-  public GenericInequalitySearch() { }
-
-  /**
    * Binary Search for the index of the generic value in the given search range that satisfies
    * the given inequality.
    * If -1 is returned there are no values in the search range that satisfy the inequality.

--- a/src/main/java/org/apache/datasketches/theta/Intersection.java
+++ b/src/main/java/org/apache/datasketches/theta/Intersection.java
@@ -86,8 +86,8 @@ public abstract class Intersection extends SetOperation {
   public abstract CompactSketch getResult(boolean dstOrdered, WritableMemory dstMem);
 
   /**
-   * Returns true if there is an intersection result available
-   * @return true if there is an intersection result available
+   * Returns true if there is a valid intersection result available
+   * @return true if there is a valid intersection result available
    */
   public abstract boolean hasResult();
 

--- a/src/main/java/org/apache/datasketches/theta/Union.java
+++ b/src/main/java/org/apache/datasketches/theta/Union.java
@@ -24,7 +24,8 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 
 /**
- * The API for Union operations
+ * Compute the union of two or more theta sketches.
+ * A new instance represents an empty set.
  *
  * @author Lee Rhodes
  */
@@ -59,7 +60,7 @@ public abstract class Union extends SetOperation {
   public abstract CompactSketch getResult(boolean dstOrdered, WritableMemory dstMem);
 
   /**
-   * Resets this Union. The seed remains intact, otherwise reverts back to its virgin state.
+   * Resets this Union. The seed remains intact, everything else reverts back to its virgin state.
    */
   public abstract void reset();
 
@@ -71,7 +72,7 @@ public abstract class Union extends SetOperation {
 
   /**
    * This implements a stateless, pair-wise union operation. The returned sketch will be cutback to
-   * k if required, similar to the regular Union operation.
+   * the smaller of the two k values if required.
    *
    * <p>Nulls and empty sketches are ignored.</p>
    *
@@ -104,7 +105,8 @@ public abstract class Union extends SetOperation {
    * This method is not valid for the older SetSketch, which was prior to Open Source (August, 2015).
    *
    * <p>This method can be repeatedly called.
-   * If the given sketch is null it is interpreted as an empty sketch.</p>
+   *
+   * <p>Nulls and empty sketches are ignored.</p>
    *
    * @param sketchIn The incoming sketch.
    */
@@ -116,7 +118,8 @@ public abstract class Union extends SetOperation {
    * This method is not valid for the older SetSketch, which was prior to Open Source (August, 2015).
    *
    * <p>This method can be repeatedly called.
-   * If the given sketch is null it is interpreted as an empty sketch.</p>
+   *
+   * <p>Nulls and empty sketches are ignored.</p>
    *
    * @param sketchIn The incoming sketch.
    * @deprecated 2.0.0.  Use {@link #union(Sketch)} instead.
@@ -130,7 +133,8 @@ public abstract class Union extends SetOperation {
    * called the SetSketch (circa 2012), which was prior to Open Source and are compact and ordered.
    *
    * <p>This method can be repeatedly called.
-   * If the given sketch is null it is interpreted as an empty sketch.</p>
+   *
+   * <p>Nulls and empty sketches are ignored.</p>
    *
    * @param mem Memory image of sketch to be merged
    */
@@ -142,7 +146,8 @@ public abstract class Union extends SetOperation {
    * called the SetSketch (circa 2012), which was prior to Open Source and are compact and ordered.
    *
    * <p>This method can be repeatedly called.
-   * If the given sketch is null it is interpreted as an empty sketch.</p>
+   *
+   * <p>Nulls and empty sketches are ignored.</p>
    *
    * @param mem Memory image of sketch to be merged
    * @deprecated 2.0.0. Use {@link #union(Memory)} instead.

--- a/src/main/java/org/apache/datasketches/theta/UnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/UnionImpl.java
@@ -272,9 +272,12 @@ final class UnionImpl extends Union {
   @Override
   public CompactSketch union(final Sketch sketchA, final Sketch sketchB, final boolean dstOrdered,
       final WritableMemory dstMem) {
-    update(sketchA);
-    update(sketchB);
-    return getResult(dstOrdered, dstMem);
+    reset();
+    union(sketchA);
+    union(sketchB);
+    final CompactSketch csk = getResult(dstOrdered, dstMem);
+    reset();
+    return csk;
   }
 
   @Deprecated
@@ -369,13 +372,13 @@ final class UnionImpl extends Union {
     if (serVer == 2) { //older Sketch, which is compact and ordered
       Util.checkSeedHashes(seedHash_, (short)extractSeedHash(skMem));
       final CompactSketch csk = ForwardCompatibility.heapify2to3(skMem, DEFAULT_UPDATE_SEED);
-      update(csk);
+      union(csk);
       return;
     }
 
     if (serVer == 1) { //much older Sketch, which is compact and ordered
       final CompactSketch csk = ForwardCompatibility.heapify1to3(skMem, DEFAULT_UPDATE_SEED);
-      update(csk);
+      union(csk);
       return;
     }
 

--- a/src/main/java/org/apache/datasketches/tuple/adouble/DoubleSummarySetOperations.java
+++ b/src/main/java/org/apache/datasketches/tuple/adouble/DoubleSummarySetOperations.java
@@ -37,7 +37,26 @@ public final class DoubleSummarySetOperations implements SummarySetOperations<Do
   private final Mode intersectionSummaryMode_;
 
   /**
-   * Creates a new instance with two modes
+   * Creates an instance with default mode of <i>sum</i> for both union and intersection.
+   * This exists for backward compatibility.
+   */
+  public DoubleSummarySetOperations() {
+    unionSummaryMode_ = DoubleSummary.Mode.Sum;
+    intersectionSummaryMode_ = DoubleSummary.Mode.Sum;
+  }
+
+  /**
+   * Creates an instance given a DoubleSummary update mode where the mode is the same for both
+   * union and intersection. This exists for backward compatibility.
+   * @param summaryMode DoubleSummary update mode.
+   */
+  public DoubleSummarySetOperations(final Mode summaryMode) {
+    unionSummaryMode_ = summaryMode;
+    intersectionSummaryMode_ = summaryMode;
+  }
+
+  /**
+   * Creates an instance with two modes.
    * @param unionSummaryMode for unions
    * @param intersectionSummaryMode for intersections
    */

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesIntersection.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesIntersection.java
@@ -51,37 +51,48 @@ public abstract class ArrayOfDoublesIntersection {
   }
 
   /**
-   * Updates the internal set by intersecting it with the given sketch.
-   * @param sketchIn Input sketch to intersect with the internal set.
+   * Performs a stateful intersection of the internal set with the given tupleSketch.
+   * @param tupleSketch Input sketch to intersect with the internal set.
+   * @param combiner Method of combining two arrays of double values
+   * @deprecated 2.0.0 Please use {@link #intersect(ArrayOfDoublesSketch, ArrayOfDoublesCombiner)}.
+   */
+  @Deprecated
+  public void  update(final ArrayOfDoublesSketch tupleSketch, final ArrayOfDoublesCombiner combiner) {
+    intersect(tupleSketch, combiner);
+  }
+
+  /**
+   * Performs a stateful intersection of the internal set with the given tupleSketch.
+   * @param tupleSketch Input sketch to intersect with the internal set.
    * @param combiner Method of combining two arrays of double values
    */
-  public void update(final ArrayOfDoublesSketch sketchIn, final ArrayOfDoublesCombiner combiner) {
+  public void intersect(final ArrayOfDoublesSketch tupleSketch, final ArrayOfDoublesCombiner combiner) {
     final boolean isFirstCall = isFirstCall_;
     isFirstCall_ = false;
-    if (sketchIn == null) {
+    if (tupleSketch == null) {
       isEmpty_ = true;
       sketch_ = null;
       return;
     }
-    Util.checkSeedHashes(seedHash_, sketchIn.getSeedHash());
-    theta_ = min(theta_, sketchIn.getThetaLong());
-    isEmpty_ |= sketchIn.isEmpty();
-    if (isEmpty_ || sketchIn.getRetainedEntries() == 0) {
+    Util.checkSeedHashes(seedHash_, tupleSketch.getSeedHash());
+    theta_ = min(theta_, tupleSketch.getThetaLong());
+    isEmpty_ |= tupleSketch.isEmpty();
+    if (isEmpty_ || tupleSketch.getRetainedEntries() == 0) {
       sketch_ = null;
       return;
     }
     if (isFirstCall) {
-      sketch_ = createSketch(sketchIn.getRetainedEntries(), numValues_, seed_);
-      final ArrayOfDoublesSketchIterator it = sketchIn.iterator();
+      sketch_ = createSketch(tupleSketch.getRetainedEntries(), numValues_, seed_);
+      final ArrayOfDoublesSketchIterator it = tupleSketch.iterator();
       while (it.next()) {
         sketch_.insert(it.getKey(), it.getValues());
       }
     } else { //not the first call
-      final int matchSize = min(sketch_.getRetainedEntries(), sketchIn.getRetainedEntries());
+      final int matchSize = min(sketch_.getRetainedEntries(), tupleSketch.getRetainedEntries());
       final long[] matchKeys = new long[matchSize];
       final double[][] matchValues = new double[matchSize][];
       int matchCount = 0;
-      final ArrayOfDoublesSketchIterator it = sketchIn.iterator();
+      final ArrayOfDoublesSketchIterator it = tupleSketch.iterator();
       while (it.next()) {
         final double[] values = sketch_.find(it.getKey());
         if (values != null) {

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnion.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnion.java
@@ -119,21 +119,37 @@ public abstract class ArrayOfDoublesUnion {
   }
 
   /**
-   * Updates the union by adding a set of entries from a given sketch
-   * @param sketchIn sketch to add to the union
+   * Performs a stateful union of the internal set with the given tupleSketch.
+   * @param tupleSketch input tuple sketch to add to the internal set.
+   *
+   * <p>Nulls and empty sketches are ignored.</p>
+   *
+   * @deprecated 2.0.0. Please use {@link #union(ArrayOfDoublesSketch)}.
    */
-  public void update(final ArrayOfDoublesSketch sketchIn) {
-    if (sketchIn == null) { return; }
-    Util.checkSeedHashes(sketch_.getSeedHash(), sketchIn.getSeedHash());
-    if (sketch_.getNumValues() != sketchIn.getNumValues()) {
+  @Deprecated
+  public void update(final ArrayOfDoublesSketch tupleSketch) {
+    union(tupleSketch);
+  }
+
+  /**
+   * Updates the union by adding a set of entries from a given sketch
+   *
+   * <p>Nulls and empty sketches are ignored.</p>
+   *
+   * @param tupleSketch sketch to add to the union
+   */
+  public void union(final ArrayOfDoublesSketch tupleSketch) {
+    if (tupleSketch == null) { return; }
+    Util.checkSeedHashes(sketch_.getSeedHash(), tupleSketch.getSeedHash());
+    if (sketch_.getNumValues() != tupleSketch.getNumValues()) {
       throw new SketchesArgumentException("Incompatible sketches: number of values mismatch "
-          + sketch_.getNumValues() + " and " + sketchIn.getNumValues());
+          + sketch_.getNumValues() + " and " + tupleSketch.getNumValues());
     }
-    if (sketchIn.isEmpty()) { return; }
-    if (sketchIn.getThetaLong() < theta_) {
-      setThetaLong(sketchIn.getThetaLong());
+    if (tupleSketch.isEmpty()) { return; }
+    if (tupleSketch.getThetaLong() < theta_) {
+      setThetaLong(tupleSketch.getThetaLong());
     }
-    final ArrayOfDoublesSketchIterator it = sketchIn.iterator();
+    final ArrayOfDoublesSketchIterator it = tupleSketch.iterator();
     while (it.next()) {
       if (it.getKey() < theta_) {
         sketch_.merge(it.getKey(), it.getValues());

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesUnionR.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesUnionR.java
@@ -34,7 +34,7 @@ final class DirectArrayOfDoublesUnionR extends DirectArrayOfDoublesUnion {
   }
 
   @Override
-  public void update(final ArrayOfDoublesSketch sketchIn) {
+  public void union(final ArrayOfDoublesSketch tupleSketch) {
     throw new SketchesReadOnlyException();
   }
 

--- a/src/test/java/org/apache/datasketches/BinarySearchTest.java
+++ b/src/test/java/org/apache/datasketches/BinarySearchTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 public class BinarySearchTest {
   static Random rand = new Random(1);
   private static final String LS = System.getProperty("line.separator");
+  private static int randDelta() { return rand.nextDouble() < 0.4 ? 0 : 1; }
 
   private static float[] buildRandFloatArr(final int len) {
     final float[] arr = new float[len];
@@ -58,20 +59,17 @@ public class BinarySearchTest {
     return arr;
   }
 
-  private static int randDelta() { return rand.nextDouble() < 0.4 ? 0 : 1; }
-
-  @Test //visual testing only
-  //@SuppressWarnings("unused")
-  private static void checkBuildRandArr() {
-    final int len = 10;
-    for (int i = 0; i < 10; i++) {
-      final float[] tarr = buildRandFloatArr(len);
-      for (int j = 0; j < len; j++) {
-        printf("%4.1f,", tarr[j]);
-      }
-      println("");
+  private static long[] buildRandLongArr(final int len) {
+    final long[] arr = new long[len];
+    long v = 1L;
+    for (int i = 0; i < len; i++) {
+      arr[i] = v;
+      v += 2 * randDelta();
     }
+    return arr;
   }
+
+  //double array
 
   @Test
   public void checkBinSearchDblLimits() {
@@ -87,8 +85,9 @@ public class BinarySearchTest {
   private static String listDblArray(final double[] arr, final int low, final int high) {
     final StringBuilder sb = new StringBuilder();
     sb.append(LS);
-    sb.append("arr: ");
-    for (int i = 0; i < arr.length; i++) {
+    final int len = arr.length;
+    sb.append("double[" + len + "]: ");
+    for (int i = 0; i < len; i++) {
       if (i == low || i == high) { sb.append(String.format("(%.0f) ", arr[i])); }
       else { sb.append(String.format("%.0f ", arr[i])); }
     }
@@ -176,6 +175,8 @@ public class BinarySearchTest {
     assertEquals(res, -1);
   }
 
+  //float array
+
   @Test
   public void checkBinSearchFltLimits() {
     for (int len = 10; len <= 13; len++) {
@@ -190,8 +191,9 @@ public class BinarySearchTest {
   private static String listFltArray(final float[] arr, final int low, final int high) {
     final StringBuilder sb = new StringBuilder();
     sb.append(LS);
-    sb.append("arr: ");
-    for (int i = 0; i < arr.length; i++) {
+    final int len = arr.length;
+    sb.append("float[" + len + "]: ");
+    for (int i = 0; i < len; i++) {
       if (i == low || i == high) { sb.append(String.format("(%.0f) ", arr[i])); }
       else { sb.append(String.format("%.0f ", arr[i])); }
     }
@@ -279,7 +281,115 @@ public class BinarySearchTest {
     assertEquals(res, -1);
   }
 
-  @Test // visual only
+  //long array
+
+  @Test
+  public void checkBinSearchLongLimits() {
+    for (int len = 10; len <= 13; len++) {
+      final long[] tarr = buildRandLongArr(len);
+      final int low = 2;
+      final int high = len - 2;
+      println(listLongArray(tarr, low, high));
+      checkBinarySearchLongLimits(tarr, low, high);
+    }
+  }
+
+  private static String listLongArray(final long[] arr, final int low, final int high) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(LS);
+    final int len = arr.length;
+    sb.append("long[" + len + "]: ");
+    for (int i = 0; i < len; i++) {
+      if (i == low || i == high) { sb.append(String.format("(%d) ", arr[i])); }
+      else { sb.append(String.format("%d ", arr[i])); }
+    }
+    return sb.toString();
+  }
+
+  private static void checkBinarySearchLongLimits(final long[] arr, final int low, final int high) {
+    final long lowV = arr[low];
+    final long highV = arr[high];
+    long v;
+    int res;
+    v = lowV - 1;
+    res = InequalitySearch.find(arr, low, high, v, LT);
+    println(LT.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = lowV;
+    res = InequalitySearch.find(arr, low, high, v, LT);
+    println(LT.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = highV + 1;
+    res = InequalitySearch.find(arr, low, high, v, LT);
+    println(LT.desc(arr, low, high, v, res));
+    assertEquals(res, high);
+
+    v = lowV -1;
+    res = InequalitySearch.find(arr, low, high, v, LE);
+    println(LE.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = highV;
+    res = InequalitySearch.find(arr, low, high, v, LE);
+    println(LE.desc(arr, low, high, v, res));
+    assertEquals(res, high);
+
+    v = highV + 1;
+    res = InequalitySearch.find(arr, low, high, v, LE);
+    println(LE.desc(arr, low, high, v, res));
+    assertEquals(res, high);
+
+    v = lowV - 1;
+    res = InequalitySearch.find(arr, low, high, v, EQ);
+    println(EQ.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = highV;
+    res = InequalitySearch.find(arr, low, high, v, EQ);
+    println(EQ.desc(arr, low, high, v, res));
+    assertEquals(arr[res], v);
+
+    v = highV + 1;
+    res = InequalitySearch.find(arr, low, high, v, EQ);
+    println(EQ.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = lowV - 1;
+    res = InequalitySearch.find(arr, low, high, v, GT);
+    println(GT.desc(arr, low, high, v, res));
+    assertEquals(res, low);
+
+    v = highV;
+    res = InequalitySearch.find(arr, low, high, v, GT);
+    println(GT.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = highV + 1;
+    res = InequalitySearch.find(arr, low, high, v, GT);
+    println(GT.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+
+    v = lowV - 1;
+    res = InequalitySearch.find(arr, low, high, v, GE);
+    println(GE.desc(arr, low, high, v, res));
+    assertEquals(res, low);
+
+    v = lowV;
+    res = InequalitySearch.find(arr, low, high, v, GE);
+    println(GE.desc(arr, low, high, v, res));
+    assertEquals(res, low);
+
+    v = highV + 1;
+    res = InequalitySearch.find(arr, low, high, v, GE);
+    println(GE.desc(arr, low, high, v, res));
+    assertEquals(res, -1);
+  }
+
+  /****************/
+
+  @Test // visual only for doubles inequality
   public void exerciseDblBinSearch() {
     //                    0 1 2 3 4 5,6
     final double[] arr = {1,1,3,3,4,5,5};
@@ -308,7 +418,7 @@ public class BinarySearchTest {
     println("");
   }
 
-  @Test // visual only
+  @Test // visual only for floats inequality
   public void exerciseFltBinSearch() {
     //                   0 1 2 3 4 5 6 7 8 9
     final float[] arr = {5,5,5,6,6,6,7,8,8,8};
@@ -321,7 +431,7 @@ public class BinarySearchTest {
   private static void checkFindFloat(final float[] arr, final InequalitySearch crit) {
     println("InequalitySearch: " + crit.name());
     final int len = arr.length;
-    for (float v = 0.5f; v <= arr[len - 1] + 0.5f; v += .5f)
+    for (float v = 0.5f; v <= arr[len - 1] + 0.5f; v += 0.5f)
     //final double v = 0.5;
     {
       final int low = 0;
@@ -336,6 +446,38 @@ public class BinarySearchTest {
     }
     println("");
   }
+
+  @Test // visual only for longs inequality
+  public void exerciseLongBinSearch() {
+    //                   0 1 2 3 4 5 6 7  8  9
+    final long[] arr =  {5,5,5,7,7,7,9,11,11,11};
+    checkFindLong(arr, LT);
+    checkFindLong(arr, LE);
+    checkFindLong(arr, GT);
+    checkFindLong(arr, GE);
+  }
+
+  /****************/
+
+  private static void checkFindLong(final long[] arr, final InequalitySearch crit) {
+    println("InequalitySearch: " + crit.name());
+    final int len = arr.length;
+    for (long v = 1L; v <= arr[len - 1] + 1L; v++)
+    {
+      final int low = 0;
+      final int high = len - 1;
+      final int idx = InequalitySearch.find(arr, low, high, v, crit);
+      if (idx == -1) {
+        println("LT: " + v + " Not resolved, return -1.");
+      }
+      else {
+        println(crit.desc(arr, low, high, v, idx));
+      }
+    }
+    println("");
+  }
+
+  //test equality binary searches
 
   @Test
   public void checkSimpleFindFloat() {
@@ -369,6 +511,36 @@ public class BinarySearchTest {
     assertEquals(idx, -1);
   }
 
+  @Test
+  public void checkSimpleFindLong() {
+    final int len = 11;
+    final long[] arr = new long[len];
+    for (int i = 0; i < len; i++) { arr[i] = i; }
+    int idx;
+    for (int i = 0; i < len; i++) {
+      idx = BinarySearch.find(arr, 0, len - 1, i);
+      assertEquals(idx, i);
+    }
+    idx = BinarySearch.find(arr, 0, len - 1, -1);
+    assertEquals(idx, -1);
+    idx = BinarySearch.find(arr, 0, len - 1, len);
+    assertEquals(idx, -1);
+  }
+
+  /****************/
+
+  //@Test //visual testing only
+  @SuppressWarnings("unused")
+  private static void checkBuildRandFloatArr() {
+    final int len = 10;
+    for (int i = 0; i < 10; i++) {
+      final float[] tarr = buildRandFloatArr(len);
+      for (int j = 0; j < len; j++) {
+        printf("%4.1f,", tarr[j]);
+      }
+      println("");
+    }
+  }
 
   /**
    * @param format the format

--- a/src/test/java/org/apache/datasketches/tuple/ReadOnlyMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/ReadOnlyMemoryTest.java
@@ -19,9 +19,7 @@
 
 package org.apache.datasketches.tuple;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
+import org.apache.datasketches.SketchesReadOnlyException;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesSetOperationBuilder;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesSketch;
@@ -29,28 +27,29 @@ import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesSketches;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUnion;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketch;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketchBuilder;
-import org.apache.datasketches.SketchesReadOnlyException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 @SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test
   public void wrapAndTryUpdatingSketch() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1});
-    ArrayOfDoublesUpdatableSketch sketch2 = (ArrayOfDoublesUpdatableSketch)
+    final ArrayOfDoublesUpdatableSketch sketch2 = (ArrayOfDoublesUpdatableSketch)
         ArrayOfDoublesSketches.wrapSketch(Memory.wrap(sketch1.toByteArray()));
     Assert.assertEquals(sketch2.getEstimate(), 1.0);
     sketch2.toByteArray();
     boolean thrown = false;
     try {
       sketch2.update(2, new double[] {1});
-    } catch (SketchesReadOnlyException e) {
+    } catch (final SketchesReadOnlyException e) {
       thrown = true;
     }
     try {
       sketch2.trim();
-    } catch (SketchesReadOnlyException e) {
+    } catch (final SketchesReadOnlyException e) {
       thrown = true;
     }
     Assert.assertTrue(thrown);
@@ -58,10 +57,10 @@ public class ReadOnlyMemoryTest {
 
   @Test
   public void heapifyAndUpdateSketch() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1});
     // downcasting is not recommended, for testing only
-    ArrayOfDoublesUpdatableSketch sketch2 = (ArrayOfDoublesUpdatableSketch)
+    final ArrayOfDoublesUpdatableSketch sketch2 = (ArrayOfDoublesUpdatableSketch)
         ArrayOfDoublesSketches.heapifySketch(Memory.wrap(sketch1.toByteArray()));
     sketch2.update(2, new double[] {1});
     Assert.assertEquals(sketch2.getEstimate(), 2.0);
@@ -69,29 +68,29 @@ public class ReadOnlyMemoryTest {
 
   @Test
   public void wrapAndTryUpdatingUnionEstimationMode() {
-    int numUniques = 10000;
+    final int numUniques = 10000;
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < numUniques; i++) {
       sketch1.update(key++, new double[] {1});
     }
-    ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union1.update(sketch1);
-    ArrayOfDoublesUnion union2 = ArrayOfDoublesSketches.wrapUnion(Memory.wrap(union1.toByteArray()));
-    ArrayOfDoublesSketch resultSketch = union2.getResult();
+    final ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union1.union(sketch1);
+    final ArrayOfDoublesUnion union2 = ArrayOfDoublesSketches.wrapUnion(Memory.wrap(union1.toByteArray()));
+    final ArrayOfDoublesSketch resultSketch = union2.getResult();
     Assert.assertTrue(resultSketch.isEstimationMode());
     Assert.assertEquals(resultSketch.getEstimate(), numUniques, numUniques * 0.04);
 
     // make sure union update actually needs to modify the union
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < numUniques; i++) {
       sketch2.update(key++, new double[] {1});
     }
 
     boolean thrown = false;
     try {
-      union2.update(sketch2);
-    } catch (SketchesReadOnlyException e) {
+      union2.union(sketch2);
+    } catch (final SketchesReadOnlyException e) {
       thrown = true;
     }
     Assert.assertTrue(thrown);
@@ -99,25 +98,25 @@ public class ReadOnlyMemoryTest {
 
   @Test
   public void heapifyAndUpdateUnion() {
-    int numUniques = 10000;
+    final int numUniques = 10000;
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < numUniques; i++) {
       sketch1.update(key++, new double[] {1});
     }
-    ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union1.update(sketch1);
-    ArrayOfDoublesUnion union2 = ArrayOfDoublesSketches.heapifyUnion(Memory.wrap(union1.toByteArray()));
-    ArrayOfDoublesSketch resultSketch = union2.getResult();
+    final ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union1.union(sketch1);
+    final ArrayOfDoublesUnion union2 = ArrayOfDoublesSketches.heapifyUnion(Memory.wrap(union1.toByteArray()));
+    final ArrayOfDoublesSketch resultSketch = union2.getResult();
     Assert.assertTrue(resultSketch.isEstimationMode());
     Assert.assertEquals(resultSketch.getEstimate(), numUniques, numUniques * 0.04);
 
     // make sure union update actually needs to modify the union
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < numUniques; i++) {
       sketch2.update(key++, new double[] {1});
     }
-    union2.update(sketch2);
+    union2.union(sketch2);
   }
 
 }

--- a/src/test/java/org/apache/datasketches/tuple/TupleExamples2Test.java
+++ b/src/test/java/org/apache/datasketches/tuple/TupleExamples2Test.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.tuple;
+
+  import static org.testng.Assert.assertEquals;
+
+import org.apache.datasketches.theta.UpdateSketch;
+import org.apache.datasketches.theta.UpdateSketchBuilder;
+import org.apache.datasketches.tuple.adouble.DoubleSummary;
+import org.apache.datasketches.tuple.adouble.DoubleSummary.Mode;
+import org.apache.datasketches.tuple.adouble.DoubleSummaryFactory;
+import org.apache.datasketches.tuple.adouble.DoubleSummarySetOperations;
+import org.testng.annotations.Test;
+
+  /**
+   * Tests for Version 2.0.0
+   * @author Lee Rhodes
+   */
+  @SuppressWarnings("javadoc")
+  public class TupleExamples2Test {
+    private final DoubleSummary.Mode umode = Mode.Sum;
+    private final DoubleSummary.Mode imode = Mode.AlwaysOne;
+    private final DoubleSummarySetOperations dsso0 = new DoubleSummarySetOperations();
+    private final DoubleSummarySetOperations dsso1 = new DoubleSummarySetOperations(umode);
+    private final DoubleSummarySetOperations dsso2 = new DoubleSummarySetOperations(umode, imode);
+    private final DoubleSummaryFactory ufactory = new DoubleSummaryFactory(umode);
+    private final DoubleSummaryFactory ifactory = new DoubleSummaryFactory(imode);
+    private final UpdateSketchBuilder thetaBldr = UpdateSketch.builder();
+    private final UpdatableSketchBuilder<Double, DoubleSummary> tupleBldr =
+        new UpdatableSketchBuilder<>(ufactory);
+
+
+    @Test
+    public void example1() { // stateful: tuple, theta, use dsso2
+      //Load source sketches
+      final UpdatableSketch<Double, DoubleSummary> tupleSk = tupleBldr.build();
+      final UpdateSketch thetaSk = thetaBldr.build();
+      for (int i = 1; i <= 12; i++) {
+        tupleSk.update(i, 1.0);
+        thetaSk.update(i + 3);
+      }
+
+      //Union
+      final Union<DoubleSummary> union = new Union<>(dsso2);
+      union.union(tupleSk);
+      union.union(thetaSk, ufactory.newSummary().update(1.0));
+      final CompactSketch<DoubleSummary> ucsk = union.getResult();
+      int entries = ucsk.getRetainedEntries();
+      println("Union Stateful: tuple, theta: " + entries);
+      final SketchIterator<DoubleSummary> uiter = ucsk.iterator();
+      int counter = 1;
+      int twos = 0;
+      int ones = 0;
+      while (uiter.next()) {
+        final int i = (int)uiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+        if (i == 1) { ones++; }
+        if (i == 2) { twos++; }
+      }
+      assertEquals(ones, 6);
+      assertEquals(twos, 9);
+
+      //Intersection
+      final Intersection<DoubleSummary> inter = new Intersection<>(dsso2);
+      inter.intersect(tupleSk);
+      inter.intersect(thetaSk, ifactory.newSummary().update(1.0));
+      final CompactSketch<DoubleSummary> icsk = inter.getResult();
+      entries = icsk.getRetainedEntries();
+      println("Intersection Stateful: tuple, theta: " + entries);
+      final SketchIterator<DoubleSummary> iiter = icsk.iterator();
+      counter = 1;
+      while (iiter.next()) {
+        final int i = (int)iiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 1
+        assertEquals(i, 1);
+      }
+    }
+
+    @Test
+    public void example2() { //stateless: tuple1, tuple2, use dsso2
+      //Load source sketches
+      final UpdatableSketch<Double, DoubleSummary> tupleSk1 = tupleBldr.build();
+      final UpdatableSketch<Double, DoubleSummary> tupleSk2 = tupleBldr.build();
+
+      for (int i = 1; i <= 12; i++) {
+        tupleSk1.update(i, 1.0);
+        tupleSk2.update(i + 3, 1.0);
+      }
+
+      //Union
+      final Union<DoubleSummary> union = new Union<>(dsso2);
+      final CompactSketch<DoubleSummary> ucsk = union.union(tupleSk1, tupleSk2);
+      int entries = ucsk.getRetainedEntries();
+      println("Union: " + entries);
+      final SketchIterator<DoubleSummary> uiter = ucsk.iterator();
+      int counter = 1;
+      int twos = 0;
+      int ones = 0;
+      while (uiter.next()) {
+        final int i = (int)uiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+        if (i == 1) { ones++; }
+        if (i == 2) { twos++; }
+      }
+      assertEquals(ones, 6);
+      assertEquals(twos, 9);
+
+      //Intersection
+      final Intersection<DoubleSummary> inter = new Intersection<>(dsso2);
+      final CompactSketch<DoubleSummary> icsk = inter.intersect(tupleSk1, tupleSk2);
+      entries = icsk.getRetainedEntries();
+      println("Intersection: " + entries);
+      final SketchIterator<DoubleSummary> iiter = icsk.iterator();
+      counter = 1;
+      while (iiter.next()) {
+        final int i = (int)iiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2
+        assertEquals(i, 1);
+      }
+    }
+
+    @Test
+    public void example3() { //stateless: tuple1, tuple2, use dsso2
+      //Load source sketches
+      final UpdatableSketch<Double, DoubleSummary> tupleSk = tupleBldr.build();
+      final UpdateSketch thetaSk = thetaBldr.build();
+      for (int i = 1; i <= 12; i++) {
+        tupleSk.update(i, 1.0);
+        thetaSk.update(i + 3);
+      }
+
+      //Union
+      final Union<DoubleSummary> union = new Union<>(dsso2);
+      final CompactSketch<DoubleSummary> ucsk =
+          union.union(tupleSk, thetaSk, ufactory.newSummary().update(1.0));
+      int entries = ucsk.getRetainedEntries();
+      println("Union: " + entries);
+      final SketchIterator<DoubleSummary> uiter = ucsk.iterator();
+      int counter = 1;
+      int twos = 0;
+      int ones = 0;
+      while (uiter.next()) {
+        final int i = (int)uiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+        if (i == 1) { ones++; }
+        if (i == 2) { twos++; }
+      }
+      assertEquals(ones, 6);
+      assertEquals(twos, 9);
+
+      //Intersection
+      final Intersection<DoubleSummary> inter = new Intersection<>(dsso2);
+      final CompactSketch<DoubleSummary> icsk =
+          inter.intersect(tupleSk, thetaSk, ufactory.newSummary().update(1.0));
+      entries = icsk.getRetainedEntries();
+      println("Intersection: " + entries);
+      final SketchIterator<DoubleSummary> iiter = icsk.iterator();
+      counter = 1;
+      while (iiter.next()) {
+        final int i = (int)iiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2
+        assertEquals(i, 1);
+      }
+    }
+
+    @Test
+    public void example4() { //stateful: tuple, theta, Mode=sum for both, use dsso0
+      //Load source sketches
+      final UpdatableSketch<Double, DoubleSummary> tupleSk = tupleBldr.build();
+      final UpdateSketch thetaSk = thetaBldr.build();
+      for (int i = 1; i <= 12; i++) {
+        tupleSk.update(i, 1.0);
+        thetaSk.update(i + 3);
+      }
+
+      //Union
+      final Union<DoubleSummary> union = new Union<>(dsso0);
+      union.union(tupleSk);
+      union.union(thetaSk, ufactory.newSummary().update(1.0));
+      final CompactSketch<DoubleSummary> ucsk = union.getResult();
+      int entries = ucsk.getRetainedEntries();
+      println("Union Stateful: tuple, theta: " + entries);
+      final SketchIterator<DoubleSummary> uiter = ucsk.iterator();
+      int counter = 1;
+      int twos = 0;
+      int ones = 0;
+      while (uiter.next()) {
+        final int i = (int)uiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+        if (i == 1) { ones++; }
+        if (i == 2) { twos++; }
+      }
+      assertEquals(ones, 6);
+      assertEquals(twos, 9);
+
+      //Intersection
+      final Intersection<DoubleSummary> inter = new Intersection<>(dsso0);
+      inter.intersect(tupleSk);
+      inter.intersect(thetaSk, ifactory.newSummary().update(1.0));
+      final CompactSketch<DoubleSummary> icsk = inter.getResult();
+      entries = icsk.getRetainedEntries();
+      println("Intersection Stateful: tuple, theta: " + entries);
+      final SketchIterator<DoubleSummary> iiter = icsk.iterator();
+      counter = 1;
+      while (iiter.next()) {
+        final int i = (int)iiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 1
+        assertEquals(i, 2);
+      }
+    }
+
+    @Test
+    public void example5() { //stateful, tuple, theta, Mode=sum for both, use dsso1
+      //Load source sketches
+      final UpdatableSketch<Double, DoubleSummary> tupleSk = tupleBldr.build();
+      final UpdateSketch thetaSk = thetaBldr.build();
+      for (int i = 1; i <= 12; i++) {
+        tupleSk.update(i, 1.0);
+        thetaSk.update(i + 3);
+      }
+
+      //Union
+      final Union<DoubleSummary> union = new Union<>(dsso1);
+      union.union(tupleSk);
+      union.union(thetaSk, ufactory.newSummary().update(1.0));
+      final CompactSketch<DoubleSummary> ucsk = union.getResult();
+      int entries = ucsk.getRetainedEntries();
+      println("Union Stateful: tuple, theta: " + entries);
+      final SketchIterator<DoubleSummary> uiter = ucsk.iterator();
+      int counter = 1;
+      int twos = 0;
+      int ones = 0;
+      while (uiter.next()) {
+        final int i = (int)uiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+        if (i == 1) { ones++; }
+        if (i == 2) { twos++; }
+      }
+      assertEquals(ones, 6);
+      assertEquals(twos, 9);
+
+      //Intersection
+      final Intersection<DoubleSummary> inter = new Intersection<>(dsso1);
+      inter.intersect(tupleSk);
+      inter.intersect(thetaSk, ifactory.newSummary().update(1.0));
+      final CompactSketch<DoubleSummary> icsk = inter.getResult();
+      entries = icsk.getRetainedEntries();
+      println("Intersection Stateful: tuple, theta: " + entries);
+      final SketchIterator<DoubleSummary> iiter = icsk.iterator();
+      counter = 1;
+      while (iiter.next()) {
+        final int i = (int)iiter.getSummary().getValue();
+        println(counter++ + ", " + i); //9 entries = 1
+        assertEquals(i, 2);
+      }
+    }
+
+
+    @Test
+    public void printlnTest() {
+      println("PRINTING: "+this.getClass().getName());
+    }
+
+    /**
+     * @param s value to print
+     */
+    static void println(final String s) {
+      //System.out.println(s); //enable/disable here
+    }
+
+}

--- a/src/test/java/org/apache/datasketches/tuple/TupleExamplesTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/TupleExamplesTest.java
@@ -29,7 +29,10 @@ import org.apache.datasketches.tuple.aninteger.IntegerSummaryFactory;
 import org.apache.datasketches.tuple.aninteger.IntegerSummarySetOperations;
 import org.testng.annotations.Test;
 
-
+/**
+ * Tests for Version 2.0.0
+ * @author Lee Rhodes
+ */
 @SuppressWarnings("javadoc")
 public class TupleExamplesTest {
   private final IntegerSummary.Mode umode = Mode.Sum;
@@ -43,7 +46,7 @@ public class TupleExamplesTest {
 
 
   @Test
-  public void tuple2dot0Examples() {
+  public void example1() {
     //Load source sketches
     final UpdatableSketch<Integer, IntegerSummary> tupleSk = tupleBldr.build();
     final UpdateSketch thetaSk = thetaBldr.build();
@@ -52,11 +55,56 @@ public class TupleExamplesTest {
       thetaSk.update(i + 3);
     }
 
-    //Union
+    //Union stateful: tuple, theta
     final Union<IntegerSummary> union = new Union<>(isso);
-    union.update(tupleSk);
-    union.update(thetaSk, ufactory.newSummary().update(1));
+    union.union(tupleSk);
+    union.union(thetaSk, ufactory.newSummary().update(1));
     final CompactSketch<IntegerSummary> ucsk = union.getResult();
+    int entries = ucsk.getRetainedEntries();
+    println("Union Stateful: tuple, theta: " + entries);
+    final SketchIterator<IntegerSummary> uiter = ucsk.iterator();
+    int counter = 1;
+    int twos = 0;
+    int ones = 0;
+    while (uiter.next()) {
+      final int i = uiter.getSummary().getValue();
+      println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+      if (i == 1) { ones++; }
+      if (i == 2) { twos++; }
+    }
+    assertEquals(ones, 6);
+    assertEquals(twos, 9);
+
+    //Intersection stateful: tuple, theta
+    final Intersection<IntegerSummary> inter = new Intersection<>(isso);
+    inter.intersect(tupleSk);
+    inter.intersect(thetaSk, ifactory.newSummary().update(1));
+    final CompactSketch<IntegerSummary> icsk = inter.getResult();
+    entries = icsk.getRetainedEntries();
+    println("Intersection Stateful: tuple, theta: " + entries);
+    final SketchIterator<IntegerSummary> iiter = icsk.iterator();
+    counter = 1;
+    while (iiter.next()) {
+      final int i = iiter.getSummary().getValue();
+      println(counter++ + ", " + i); //9 entries = 1
+      assertEquals(i, 1);
+    }
+  }
+
+  @Test
+  public void example2() {
+    //Load source sketches
+    final UpdatableSketch<Integer, IntegerSummary> tupleSk1 = tupleBldr.build();
+    final UpdatableSketch<Integer, IntegerSummary> tupleSk2 = tupleBldr.build();
+
+    for (int i = 1; i <= 12; i++) {
+      tupleSk1.update(i, 1);
+      tupleSk2.update(i + 3, 1);
+    }
+
+    //Union, stateless: tuple1, tuple2
+    final Union<IntegerSummary> union = new Union<>(isso);
+    final CompactSketch<IntegerSummary> ucsk = union.union(tupleSk1, tupleSk2);
     int entries = ucsk.getRetainedEntries();
     println("Union: " + entries);
     final SketchIterator<IntegerSummary> uiter = ucsk.iterator();
@@ -72,18 +120,60 @@ public class TupleExamplesTest {
     assertEquals(ones, 6);
     assertEquals(twos, 9);
 
-    //Intersection
+    //Intersection stateless: tuple1, tuple2
     final Intersection<IntegerSummary> inter = new Intersection<>(isso);
-    inter.update(tupleSk);
-    inter.update(thetaSk, ifactory.newSummary().update(1));
-    final CompactSketch<IntegerSummary> icsk = inter.getResult();
+    final CompactSketch<IntegerSummary> icsk = inter.intersect(tupleSk1, tupleSk2);
     entries = icsk.getRetainedEntries();
     println("Intersection: " + entries);
     final SketchIterator<IntegerSummary> iiter = icsk.iterator();
     counter = 1;
     while (iiter.next()) {
       final int i = iiter.getSummary().getValue();
-      println(counter++ + ", " + i); //9 entries = 1
+      println(counter++ + ", " + i); //9 entries = 2
+      assertEquals(i, 1);
+    }
+  }
+
+  @Test
+  public void example3() {
+    //Load source sketches
+    final UpdatableSketch<Integer, IntegerSummary> tupleSk = tupleBldr.build();
+    final UpdateSketch thetaSk = thetaBldr.build();
+    for (int i = 1; i <= 12; i++) {
+      tupleSk.update(i, 1);
+      thetaSk.update(i + 3);
+    }
+
+    //Union, stateless: tuple1, tuple2
+    final Union<IntegerSummary> union = new Union<>(isso);
+    final CompactSketch<IntegerSummary> ucsk =
+        union.union(tupleSk, thetaSk, ufactory.newSummary().update(1));
+    int entries = ucsk.getRetainedEntries();
+    println("Union: " + entries);
+    final SketchIterator<IntegerSummary> uiter = ucsk.iterator();
+    int counter = 1;
+    int twos = 0;
+    int ones = 0;
+    while (uiter.next()) {
+      final int i = uiter.getSummary().getValue();
+      println(counter++ + ", " + i); //9 entries = 2, 6 entries = 1
+      if (i == 1) { ones++; }
+      if (i == 2) { twos++; }
+    }
+    assertEquals(ones, 6);
+    assertEquals(twos, 9);
+
+    //Intersection stateless: tuple1, tuple2
+    final Intersection<IntegerSummary> inter = new Intersection<>(isso);
+    final CompactSketch<IntegerSummary> icsk =
+        inter.intersect(tupleSk, thetaSk, ufactory.newSummary().update(1));
+    entries = icsk.getRetainedEntries();
+    println("Intersection: " + entries);
+    final SketchIterator<IntegerSummary> iiter = icsk.iterator();
+    counter = 1;
+    while (iiter.next()) {
+      final int i = iiter.getSummary().getValue();
+      println(counter++ + ", " + i); //9 entries = 2
       assertEquals(i, 1);
     }
   }

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleIntersectionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleIntersectionTest.java
@@ -45,14 +45,14 @@ public class AdoubleIntersectionTest {
 
   @Test
   public void intersectionNotEmptyNoEntries() {
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>
           (new DoubleSummaryFactory(mode)).setSamplingProbability(0.01f).build();
     sketch1.update("a", 1.0); // this happens to get rejected because of sampling with low probability
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
-    intersection.update(sketch1);
-    CompactSketch<DoubleSummary> result = intersection.getResult();
+    intersection.intersect(sketch1);
+    final CompactSketch<DoubleSummary> result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -62,19 +62,19 @@ public class AdoubleIntersectionTest {
 
   @Test
   public void intersectionExactWithEmpty() {
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     sketch1.update(1, 1.0);
     sketch1.update(2, 1.0);
     sketch1.update(3, 1.0);
 
-    Sketch<DoubleSummary> sketch2 = Sketches.createEmptySketch();
+    final Sketch<DoubleSummary> sketch2 = Sketches.createEmptySketch();
 
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
-    intersection.update(sketch1);
-    intersection.update(sketch2);
-    CompactSketch<DoubleSummary> result = intersection.getResult();
+    intersection.intersect(sketch1);
+    intersection.intersect(sketch2);
+    final CompactSketch<DoubleSummary> result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -92,24 +92,24 @@ public class AdoubleIntersectionTest {
     sketch1.update(2, 1.0);
     sketch1.update(2, 1.0);
 
-    UpdatableSketch<Double, DoubleSummary> sketch2 =
+    final UpdatableSketch<Double, DoubleSummary> sketch2 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     sketch2.update(2, 1.0);
     sketch2.update(2, 1.0);
     sketch2.update(3, 1.0);
     sketch2.update(3, 1.0);
 
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
     intersection.update(sketch1);
     intersection.update(sketch2);
-    CompactSketch<DoubleSummary> result = intersection.getResult();
+    final CompactSketch<DoubleSummary> result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 1);
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 1.0);
     Assert.assertEquals(result.getLowerBound(1), 1.0);
     Assert.assertEquals(result.getUpperBound(1), 1.0);
-    SketchIterator<DoubleSummary> it = result.iterator();
+    final SketchIterator<DoubleSummary> it = result.iterator();
     Assert.assertTrue(it.next());
     Assert.assertTrue(it.getHash() > 0);
     Assert.assertTrue(it.getKey() > 0);
@@ -119,29 +119,29 @@ public class AdoubleIntersectionTest {
     intersection.reset();
     sketch1 = null;
     try { intersection.update(sketch1); fail();}
-    catch (SketchesArgumentException e) { }
+    catch (final SketchesArgumentException e) { }
 
 }
 
   @Test
   public void intersectionDisjointEstimationMode() {
     int key = 0;
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, 1.0);
     }
 
-    UpdatableSketch<Double, DoubleSummary> sketch2 =
+    final UpdatableSketch<Double, DoubleSummary> sketch2 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, 1.0);
     }
 
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
-    intersection.update(sketch1);
-    intersection.update(sketch2);
+    intersection.intersect(sketch1);
+    intersection.intersect(sketch2);
     CompactSketch<DoubleSummary> result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertFalse(result.isEmpty());
@@ -150,7 +150,7 @@ public class AdoubleIntersectionTest {
     Assert.assertTrue(result.getUpperBound(1) > 0);
 
     // an intersection with no entries must survive more updates
-    intersection.update(sketch1);
+    intersection.intersect(sketch1);
     result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertFalse(result.isEmpty());
@@ -162,30 +162,30 @@ public class AdoubleIntersectionTest {
   @Test
   public void intersectionEstimationMode() {
     int key = 0;
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, 1.0);
     }
 
     key -= 4096; // overlap half of the entries
-    UpdatableSketch<Double, DoubleSummary> sketch2 =
+    final UpdatableSketch<Double, DoubleSummary> sketch2 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, 1.0);
     }
 
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
-    intersection.update(sketch1);
-    intersection.update(sketch2);
-    CompactSketch<DoubleSummary> result = intersection.getResult();
+    intersection.intersect(sketch1);
+    intersection.intersect(sketch2);
+    final CompactSketch<DoubleSummary> result = intersection.getResult();
     Assert.assertFalse(result.isEmpty());
     // crude estimate of RSE(95%) = 2 / sqrt(result.getRetainedEntries())
     Assert.assertEquals(result.getEstimate(), 4096.0, 4096 * 0.03);
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
-    SketchIterator<DoubleSummary> it = result.iterator();
+    final SketchIterator<DoubleSummary> it = result.iterator();
     while (it.next()) {
       Assert.assertEquals(it.getSummary().getValue(), 2.0);
     }
@@ -193,71 +193,71 @@ public class AdoubleIntersectionTest {
 
   @Test
   public void checkExactIntersectionWithTheta() {
-    UpdateSketch thSkNull = null;
-    UpdateSketch thSkEmpty = new UpdateSketchBuilder().build();
-    UpdateSketch thSk10 = new UpdateSketchBuilder().build();
-    UpdateSketch thSk15 = new UpdateSketchBuilder().build();
+    final UpdateSketch thSkNull = null;
+    final UpdateSketch thSkEmpty = new UpdateSketchBuilder().build();
+    final UpdateSketch thSk10 = new UpdateSketchBuilder().build();
+    final UpdateSketch thSk15 = new UpdateSketchBuilder().build();
     for (int i = 0; i < 10; i++) { thSk10.update(i); }
     for (int i = 0; i < 10; i++) { thSk15.update(i + 5); } //overlap = 5
 
     DoubleSummary dsum = new DoubleSummaryFactory(mode).newSummary();
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
     CompactSketch<DoubleSummary> result;
 
     try { intersection.getResult(); fail(); }
-    catch (SketchesStateException e ) { } //OK.
+    catch (final SketchesStateException e ) { } //OK.
 
-    try { intersection.update(thSkNull, dsum); fail(); }
-    catch (SketchesArgumentException e) { } //OK
+    try { intersection.intersect(thSkNull, dsum); fail(); }
+    catch (final SketchesArgumentException e) { } //OK
 
-    intersection.update(thSkEmpty, dsum);
+    intersection.intersect(thSkEmpty, dsum);
     result = intersection.getResult();
     Assert.assertTrue(result.isEmpty()); //Empty after empty first call
     intersection.reset();
 
-    intersection.update(thSk10, dsum);
+    intersection.intersect(thSk10, dsum);
     result = intersection.getResult();
     Assert.assertEquals(result.getEstimate(), 10.0); //Returns valid first call
     intersection.reset();
 
-    intersection.update(thSk10, dsum);  // Valid first call
-    intersection.update(thSkEmpty, dsum);
+    intersection.intersect(thSk10, dsum);  // Valid first call
+    intersection.intersect(thSkEmpty, dsum);
     result = intersection.getResult();
     Assert.assertTrue(result.isEmpty()); //Returns Empty after empty second call
     intersection.reset();
 
-    intersection.update(thSk10, dsum);
-    intersection.update(thSk15, dsum);
+    intersection.intersect(thSk10, dsum);
+    intersection.intersect(thSk15, dsum);
     result = intersection.getResult();
     Assert.assertEquals(result.getEstimate(), 5.0); //Returns intersection
     intersection.reset();
 
     dsum = null;
-    try { intersection.update(thSk10, dsum); fail(); }
-    catch (SketchesArgumentException e) { }
+    try { intersection.intersect(thSk10, dsum); fail(); }
+    catch (final SketchesArgumentException e) { }
   }
 
   @Test
   public void checkExactIntersectionWithThetaDisjoint() {
-    UpdateSketch thSkA = new UpdateSketchBuilder().setLogNominalEntries(10).build();
-    UpdateSketch thSkB = new UpdateSketchBuilder().setLogNominalEntries(10).build();
+    final UpdateSketch thSkA = new UpdateSketchBuilder().setLogNominalEntries(10).build();
+    final UpdateSketch thSkB = new UpdateSketchBuilder().setLogNominalEntries(10).build();
     int key = 0;
     for (int i = 0; i < 32;  i++) { thSkA.update(key++); }
     for (int i = 0; i < 32; i++) { thSkB.update(key++); }
 
-    DoubleSummary dsum = new DoubleSummaryFactory(mode).newSummary();
-    Intersection<DoubleSummary> intersection =
+    final DoubleSummary dsum = new DoubleSummaryFactory(mode).newSummary();
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
     CompactSketch<DoubleSummary> result;
 
-    intersection.update(thSkA, dsum);
-    intersection.update(thSkB, dsum);
+    intersection.intersect(thSkA, dsum);
+    intersection.intersect(thSkB, dsum);
     result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
 
     // an intersection with no entries must survive more updates
-    intersection.update(thSkA, dsum);
+    intersection.intersect(thSkA, dsum);
     result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     intersection.reset();
@@ -265,39 +265,39 @@ public class AdoubleIntersectionTest {
 
   @Test
   public void checkEstimatingIntersectionWithThetaOverlapping() {
-    UpdateSketch thSkA = new UpdateSketchBuilder().setLogNominalEntries(4).build();
-    UpdateSketch thSkB = new UpdateSketchBuilder().setLogNominalEntries(10).build();
+    final UpdateSketch thSkA = new UpdateSketchBuilder().setLogNominalEntries(4).build();
+    final UpdateSketch thSkB = new UpdateSketchBuilder().setLogNominalEntries(10).build();
     for (int i = 0; i < 64;  i++) { thSkA.update(i); } //dense mode, low theta
     for (int i = 32; i < 96; i++) { thSkB.update(i); } //exact overlapping
 
-    DoubleSummary dsum = new DoubleSummaryFactory(mode).newSummary();
-    Intersection<DoubleSummary> intersection =
+    final DoubleSummary dsum = new DoubleSummaryFactory(mode).newSummary();
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
     CompactSketch<DoubleSummary> result;
 
-    intersection.update(thSkA, dsum);
-    intersection.update(thSkB, dsum);
+    intersection.intersect(thSkA, dsum);
+    intersection.intersect(thSkB, dsum);
     result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 14);
 
     thSkB.reset();
     for (int i = 100; i < 164; i++) { thSkB.update(i); } //exact, disjoint
-    intersection.update(thSkB, dsum); //remove existing entries
+    intersection.intersect(thSkB, dsum); //remove existing entries
     result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
-    intersection.update(thSkB, dsum);
+    intersection.intersect(thSkB, dsum);
     result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
   }
 
   @Test
   public void intersectionEmpty() {
-    UpdatableSketch<Double, DoubleSummary> sketch =
+    final UpdatableSketch<Double, DoubleSummary> sketch =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
-    Intersection<DoubleSummary> intersection =
+    final Intersection<DoubleSummary> intersection =
         new Intersection<>(new DoubleSummarySetOperations(mode, mode));
-    intersection.update(sketch);
-    CompactSketch<DoubleSummary> result = intersection.getResult();
+    intersection.intersect(sketch);
+    final CompactSketch<DoubleSummary> result = intersection.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 0.0);

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleUnionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleUnionTest.java
@@ -42,14 +42,14 @@ public class AdoubleUnionTest {
 
   @Test
   public void unionEmptySampling() {
-    UpdatableSketch<Double, DoubleSummary> sketch =
+    final UpdatableSketch<Double, DoubleSummary> sketch =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).setSamplingProbability(0.01f).build();
     sketch.update(1, 1.0);
     Assert.assertEquals(sketch.getRetainedEntries(), 0); // not retained due to low sampling probability
 
-    Union<DoubleSummary> union = new Union<>(new DoubleSummarySetOperations(mode, mode));
-    union.update(sketch);
-    CompactSketch<DoubleSummary> result = union.getResult();
+    final Union<DoubleSummary> union = new Union<>(new DoubleSummarySetOperations(mode, mode));
+    union.union(sketch);
+    final CompactSketch<DoubleSummary> result = union.getResult();
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertFalse(result.isEmpty());
     Assert.assertTrue(result.isEstimationMode());
@@ -58,14 +58,14 @@ public class AdoubleUnionTest {
 
   @Test
   public void unionExactMode() {
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     sketch1.update(1, 1.0);
     sketch1.update(1, 1.0);
     sketch1.update(1, 1.0);
     sketch1.update(2, 1.0);
 
-    UpdatableSketch<Double, DoubleSummary> sketch2 =
+    final UpdatableSketch<Double, DoubleSummary> sketch2 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     sketch2.update(2, 1.0);
     sketch2.update(2, 1.0);
@@ -73,13 +73,13 @@ public class AdoubleUnionTest {
     sketch2.update(3, 1.0);
     sketch2.update(3, 1.0);
 
-    Union<DoubleSummary> union = new Union<>(new DoubleSummarySetOperations(mode, mode));
-    union.update(sketch1);
-    union.update(sketch2);
+    final Union<DoubleSummary> union = new Union<>(new DoubleSummarySetOperations(mode, mode));
+    union.union(sketch1);
+    union.union(sketch2);
     CompactSketch<DoubleSummary> result = union.getResult();
     Assert.assertEquals(result.getEstimate(), 3.0);
 
-    SketchIterator<DoubleSummary> it = result.iterator();
+    final SketchIterator<DoubleSummary> it = result.iterator();
     Assert.assertTrue(it.next());
     Assert.assertEquals(it.getSummary().getValue(), 3.0);
     Assert.assertTrue(it.next());
@@ -102,23 +102,23 @@ public class AdoubleUnionTest {
   @Test
   public void unionEstimationMode() {
     int key = 0;
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, 1.0);
     }
 
     key -= 4096; // overlap half of the entries
-    UpdatableSketch<Double, DoubleSummary> sketch2 =
+    final UpdatableSketch<Double, DoubleSummary> sketch2 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, 1.0);
     }
 
-    Union<DoubleSummary> union = new Union<>(4096, new DoubleSummarySetOperations(mode, mode));
-    union.update(sketch1);
-    union.update(sketch2);
-    CompactSketch<DoubleSummary> result = union.getResult();
+    final Union<DoubleSummary> union = new Union<>(4096, new DoubleSummarySetOperations(mode, mode));
+    union.union(sketch1);
+    union.union(sketch2);
+    final CompactSketch<DoubleSummary> result = union.getResult();
     Assert.assertEquals(result.getEstimate(), 12288.0, 12288 * 0.01);
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
@@ -127,7 +127,7 @@ public class AdoubleUnionTest {
   @Test
   public void unionMixedMode() {
     int key = 0;
-    UpdatableSketch<Double, DoubleSummary> sketch1 =
+    final UpdatableSketch<Double, DoubleSummary> sketch1 =
         new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode)).build();
     for (int i = 0; i < 1000; i++) {
       sketch1.update(key++, 1.0);
@@ -135,7 +135,7 @@ public class AdoubleUnionTest {
     }
 
     key -= 500; // overlap half of the entries
-    UpdatableSketch<Double, DoubleSummary> sketch2 =
+    final UpdatableSketch<Double, DoubleSummary> sketch2 =
         new UpdatableSketchBuilder<>
           (new DoubleSummaryFactory(mode)).setSamplingProbability(0.2f).build();
     for (int i = 0; i < 20000; i++) {
@@ -143,10 +143,10 @@ public class AdoubleUnionTest {
       //System.out.println("theta2=" + sketch2.getTheta() + " " + sketch2.getThetaLong());
     }
 
-    Union<DoubleSummary> union = new Union<>(4096, new DoubleSummarySetOperations(mode, mode));
-    union.update(sketch1);
-    union.update(sketch2);
-    CompactSketch<DoubleSummary> result = union.getResult();
+    final Union<DoubleSummary> union = new Union<>(4096, new DoubleSummarySetOperations(mode, mode));
+    union.union(sketch1);
+    union.union(sketch2);
+    final CompactSketch<DoubleSummary> result = union.getResult();
     Assert.assertEquals(result.getEstimate(), 20500.0, 20500 * 0.01);
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
@@ -154,20 +154,20 @@ public class AdoubleUnionTest {
 
   @Test
   public void checkUnionUpdateWithTheta() {
-    Union<DoubleSummary> union = new Union<>(new DoubleSummarySetOperations(mode, mode));
+    final Union<DoubleSummary> union = new Union<>(new DoubleSummarySetOperations(mode, mode));
     UpdateSketch usk = null;
     DoubleSummary dsum = null;
 
-    try { union.update(usk, dsum); fail(); }
-    catch (SketchesArgumentException e) { }
+    try { union.union(usk, dsum); fail(); }
+    catch (final SketchesArgumentException e) { }
 
     usk = new UpdateSketchBuilder().build();
-    try { union.update(usk, dsum); fail(); }
-    catch (SketchesArgumentException e) { }
+    try { union.union(usk, dsum); fail(); }
+    catch (final SketchesArgumentException e) { }
 
     dsum = new DoubleSummaryFactory(mode).newSummary();
     for (int i = 0; i < 10; i++) { usk.update(i); }
-    union.update(usk, dsum);
+    union.union(usk, dsum);
     Assert.assertEquals(union.getResult().getEstimate(), 10.0);
   }
 

--- a/src/test/java/org/apache/datasketches/tuple/aninteger/EngagementTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/aninteger/EngagementTest.java
@@ -39,18 +39,18 @@ public class EngagementTest {
 
   @Test
   public void computeEngagementHistogram() {
-    int lgK = 8; //Using a larger sketch >= 9 will produce exact results for this little example
-    int K = 1 << lgK;
-    int days = 30;
+    final int lgK = 8; //Using a larger sketch >= 9 will produce exact results for this little example
+    final int K = 1 << lgK;
+    final int days = 30;
     int v = 0;
-    IntegerSketch[] skArr = new IntegerSketch[days];
+    final IntegerSketch[] skArr = new IntegerSketch[days];
     for (int i = 0; i < days; i++) {
       skArr[i] = new IntegerSketch(lgK, AlwaysOne);
     }
     for (int i = 0; i <= days; i++) { //31 generating indices for symmetry
-      int numIds = numIDs(days, i);
-      int numDays = numDays(days, i);
-      int myV = v++;
+      final int numIds = numIDs(days, i);
+      final int numDays = numDays(days, i);
+      final int myV = v++;
       for (int d = 0; d < numDays; d++) {
         for (int id = 0; id < numIds; id++) {
           skArr[d].update(myV + id, 1);
@@ -61,34 +61,34 @@ public class EngagementTest {
     unionOps(K, Sum, skArr);
   }
 
-  private static int numIDs(int totalDays, int index) {
-    double d = totalDays;
-    double i = index;
-    return (int)(round(exp((i * log(d)) / d)));
+  private static int numIDs(final int totalDays, final int index) {
+    final double d = totalDays;
+    final double i = index;
+    return (int)round(exp(i * log(d) / d));
   }
 
-  private static int numDays(int totalDays, int index) {
-    double d = totalDays;
-    double i = index;
-    return (int)(round(exp(((d - i) * log(d)) / d)));
+  private static int numDays(final int totalDays, final int index) {
+    final double d = totalDays;
+    final double i = index;
+    return (int)round(exp((d - i) * log(d) / d));
   }
 
-  private static void unionOps(int K, IntegerSummary.Mode mode, IntegerSketch ... sketches) {
-    IntegerSummarySetOperations setOps = new IntegerSummarySetOperations(mode, mode);
-    Union<IntegerSummary> union = new Union<>(K, setOps);
-    int len = sketches.length;
+  private static void unionOps(final int K, final IntegerSummary.Mode mode, final IntegerSketch ... sketches) {
+    final IntegerSummarySetOperations setOps = new IntegerSummarySetOperations(mode, mode);
+    final Union<IntegerSummary> union = new Union<>(K, setOps);
+    final int len = sketches.length;
 
-    for (IntegerSketch isk : sketches) {
-      union.update(isk);
+    for (final IntegerSketch isk : sketches) {
+      union.union(isk);
     }
-    CompactSketch<IntegerSummary> result = union.getResult();
-    SketchIterator<IntegerSummary> itr = result.iterator();
+    final CompactSketch<IntegerSummary> result = union.getResult();
+    final SketchIterator<IntegerSummary> itr = result.iterator();
 
-    int[] numDaysArr = new int[len + 1]; //zero index is ignored
+    final int[] numDaysArr = new int[len + 1]; //zero index is ignored
 
     while (itr.next()) {
       //For each unique visitor from the result sketch, get the # days visited
-      int numDaysVisited = itr.getSummary().getValue();
+      final int numDaysVisited = itr.getSummary().getValue();
       //increment the number of visitors that visited numDays
       numDaysArr[numDaysVisited]++; //values range from 1 to 30
     }
@@ -97,40 +97,40 @@ public class EngagementTest {
     println("Number of Unique Visitors by Number of Days Visited");
     printf("%12s%12s%12s%12s\n","Days Visited", "Estimate", "LB", "UB");
     int sumVisits = 0;
-    double theta = result.getTheta();
+    final double theta = result.getTheta();
     for (int i = 0; i < numDaysArr.length; i++) {
-      int visitorsAtDaysVisited = numDaysArr[i];
+      final int visitorsAtDaysVisited = numDaysArr[i];
       if (visitorsAtDaysVisited == 0) { continue; }
       sumVisits += visitorsAtDaysVisited * i;
 
-      double estVisitorsAtDaysVisited = visitorsAtDaysVisited / theta;
-      double lbVisitorsAtDaysVisited = result.getLowerBound(numStdDev, visitorsAtDaysVisited);
-      double ubVisitorsAtDaysVisited = result.getUpperBound(numStdDev, visitorsAtDaysVisited);
+      final double estVisitorsAtDaysVisited = visitorsAtDaysVisited / theta;
+      final double lbVisitorsAtDaysVisited = result.getLowerBound(numStdDev, visitorsAtDaysVisited);
+      final double ubVisitorsAtDaysVisited = result.getUpperBound(numStdDev, visitorsAtDaysVisited);
 
       printf("%12d%12.0f%12.0f%12.0f\n",
           i, estVisitorsAtDaysVisited, lbVisitorsAtDaysVisited, ubVisitorsAtDaysVisited);
     }
 
     //The estimate and bounds of the total number of visitors comes directly from the sketch.
-    double visitors = result.getEstimate();
-    double lbVisitors = result.getLowerBound(numStdDev);
-    double ubVisitors = result.getUpperBound(numStdDev);
+    final double visitors = result.getEstimate();
+    final double lbVisitors = result.getLowerBound(numStdDev);
+    final double ubVisitors = result.getUpperBound(numStdDev);
     printf("\n%12s%12s%12s%12s\n","Totals", "Estimate", "LB", "UB");
     printf("%12s%12.0f%12.0f%12.0f\n", "Visitors", visitors, lbVisitors, ubVisitors);
 
     //The total number of visits, however, is a scaled metric and takes advantage of the fact that
     //the retained entries in the sketch is a uniform random sample of all unique visitors, and
     //the the rest of the unique users will likely behave in the same way.
-    double estVisits = sumVisits / theta;
-    double lbVisits = (estVisits * lbVisitors) / visitors;
-    double ubVisits = (estVisits * ubVisitors) / visitors;
+    final double estVisits = sumVisits / theta;
+    final double lbVisits = estVisits * lbVisitors / visitors;
+    final double ubVisits = estVisits * ubVisitors / visitors;
     printf("%12s%12.0f%12.0f%12.0f\n\n", "Visits", estVisits, lbVisits, ubVisits);
   }
 
   /**
    * @param o object to print
    */
-  private static void println(Object o) {
+  private static void println(final Object o) {
     printf("%s\n", o.toString());
   }
 
@@ -138,7 +138,7 @@ public class EngagementTest {
    * @param fmt format
    * @param args arguments
    */
-  private static void printf(String fmt, Object ... args) {
+  private static void printf(final String fmt, final Object ... args) {
     //System.out.printf(fmt, args); //Enable/Disable printing here
   }
 }

--- a/src/test/java/org/apache/datasketches/tuple/aninteger/IntegerSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/aninteger/IntegerSketchTest.java
@@ -35,87 +35,87 @@ public class IntegerSketchTest {
 
   @Test
   public void serDeTest() {
-    int lgK = 12;
-    int K = 1 << lgK;
-    IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
-    IntegerSketch a1Sk = new IntegerSketch(lgK, a1Mode);
-    int m = 2 * K;
+    final int lgK = 12;
+    final int K = 1 << lgK;
+    final IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
+    final IntegerSketch a1Sk = new IntegerSketch(lgK, a1Mode);
+    final int m = 2 * K;
     for (int i = 0; i < m; i++) {
       a1Sk.update(i, 1);
     }
-    double est1 = a1Sk.getEstimate();
-    Memory mem = Memory.wrap(a1Sk.toByteArray());
-    IntegerSketch a1Sk2 = new IntegerSketch(mem, a1Mode);
-    double est2 = a1Sk2.getEstimate();
+    final double est1 = a1Sk.getEstimate();
+    final Memory mem = Memory.wrap(a1Sk.toByteArray());
+    final IntegerSketch a1Sk2 = new IntegerSketch(mem, a1Mode);
+    final double est2 = a1Sk2.getEstimate();
     assertEquals(est1, est2);
   }
 
   @Test
   public void intersectTest() {
-    int lgK = 12;
-    int K = 1 << lgK;
-    IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
-    IntegerSketch a1Sk1 = new IntegerSketch(lgK, a1Mode);
-    IntegerSketch a1Sk2 = new IntegerSketch(lgK, a1Mode);
-    int m = 2 * K;
+    final int lgK = 12;
+    final int K = 1 << lgK;
+    final IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
+    final IntegerSketch a1Sk1 = new IntegerSketch(lgK, a1Mode);
+    final IntegerSketch a1Sk2 = new IntegerSketch(lgK, a1Mode);
+    final int m = 2 * K;
     for (int i = 0; i < m; i++) {
       a1Sk1.update(i, 1);
-      a1Sk2.update(i + (m/2), 1);
+      a1Sk2.update(i + m/2, 1);
     }
-    Intersection<IntegerSummary> inter =
+    final Intersection<IntegerSummary> inter =
         new Intersection<>(new IntegerSummarySetOperations(a1Mode, a1Mode));
-    inter.update(a1Sk1);
-    inter.update(a1Sk2);
-    CompactSketch<IntegerSummary> csk = inter.getResult();
+    inter.intersect(a1Sk1);
+    inter.intersect(a1Sk2);
+    final CompactSketch<IntegerSummary> csk = inter.getResult();
     assertEquals(csk.getEstimate(), K * 1.0, K * .03);
   }
 
   @SuppressWarnings("deprecation")
   @Test
   public void aNotBTest() {
-    int lgK = 4;
-    int u = 5;
-    IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
-    IntegerSketch a1Sk1 = new IntegerSketch(lgK, a1Mode);
-    IntegerSketch a1Sk2 = null;//new IntegerSketch(lgK, a1Mode);
-    AnotB<IntegerSummary> anotb = new AnotB<>();
+    final int lgK = 4;
+    final int u = 5;
+    final IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
+    final IntegerSketch a1Sk1 = new IntegerSketch(lgK, a1Mode);
+    final IntegerSketch a1Sk2 = null;//new IntegerSketch(lgK, a1Mode);
+    final AnotB<IntegerSummary> anotb = new AnotB<>();
     for (int i = 0; i < u; i++) {
       a1Sk1.update(i, 1);
     }
     anotb.update(a1Sk1, a1Sk2);
-    CompactSketch<IntegerSummary> cSk = anotb.getResult();
+    final CompactSketch<IntegerSummary> cSk = anotb.getResult();
     assertEquals((int)cSk.getEstimate(), u);
   }
 
   @Test
   public void checkMinMaxMode() {
-    int lgK = 12;
-    int K = 1 << lgK;
-    IntegerSummary.Mode minMode = IntegerSummary.Mode.Min;
-    IntegerSummary.Mode maxMode = IntegerSummary.Mode.Max;
-    IntegerSketch a1Sk1 = new IntegerSketch(lgK, minMode);
-    IntegerSketch a1Sk2 = new IntegerSketch(lgK, maxMode);
-    int m = K / 2;
+    final int lgK = 12;
+    final int K = 1 << lgK;
+    final IntegerSummary.Mode minMode = IntegerSummary.Mode.Min;
+    final IntegerSummary.Mode maxMode = IntegerSummary.Mode.Max;
+    final IntegerSketch a1Sk1 = new IntegerSketch(lgK, minMode);
+    final IntegerSketch a1Sk2 = new IntegerSketch(lgK, maxMode);
+    final int m = K / 2;
     for (int key = 0; key < m; key++) {
       a1Sk1.update(key, 1);
       a1Sk1.update(key, 0);
       a1Sk1.update(key, 2);
-      a1Sk2.update(key + (m/2), 1);
-      a1Sk2.update(key + (m/2), 0);
-      a1Sk2.update(key + (m/2), 2);
+      a1Sk2.update(key + m/2, 1);
+      a1Sk2.update(key + m/2, 0);
+      a1Sk2.update(key + m/2, 2);
     }
-    double est1 = a1Sk1.getEstimate();
-    double est2 = a1Sk2.getEstimate();
+    final double est1 = a1Sk1.getEstimate();
+    final double est2 = a1Sk2.getEstimate();
     assertEquals(est1, est2);
   }
 
   @Test
   public void checkStringKey() {
-    int lgK = 12;
-    int K = 1 << lgK;
-    IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
-    IntegerSketch a1Sk1 = new IntegerSketch(lgK, a1Mode);
-    int m = K / 2;
+    final int lgK = 12;
+    final int K = 1 << lgK;
+    final IntegerSummary.Mode a1Mode = IntegerSummary.Mode.AlwaysOne;
+    final IntegerSketch a1Sk1 = new IntegerSketch(lgK, a1Mode);
+    final int m = K / 2;
     for (int key = 0; key < m; key++) {
       a1Sk1.update(Integer.toHexString(key), 1);
     }
@@ -125,7 +125,7 @@ public class IntegerSketchTest {
   /**
    * @param o object to print
    */
-  static void println(Object o) {
+  static void println(final Object o) {
     //System.out.println(o.toString()); //Disable
   }
 
@@ -133,7 +133,7 @@ public class IntegerSketchTest {
    * @param fmt format
    * @param args arguments
    */
-  static void printf(String fmt, Object ... args) {
+  static void printf(final String fmt, final Object ... args) {
     //System.out.printf(fmt, args); //Disable
   }
 }

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesIntersectionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesIntersectionTest.java
@@ -26,9 +26,11 @@ import org.testng.annotations.Test;
 
 @SuppressWarnings("javadoc")
 public class ArrayOfDoublesIntersectionTest {
+
   private static ArrayOfDoublesCombiner combiner = new ArrayOfDoublesCombiner() {
+
     @Override
-    public double[] combine(double[] a, double[] b) {
+    public double[] combine(final double[] a, final double[] b) {
       for (int i = 0; i < a.length; i++) {
         a[i] += b[i];
       }
@@ -38,9 +40,9 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void nullInput() {
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(null, null);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(null, null);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -51,10 +53,10 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void empty() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(sketch1, null);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(sketch1, null);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -65,11 +67,11 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void notEmptyNoEntries() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSamplingProbability(0.01f).build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSamplingProbability(0.01f).build();
     sketch1.update("a", new double[] {1}); // this happens to get rejected because of sampling with low probability
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(sketch1, null);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(sketch1, null);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -80,17 +82,17 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void heapExactWithEmpty() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1});
     sketch1.update(2, new double[] {1});
     sketch1.update(3, new double[] {1});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(sketch1, null);
-    intersection.update(sketch2, null);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(sketch1, null);
+    intersection.intersect(sketch2, null);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -100,20 +102,20 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void directExactWithEmpty() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder()
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder()
         .build(WritableMemory.wrap(new byte[1000000]));
     sketch1.update(1, new double[] {1});
     sketch1.update(2, new double[] {1});
     sketch1.update(3, new double[] {1});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder()
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder()
         .build(WritableMemory.wrap(new byte[1000000]));
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().
         buildIntersection(WritableMemory.wrap(new byte[1000000]));
-    intersection.update(sketch1, null);
-    intersection.update(sketch2, null);
-    ArrayOfDoublesCompactSketch result = intersection.getResult(WritableMemory.wrap(new byte[1000000]));
+    intersection.intersect(sketch1, null);
+    intersection.intersect(sketch2, null);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -123,34 +125,34 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void heapExactMode() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1});
     sketch1.update(1, new double[] {1});
     sketch1.update(2, new double[] {1});
     sketch1.update(2, new double[] {1});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch2.update(2, new double[] {1});
     sketch2.update(2, new double[] {1});
     sketch2.update(3, new double[] {1});
     sketch2.update(3, new double[] {1});
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(sketch1, combiner);
-    intersection.update(sketch2, combiner);
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(sketch1, combiner);
+    intersection.intersect(sketch2, combiner);
     ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 1);
     Assert.assertEquals(result.getEstimate(), 1.0);
     Assert.assertEquals(result.getLowerBound(1), 1.0);
     Assert.assertEquals(result.getUpperBound(1), 1.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     for (int i = 0; i < values.length; i++) {
       Assert.assertEquals(values[i][0], 4.0);
     }
 
     intersection.reset();
-    intersection.update(null, null);
+    intersection.intersect(null, null);
     result = intersection.getResult();
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
@@ -162,20 +164,20 @@ public class ArrayOfDoublesIntersectionTest {
   @Test
   public void heapDisjointEstimationMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(sketch1, combiner);
-    intersection.update(sketch2, combiner);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(sketch1, combiner);
+    intersection.intersect(sketch2, combiner);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -187,23 +189,23 @@ public class ArrayOfDoublesIntersectionTest {
   @Test
   public void directDisjointEstimationMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().
         build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().
         build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().
         buildIntersection(WritableMemory.wrap(new byte[1000000]));
-    intersection.update(sketch1, combiner);
-    intersection.update(sketch2, combiner);
-    ArrayOfDoublesCompactSketch result = intersection.getResult(WritableMemory.wrap(new byte[1000000]));
+    intersection.intersect(sketch1, combiner);
+    intersection.intersect(sketch2, combiner);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertTrue(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 0);
     Assert.assertEquals(result.getEstimate(), 0.0);
@@ -215,26 +217,26 @@ public class ArrayOfDoublesIntersectionTest {
   @Test
   public void heapEstimationMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
-    intersection.update(sketch1, combiner);
-    intersection.update(sketch2, combiner);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
+    intersection.intersect(sketch1, combiner);
+    intersection.intersect(sketch2, combiner);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 4096.0, 4096 * 0.03); // crude estimate of RSE(95%) = 2 / sqrt(result.getRetainedEntries())
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     for (int i = 0; i < values.length; i++) {
       Assert.assertEquals(values[i][0], 2.0);
     }
@@ -243,26 +245,26 @@ public class ArrayOfDoublesIntersectionTest {
   @Test
   public void directEstimationMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection(WritableMemory.wrap(new byte[1000000]));
-    intersection.update(sketch1, combiner);
-    intersection.update(sketch2, combiner);
-    ArrayOfDoublesCompactSketch result = intersection.getResult(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection(WritableMemory.wrap(new byte[1000000]));
+    intersection.intersect(sketch1, combiner);
+    intersection.intersect(sketch2, combiner);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 4096.0, 4096 * 0.03); // crude estimate of RSE(95%) = 2 / sqrt(result.getRetainedEntries())
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     for (int i = 0; i < values.length; i++) {
       Assert.assertEquals(values[i][0], 2.0);
     }
@@ -270,30 +272,30 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test
   public void heapExactModeCustomSeed() {
-    long seed = 1234567890;
+    final long seed = 1234567890;
 
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
     sketch1.update(1, new double[] {1});
     sketch1.update(1, new double[] {1});
     sketch1.update(2, new double[] {1});
     sketch1.update(2, new double[] {1});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
     sketch2.update(2, new double[] {1});
     sketch2.update(2, new double[] {1});
     sketch2.update(3, new double[] {1});
     sketch2.update(3, new double[] {1});
 
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().setSeed(seed).buildIntersection();
-    intersection.update(sketch1, combiner);
-    intersection.update(sketch2, combiner);
-    ArrayOfDoublesCompactSketch result = intersection.getResult();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().setSeed(seed).buildIntersection();
+    intersection.intersect(sketch1, combiner);
+    intersection.intersect(sketch2, combiner);
+    final ArrayOfDoublesCompactSketch result = intersection.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getRetainedEntries(), 1);
     Assert.assertEquals(result.getEstimate(), 1.0);
     Assert.assertEquals(result.getLowerBound(1), 1.0);
     Assert.assertEquals(result.getUpperBound(1), 1.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     for (int i = 0; i < values.length; i++) {
       Assert.assertEquals(values[i][0], 4.0);
     }
@@ -301,8 +303,8 @@ public class ArrayOfDoublesIntersectionTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void incompatibleSeeds() {
-    ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(1).build();
-    ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().setSeed(2).buildIntersection();
-    intersection.update(sketch, combiner);
+    final ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(1).build();
+    final ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().setSeed(2).buildIntersection();
+    intersection.intersect(sketch, combiner);
   }
 }

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnionTest.java
@@ -34,23 +34,23 @@ public class ArrayOfDoublesUnionTest {
 
   @Test
   public void heapExactMode() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(2, new double[] {1.0});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch2.update(2, new double[] {1.0});
     sketch2.update(2, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
 
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union.update(sketch1);
-    union.update(sketch2);
-    int maxBytes = ArrayOfDoublesUnion.getMaxBytes(
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union.union(sketch1);
+    union.union(sketch2);
+    final int maxBytes = ArrayOfDoublesUnion.getMaxBytes(
         ArrayOfDoublesSetOperationBuilder.DEFAULT_NOMINAL_ENTRIES,
         ArrayOfDoublesSetOperationBuilder.DEFAULT_NUMBER_OF_VALUES);
     Assert.assertEquals(maxBytes, 131120); // 48 bytes preamble + 2 * nominal entries * (key size + value size)
@@ -61,8 +61,8 @@ public class ArrayOfDoublesUnionTest {
     Assert.assertEquals(values[1][0], 3.0);
     Assert.assertEquals(values[2][0], 3.0);
 
-    WritableMemory wmem = WritableMemory.wrap(union.toByteArray());
-    ArrayOfDoublesUnion wrappedUnion = ArrayOfDoublesSketches.wrapUnion(wmem);
+    final WritableMemory wmem = WritableMemory.wrap(union.toByteArray());
+    final ArrayOfDoublesUnion wrappedUnion = ArrayOfDoublesSketches.wrapUnion(wmem);
     result = wrappedUnion.getResult();
     Assert.assertEquals(result.getEstimate(), 3.0);
     values = result.getValues();
@@ -84,20 +84,20 @@ public class ArrayOfDoublesUnionTest {
   @Test
   public void heapEstimationMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union.update(sketch1);
-    union.update(sketch2);
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union.union(sketch1);
+    union.union(sketch2);
     ArrayOfDoublesCompactSketch result = union.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertTrue(result.isEstimationMode());
@@ -116,28 +116,28 @@ public class ArrayOfDoublesUnionTest {
   @Test
   public void heapEstimationModeFullOverlapTwoValuesAndDownsizing() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0, 2.0});
     }
 
     key = 0; // full overlap
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0, 2.0});
     }
 
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().setNumberOfValues(2).setNominalEntries(1024).buildUnion();
-    union.update(sketch1);
-    union.update(sketch2);
-    ArrayOfDoublesCompactSketch result = union.getResult();
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().setNumberOfValues(2).setNominalEntries(1024).buildUnion();
+    union.union(sketch1);
+    union.union(sketch2);
+    final ArrayOfDoublesCompactSketch result = union.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertTrue(result.isEstimationMode());
     Assert.assertEquals(result.getEstimate(), 8192.0, 8192 * 0.01);
     Assert.assertEquals(result.getRetainedEntries(), 1024); // union was downsampled
 
-    ArrayOfDoublesSketchIterator it = result.iterator();
-    double[] expected = {2, 4};
+    final ArrayOfDoublesSketchIterator it = result.iterator();
+    final double[] expected = {2, 4};
     while (it.next()) {
       Assert.assertEquals(it.getValues(), expected, Arrays.toString(it.getValues()) + " != " + Arrays.toString(expected));
     }
@@ -146,21 +146,21 @@ public class ArrayOfDoublesUnionTest {
   @Test
   public void heapMixedMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 1000; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 500; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSamplingProbability(0.2f).build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSamplingProbability(0.2f).build();
     for (int i = 0; i < 20000; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union.update(sketch1);
-    union.update(sketch2);
-    ArrayOfDoublesCompactSketch result = union.getResult();
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union.union(sketch1);
+    union.union(sketch2);
+    final ArrayOfDoublesCompactSketch result = union.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertTrue(result.isEstimationMode());
     Assert.assertEquals(result.getEstimate(), 20500.0, 20500 * 0.01);
@@ -169,22 +169,22 @@ public class ArrayOfDoublesUnionTest {
   @Test
   public void heapSerializeDeserialize() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union1.update(sketch1);
-    union1.update(sketch2);
+    final ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union1.union(sketch1);
+    union1.union(sketch2);
 
-    ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.heapify(Memory.wrap(union1.toByteArray()));
+    final ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.heapify(Memory.wrap(union1.toByteArray()));
     ArrayOfDoublesCompactSketch result = union2.getResult();
     Assert.assertEquals(result.getEstimate(), 12288.0, 12288 * 0.01);
 
@@ -196,7 +196,7 @@ public class ArrayOfDoublesUnionTest {
     Assert.assertEquals(result.getUpperBound(1), 0.0);
     Assert.assertEquals(result.getLowerBound(1), 0.0);
     Assert.assertEquals(result.getTheta(), 1.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     for (int i = 0; i < values.length; i++) {
       Assert.assertEquals(values[i][0], 2.0);
     }
@@ -216,50 +216,50 @@ public class ArrayOfDoublesUnionTest {
 
   @Test
   public void heapSerializeDeserializeWithSeed() {
-    long seed = 1;
+    final long seed = 1;
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().setSeed(seed).buildUnion();
-    union1.update(sketch1);
-    union1.update(sketch2);
+    final ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().setSeed(seed).buildUnion();
+    union1.union(sketch1);
+    union1.union(sketch2);
 
-    ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.heapify(Memory.wrap(union1.toByteArray()), seed);
-    ArrayOfDoublesCompactSketch result = union2.getResult();
+    final ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.heapify(Memory.wrap(union1.toByteArray()), seed);
+    final ArrayOfDoublesCompactSketch result = union2.getResult();
     Assert.assertEquals(result.getEstimate(), 12288.0, 12288 * 0.01);
   }
 
   @Test
   public void directSerializeDeserialize() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(
         WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(
         WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion(
+    final ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().buildUnion(
         WritableMemory.wrap(new byte[1000000]));
-    union1.update(sketch1);
-    union1.update(sketch2);
+    union1.union(sketch1);
+    union1.union(sketch2);
 
-    ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.wrap(WritableMemory.wrap(union1.toByteArray()));
+    final ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.wrap(WritableMemory.wrap(union1.toByteArray()));
     ArrayOfDoublesCompactSketch result = union2.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertEquals(result.getEstimate(), 12288.0, 12288 * 0.01);
 
@@ -271,7 +271,7 @@ public class ArrayOfDoublesUnionTest {
     Assert.assertEquals(result.getUpperBound(1), 0.0);
     Assert.assertEquals(result.getLowerBound(1), 0.0);
     Assert.assertEquals(result.getTheta(), 1.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     for (int i = 0; i < values.length; i++) {
       Assert.assertEquals(values[i][0], 2.0);
     }
@@ -279,52 +279,52 @@ public class ArrayOfDoublesUnionTest {
 
   @Test
   public void directSerializeDeserializeWithSeed() {
-    long seed = 1;
+    final long seed = 1;
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed)
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed)
         .build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed)
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed)
         .build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().setSeed(seed)
+    final ArrayOfDoublesUnion union1 = new ArrayOfDoublesSetOperationBuilder().setSeed(seed)
         .buildUnion(WritableMemory.wrap(new byte[1000000]));
-    union1.update(sketch1);
-    union1.update(sketch2);
+    union1.union(sketch1);
+    union1.union(sketch2);
 
-    ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.wrap(WritableMemory.wrap(union1.toByteArray()), seed);
-    ArrayOfDoublesCompactSketch result = union2.getResult(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUnion union2 = ArrayOfDoublesUnion.wrap(WritableMemory.wrap(union1.toByteArray()), seed);
+    final ArrayOfDoublesCompactSketch result = union2.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertEquals(result.getEstimate(), 12288.0, 12288 * 0.01);
   }
 
   @Test
   public void directExactMode() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(2, new double[] {1.0});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
     sketch2.update(2, new double[] {1.0});
     sketch2.update(2, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
 
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion(WritableMemory.wrap(new byte[1000000]));
-    union.update(sketch1);
-    union.update(sketch2);
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion(WritableMemory.wrap(new byte[1000000]));
+    union.union(sketch1);
+    union.union(sketch2);
     ArrayOfDoublesCompactSketch result = union.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertEquals(result.getEstimate(), 3.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     Assert.assertEquals(values[0][0], 3.0);
     Assert.assertEquals(values[1][0], 3.0);
     Assert.assertEquals(values[2][0], 3.0);
@@ -342,20 +342,20 @@ public class ArrayOfDoublesUnionTest {
   @Test
   public void directEstimationMode() {
     int key = 0;
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch1.update(key++, new double[] {1.0});
     }
 
     key -= 4096; // overlap half of the entries
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
     for (int i = 0; i < 8192; i++) {
       sketch2.update(key++, new double[] {1.0});
     }
 
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion(WritableMemory.wrap(new byte[1000000]));
-    union.update(sketch1);
-    union.update(sketch2);
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion(WritableMemory.wrap(new byte[1000000]));
+    union.union(sketch1);
+    union.union(sketch2);
     ArrayOfDoublesCompactSketch result = union.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertEquals(result.getEstimate(), 12288.0, 12288 * 0.01);
 
@@ -371,29 +371,29 @@ public class ArrayOfDoublesUnionTest {
 
   @Test
   public void heapToDirect() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(2, new double[] {1.0});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch2.update(2, new double[] {1.0});
     sketch2.update(2, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
 
-    ArrayOfDoublesUnion heapUnion = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    heapUnion.update(sketch1);
+    final ArrayOfDoublesUnion heapUnion = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    heapUnion.union(sketch1);
 
-    ArrayOfDoublesUnion directUnion = ArrayOfDoublesUnion.wrap(WritableMemory.wrap(heapUnion.toByteArray()));
-    directUnion.update(sketch2);
+    final ArrayOfDoublesUnion directUnion = ArrayOfDoublesUnion.wrap(WritableMemory.wrap(heapUnion.toByteArray()));
+    directUnion.union(sketch2);
 
-    ArrayOfDoublesCompactSketch result = directUnion.getResult(WritableMemory.wrap(new byte[1000000]));
+    final ArrayOfDoublesCompactSketch result = directUnion.getResult(WritableMemory.wrap(new byte[1000000]));
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 3.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     Assert.assertEquals(values.length, 3);
     Assert.assertEquals(values[0][0], 3.0);
     Assert.assertEquals(values[1][0], 3.0);
@@ -402,29 +402,29 @@ public class ArrayOfDoublesUnionTest {
 
   @Test
   public void directToHeap() {
-    ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(1, new double[] {1.0});
     sketch1.update(2, new double[] {1.0});
 
-    ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
     sketch2.update(2, new double[] {1.0});
     sketch2.update(2, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
     sketch2.update(3, new double[] {1.0});
 
-    ArrayOfDoublesUnion directUnion = new ArrayOfDoublesSetOperationBuilder().buildUnion(WritableMemory.wrap(new byte[1000000]));
-    directUnion.update(sketch1);
+    final ArrayOfDoublesUnion directUnion = new ArrayOfDoublesSetOperationBuilder().buildUnion(WritableMemory.wrap(new byte[1000000]));
+    directUnion.union(sketch1);
 
-    ArrayOfDoublesUnion heapUnion = ArrayOfDoublesUnion.heapify(Memory.wrap(directUnion.toByteArray()));
-    heapUnion.update(sketch2);
+    final ArrayOfDoublesUnion heapUnion = ArrayOfDoublesUnion.heapify(Memory.wrap(directUnion.toByteArray()));
+    heapUnion.union(sketch2);
 
-    ArrayOfDoublesCompactSketch result = heapUnion.getResult();
+    final ArrayOfDoublesCompactSketch result = heapUnion.getResult();
     Assert.assertFalse(result.isEmpty());
     Assert.assertEquals(result.getEstimate(), 3.0);
-    double[][] values = result.getValues();
+    final double[][] values = result.getValues();
     Assert.assertEquals(values.length, 3);
     Assert.assertEquals(values[0][0], 3.0);
     Assert.assertEquals(values[1][0], 3.0);
@@ -433,23 +433,23 @@ public class ArrayOfDoublesUnionTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void incompatibleSeeds() {
-    ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(1).build();
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().setSeed(2).buildUnion();
-    union.update(sketch);
+    final ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setSeed(1).build();
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().setSeed(2).buildUnion();
+    union.union(sketch);
   }
 
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void incompatibleInputSketchFewerValues() {
-    ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().setNumberOfValues(2).buildUnion();
-    union.update(sketch);
+    final ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().build();
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().setNumberOfValues(2).buildUnion();
+    union.union(sketch);
   }
 
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void incompatibleInputSketchMoreValues() {
-    ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
-    ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
-    union.update(sketch);
+    final ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
+    final ArrayOfDoublesUnion union = new ArrayOfDoublesSetOperationBuilder().buildUnion();
+    union.union(sketch);
   }
 
   @Test
@@ -465,9 +465,9 @@ public class ArrayOfDoublesUnionTest {
     sketch.trim(); // pretend this is a result from a union
 
     // as Druid wraps memory
-    ArrayOfDoublesSketches.wrapUnion(mem).update(sketch.compact(WritableMemory.wrap(new byte[1000000])));
+    ArrayOfDoublesSketches.wrapUnion(mem).union(sketch.compact(WritableMemory.wrap(new byte[1000000])));
 
-    ArrayOfDoublesSketch result = ArrayOfDoublesUnion.wrap(mem).getResult();
+    final ArrayOfDoublesSketch result = ArrayOfDoublesUnion.wrap(mem).getResult();
     Assert.assertEquals(result.getEstimate(), sketch.getEstimate());
     Assert.assertEquals(result.isEstimationMode(), sketch.isEstimationMode());
   }
@@ -485,7 +485,7 @@ public class ArrayOfDoublesUnionTest {
       sketch1.update(key++, new double[] {1.0});
     }
     // as Druid wraps memory
-    ArrayOfDoublesSketches.wrapUnion(mem).update(sketch1.compact(WritableMemory.wrap(new byte[1000000])));
+    ArrayOfDoublesSketches.wrapUnion(mem).union(sketch1.compact(WritableMemory.wrap(new byte[1000000])));
 
     final int n2 = 1000000; // estimation mode
     final ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
@@ -493,7 +493,7 @@ public class ArrayOfDoublesUnionTest {
       sketch2.update(key++, new double[] {1.0});
     }
     // as Druid wraps memory
-    ArrayOfDoublesSketches.wrapUnion(mem).update(sketch2.compact(WritableMemory.wrap(new byte[1000000])));
+    ArrayOfDoublesSketches.wrapUnion(mem).union(sketch2.compact(WritableMemory.wrap(new byte[1000000])));
 
     // build one sketch that must be the same as union
     key = 0; // reset to have the same keys
@@ -504,7 +504,7 @@ public class ArrayOfDoublesUnionTest {
     }
     expected.trim(); // union result is trimmed, so we need to trim this sketch for valid comparison
 
-    ArrayOfDoublesSketch result = ArrayOfDoublesUnion.wrap(mem).getResult();
+    final ArrayOfDoublesSketch result = ArrayOfDoublesUnion.wrap(mem).getResult();
     Assert.assertEquals(result.getEstimate(), expected.getEstimate());
     Assert.assertEquals(result.isEstimationMode(), expected.isEstimationMode());
     Assert.assertEquals(result.getUpperBound(1), expected.getUpperBound(1));


### PR DESCRIPTION
Made parallel APIs for SetOperations in Theta, and Tuple (generics): We now have both stateful and stateless operations for union, intersection and AnotB.  Added comprehensive examples (and live tests) for these added stateless and stateful operations.

Made consistent naming of union and intersection operations in ArrayOfDoubles package. We don't have stateless operations for union and intersection in ArrayOfDoubles. This can wait for when we do major refactoring of that package.

Also added more complete testing for the inequality search methods for long arrays, which were missing. 


