### PR TITLE
Add a method in item sketch to retrieve active keys

### DIFF
--- a/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
@@ -306,6 +306,15 @@ public class ItemsSketch<T> {
   }
 
   /**
+  * Returns which are the active keys currently in the sketch.
+  *
+  */
+  public T[] getKeyswhichAreActive(){
+    return hashMap.getActiveKeys();
+  }
+
+  
+  /**
    * Returns epsilon used to compute <i>a priori</i> error.
    * This is just the value <i>3.5 / maxMapSize</i>.
    * @param maxMapSize the planned map size to be used when constructing this sketch.


### PR DESCRIPTION
This is a small addition to the list of current methods supported under ItemSketch.

In many applications, it's required to know at each stage what are the current active Items residing in the hashmap. Instead of indirectly calculating based on the current map size and all, we can get info directly regarding a list of current active keys residing in the hashmap.

Also using this we can get to know which key got removed from consecutive timestamps T1 and T2 or which new one got added.

sketch.getWhichKeysAreActive()_T1 - sketch.getWhichKeysAreActive()_T2