### PR TITLE
Add ByteBuffer hashing methods to MurmurHash3, BaseHllSketch.

### DIFF
--- a/src/main/java/org/apache/datasketches/hll/BaseHllSketch.java
+++ b/src/main/java/org/apache/datasketches/hll/BaseHllSketch.java
@@ -27,6 +27,8 @@ import static org.apache.datasketches.hll.HllUtil.KEY_MASK_26;
 
 import org.apache.datasketches.memory.Memory;
 
+import java.nio.ByteBuffer;
+
 /**
  * Although this class is package-private, it provides a single place to define and document
  * the common public API for both HllSketch and Union.
@@ -324,6 +326,23 @@ abstract class BaseHllSketch {
   public void update(final String datum) {
     if ((datum == null) || datum.isEmpty()) { return; }
     final byte[] data = datum.getBytes(UTF_8);
+    couponUpdate(coupon(hash(data, DEFAULT_UPDATE_SEED)));
+  }
+
+  /**
+   * Present the given byte buffer as a potential unique item.
+   * Bytes are read from the current position of the buffer until its limit.
+   * If the byte buffer is null or has no bytes remaining, no update attempt is made and the method returns.
+   *
+   * This method will not modify the position, mark, limit, or byte order of the buffer.
+   *
+   * Little-endian order is preferred, but not required. This method may perform better if the provided byte
+   * buffer is in little-endian order.
+   *
+   * @param data The given byte buffer.
+   */
+  public void update(final ByteBuffer data) {
+    if ((data == null) || (data.remaining() == 0)) { return; }
     couponUpdate(coupon(hash(data, DEFAULT_UPDATE_SEED)));
   }
 

--- a/src/test/java/org/apache/datasketches/hll/BaseHllSketchTest.java
+++ b/src/test/java/org/apache/datasketches/hll/BaseHllSketchTest.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 
 import org.apache.datasketches.memory.WritableMemory;
 
+import java.nio.ByteBuffer;
+
 /**
  * @author Lee Rhodes
  *
@@ -40,6 +42,10 @@ public class BaseHllSketchTest {
     sk.update(byteArr);
     sk.update(new byte[] {});
     sk.update(new byte[] {0, 1, 2, 3});
+    ByteBuffer byteBuf = null;
+    sk.update(byteBuf);
+    sk.update(ByteBuffer.wrap(new byte[] {}));
+    sk.update(ByteBuffer.wrap(new byte[] {0, 1, 2, 3}));
     char[] charArr = null;
     sk.update(charArr);
     sk.update(new char[] {});
@@ -66,6 +72,10 @@ public class BaseHllSketchTest {
     u.update(byteArr1);
     u.update(new byte[] {});
     u.update(new byte[] {0, 1, 2, 3});
+    ByteBuffer byteBuf1 = null;
+    u.update(byteBuf1);
+    u.update(ByteBuffer.wrap(new byte[] {}));
+    u.update(ByteBuffer.wrap(new byte[] {0, 1, 2, 3}));
     char[] charArr1 = null;
     u.update(charArr1);
     u.update(new char[] {});


### PR DESCRIPTION
My motivation for introducing the ByteBuffer methods is to allow Druid to pass mapped buffers directly to an HllSketch; see https://github.com/apache/druid/pull/11172, https://github.com/apache/druid/pull/11201. We're trying to eliminate unnecessary decodes and copies from the string-column-to-hll-sketch execution path.

Benchmarks in the second Druid PR, _without_ this change are clocking about 50ns per row for very short strings (the benchmark is mostly doing 2–4 character strings). We can speed up the per-row time on this benchmark by another 10ns or so by applying this patch here to datasketches-java, which lets us eliminate one more copy.