### PR TITLE
Memory2 javadoc fixes and Github matrix testing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,7 +56,7 @@ jobs:
               --toolchains .github/workflows/.toolchains.xml
         
         - name: Test & Report
-          if: ${{ success() }}
+          if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q
               -Dcoveralls-repo-token=${repo_token}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,7 @@ name: Java Test Coverage with Maven, Coveralls
 on:
     pull_request:
     push:
-        branches: [ master, Memory2-doc-fixes-gh-action ]
+        branches: [ master, Memory2-doc-fixes-gh-actions ]
     workflow_dispatch:
 
 env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,7 @@ name: Java Test Coverage with Maven, Coveralls
 on:
     pull_request:
     push:
-        branches: [ master ]
+        branches: [ master, Memory2-doc-fixes-gh-action ]
     workflow_dispatch:
 
 env:
@@ -14,6 +14,13 @@ jobs:
     build:
         name: Build, Test, Coverage
         runs-on: ubuntu-latest
+        strategy:
+          fail-fast: false
+          matrix:
+              jdk: [ 8,9,10,11,12,13 ]
+
+        env:
+          JDK_VERSION: ${{ matrix.jdk }}
         
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -28,13 +35,17 @@ jobs:
               key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
               restore-keys: build-${{ runner.os }}-maven-
 
-        - name: Install JDK
+        - name: Install Matrix JDK
           uses: AdoptOpenJDK/install-jdk@v1
           with:
-              version: '8'
+              version: ${{ matrix.jdk }}
               architecture: x64
               impl: hotspot
-              targets: 'JDK_8;JAVA_HOME'
+              targets: 'JAVA_HOME'
+
+        - name: Echo Java Version
+          run: >
+              java -version
 
         - name: Install Dependencies
           run: >

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,8 +49,7 @@ jobs:
 
         - name: Install Dependencies
           run: >
-              mvn clean install -B -V -q
-              -DskipTests=false
+              mvn clean test install -B -V -q
               -Dmaven.javadoc.skip=true
               -Dgpg.skip=true
               --toolchains .github/workflows/.toolchains.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,14 +47,22 @@ jobs:
           run: >
               java -version
 
+        - name: Test
+          run: >
+              mvn clean test
+              -Dmaven.javadoc.skip=true
+              -Dgpg.skip=true
+              --toolchains .github/workflows/.toolchains.xml
+
         - name: Install Dependencies
           run: >
-              mvn clean test install -B -V -q
+              mvn clean install -B -V -q
+              -DskipTests=true
               -Dmaven.javadoc.skip=true
               -Dgpg.skip=true
               --toolchains .github/workflows/.toolchains.xml
         
-        - name: Test & Report
+        - name: Report
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,7 +50,7 @@ jobs:
         - name: Install Dependencies
           run: >
               mvn clean install -B -V -q
-              -DskipTests=true
+              -DskipTests=false
               -Dmaven.javadoc.skip=true
               -Dgpg.skip=true
               --toolchains .github/workflows/.toolchains.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,7 @@ name: Java Test Coverage with Maven, Coveralls
 on:
     pull_request:
     push:
-        branches: [ master, Memory2-doc-fixes-gh-actions ]
+        branches: [ master ]
     workflow_dispatch:
 
 env:
@@ -21,7 +21,7 @@ jobs:
 
         env:
           JDK_VERSION: ${{ matrix.jdk }}
-        
+
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
           uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
               -Dmaven.javadoc.skip=true
               -Dgpg.skip=true
               --toolchains .github/workflows/.toolchains.xml
-        
+
         - name: Report
           if: ${{ matrix.jdk == 8 && success() }}
           run: >

--- a/pom.xml
+++ b/pom.xml
@@ -703,6 +703,12 @@ under the License.
                 <useManifestOnlyJar>false</useManifestOnlyJar>
                 <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 <reportsDirectory>${project.build.directory}/test-output/${maven.build.timestamp}</reportsDirectory>
+                <argLine>
+                  --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                  --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                  --add-opens java.base/java.nio=ALL-UNNAMED
+                  --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                </argLine>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -703,12 +703,14 @@ under the License.
                 <useManifestOnlyJar>false</useManifestOnlyJar>
                 <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 <reportsDirectory>${project.build.directory}/test-output/${maven.build.timestamp}</reportsDirectory>
+                <!-- intentional failure
                 <argLine>
                   --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
                   --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
                   --add-opens java.base/java.nio=ALL-UNNAMED
                   --add-opens java.base/sun.nio.ch=ALL-UNNAMED
                 </argLine>
+                -->
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -703,14 +703,6 @@ under the License.
                 <useManifestOnlyJar>false</useManifestOnlyJar>
                 <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 <reportsDirectory>${project.build.directory}/test-output/${maven.build.timestamp}</reportsDirectory>
-                <!-- intentional failure
-                <argLine>
-                  --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
-                  --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
-                  --add-opens java.base/java.nio=ALL-UNNAMED
-                  --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-                </argLine>
-                -->
               </configuration>
             </plugin>
           </plugins>

--- a/src/main/java/org/apache/datasketches/ArrayOfNumbersSerDe.java
+++ b/src/main/java/org/apache/datasketches/ArrayOfNumbersSerDe.java
@@ -30,8 +30,8 @@ import org.apache.datasketches.memory.WritableMemory;
  * The class keeps the values byte aligned, even though only 3 bits are strictly necessary to
  * encode one of the 6 different primitives with object types that extend Number.</p>
  *
- * <p>Classes handled are: <tt>Long</tt>, <tt>Integer</tt>, <tt>Short</tt>, <tt>Byte</tt>,
- * <tt>Double</tt>, and <tt>Float</tt>.</p>
+ * <p>Classes handled are: <code>Long</code>, <code>Integer</code>, <code>Short</code>,
+ * <code>Byte</code>, <code>Double</code>, and <code>Float</code>.</p>
  *
  * @author Jon Malkin
  */

--- a/src/main/java/org/apache/datasketches/hllmap/Map.java
+++ b/src/main/java/org/apache/datasketches/hllmap/Map.java
@@ -138,7 +138,7 @@ abstract class Map {
   void deleteKey(final int index) {}
 
   /**
-   * Returns <tt>true</tt> if the two specified sub-arrays of bytes are <i>equal</i> to one another.
+   * Returns <code>true</code> if the two specified sub-arrays of bytes are <i>equal</i> to one another.
    * Two arrays are considered equal if all corresponding pairs of elements in the two arrays are
    * equal. In other words, two arrays are equal if and only if they contain the same elements
    * in the same order.
@@ -148,7 +148,7 @@ abstract class Map {
    * @param b the other sub-array to be tested for equality
    * @param offsetB the offset in bytes of the start of sub-array <i>b</i>.
    * @param length the length in bytes of the two sub-arrays.
-   * @return <tt>true</tt> if the two sub-arrays are equal
+   * @return <code>true</code> if the two sub-arrays are equal
    */
   static final boolean arraysEqual(final byte[] a, final int offsetA, final byte[] b,
       final int offsetB, final int length) {

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirItemsSketch.java
@@ -104,7 +104,7 @@ public final class ReservoirItemsSketch<T> {
    * when deserializing.
    * Uses size of items array to as initial array allocation.
    *
-   * @param data      Reservoir items as an <tt>ArrayList&lt;T&gt;</tt>
+   * @param data      Reservoir items as an <code>ArrayList&lt;T&gt;</code>
    * @param itemsSeen Number of items presented to the sketch so far
    * @param rf        <a href="{@docRoot}/resources/dictionary.html#resizeFactor">See Resize Factor</a>
    * @param k         Maximum size of reservoir
@@ -349,7 +349,7 @@ public final class ReservoirItemsSketch<T> {
    * may be smaller than the reservoir capacity.
    *
    * <p>In order to allocate an array of generic type T, uses the class of the first item in
-   * the array. This method method may throw an <tt>ArrayAssignmentException</tt> if the
+   * the array. This method method may throw an <code>ArrayAssignmentException</code> if the
    * reservoir stores instances of a polymorphic base class.</p>
    *
    * @return A copy of the reservoir array
@@ -557,7 +557,7 @@ public final class ReservoirItemsSketch<T> {
    * few points.
    *
    * @param pos The position from which to retrieve the element
-   * @return The value in the reservoir at position <tt>pos</tt>
+   * @return The value in the reservoir at position <code>pos</code>
    */
   T getValueAtPosition(final int pos) {
     if (itemsSeen_ == 0) {

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirItemsUnion.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirItemsUnion.java
@@ -45,7 +45,7 @@ import org.apache.datasketches.memory.WritableMemory;
  * base. As a result, we provide only a stateful union. Using the same approach for a merge would
  * result in unpredictable side effects on the underlying sketches.</p>
  *
- * <p>A union object is created with a maximum value of <tt>k</tt>, represented using the
+ * <p>A union object is created with a maximum value of <code>k</code>, represented using the
  * ReservoirSize class. The unioning process may cause the actual number of samples to fall below
  * that maximum value, but never to exceed it. The result of a union will be a reservoir where
  * each item from the global input has a uniform probability of selection, but there are no

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirLongsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirLongsSketch.java
@@ -45,7 +45,7 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 
 /**
- * This sketch provides a reservoir sample over an input stream of <tt>long</tt>s. The sketch
+ * This sketch provides a reservoir sample over an input stream of <code>long</code>s. The sketch
  * contains a uniform random sample of items from the stream.
  *
  * @author Jon Malkin
@@ -484,7 +484,7 @@ public final class ReservoirLongsSketch {
    * points.
    *
    * @param pos The position from which to retrieve the element
-   * @return The value in the reservoir at position <tt>pos</tt>
+   * @return The value in the reservoir at position <code>pos</code>
    */
   long getValueAtPosition(final int pos) {
     if (itemsSeen_ == 0) {

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirLongsUnion.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirLongsUnion.java
@@ -44,7 +44,7 @@ import org.apache.datasketches.memory.WritableMemory;
  * </p>
  *
  * <p>
- * A union object is created with a maximum value of <tt>k</tt>, represented using the ReservoirSize
+ * A union object is created with a maximum value of <code>k</code>, represented using the ReservoirSize
  * class. The unioning process may cause the actual number of samples to fall below that maximum
  * value, but never to exceed it. The result of a union will be a reservoir where each item from the
  * global input has a uniform probability of selection, but there are no claims about higher order

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirSize.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirSize.java
@@ -65,7 +65,7 @@ final class ReservoirSize {
 
   /**
    * Given target reservoir size k, computes the smallest representable reservoir size that can
-   * hold k entries and returns it in a 16-bit fixed-point format as a <tt>short</tt>.
+   * hold k entries and returns it in a 16-bit fixed-point format as a <code>short</code>.
    *
    * @param k target reservoir size
    * @return reservoir size as 16-bit encoded value
@@ -104,7 +104,7 @@ final class ReservoirSize {
    * Decodes the 16-bit reservoir size value into an int.
    *
    * @param encodedSize Encoded 16-bit value
-   * @return int represented by <tt>encodedSize</tt>
+   * @return int represented by <code>encodedSize</code>
    */
   public static int decodeValue(final short encodedSize) {
     final int value = encodedSize & 0xFFFF;

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsSamples.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsSamples.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
  * This class provides access to the samples contained in a VarOptItemsSketch. It provides two
  * mechanisms for access:
  * <ul>
- *   <li>An <tt>Iterator</tt> over <tt>WeightedSample</tt> objects which can can be used to
+ *   <li>An <code>Iterator</code> over <code>WeightedSample</code> objects which can can be used to
  *   access both the items and weights in the sample, and which avoids copying data from the
  *   sketch.</li>
  *   <li>Getter methods to obtain items or weights as arrays, or individual items. These
@@ -36,10 +36,10 @@ import java.util.NoSuchElementException;
  * </ul>
  *
  * <p>If using getters with a sketch storing heterogeneous items from a polymorphic base class, you
- * must call <tt>setClass()</tt> prior to calling one of the getter methods. This is not
+ * must call <code>setClass()</code> prior to calling one of the getter methods. This is not
  * necessary if using the iterator.</p>
  *
- * <p>The class also implements <tt>Iterable</tt> to allow the use of forEach loops for
+ * <p>The class also implements <code>Iterable</code> to allow the use of forEach loops for
  * convenience.</p>
  *
  * @param <T> an item of type T
@@ -204,7 +204,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
   /**
    * Specifies the class to use when copying the item array from the sketch. This method is
    * required if the sketch stores heterogeneous item types of some base class, for instance a
-   * sketch over <tt>Number</tt>s.
+   * sketch over <code>Number</code>s.
    *
    * @param clazz The class to use when creating the item array result
    */
@@ -241,7 +241,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
    * Returns a single item from the samples contained in the sketch. Does not perform bounds
    * checking on the input. If this is the first getter call, copies data arrays from the sketch.
    * @param i An index into the list of samples
-   * @return The sample at array position <tt>i</tt>
+   * @return The sample at array position <code>i</code>
    */
   public T items(final int i) {
     loadArrays();
@@ -262,7 +262,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
    * Returns a single weight from the samples contained in the sketch. Does not perform bounds
    * checking on the input. If this is the first getter call, copies data arrays from the sketch.
    * @param i An index into the list of weights
-   * @return The weight at array position <tt>i</tt>
+   * @return The weight at array position <code>i</code>
    */
   public double weights(final int i) {
     loadArrays();


### PR DESCRIPTION
The Teletype `<tt>` tag has been deprecated in HTML 5 and was resulting in Javadoc generation errors on this branch.  The official HTML documentation recommends using alternatives such as `<samp />` or `<code />` instead.
This PR replaces `<tt />` usages with `<code />`.

Finally, matrix testing support has been added to the build to run the tests against Java 8-13.