### PR TITLE
Code additions requested by Will.

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---add-opens java.base/jdk.internal.ref=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -698,6 +698,7 @@ under the License.
                 <argLine>
                   --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
                   --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                  --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
                   --add-opens java.base/java.nio=ALL-UNNAMED
                   --add-opens java.base/sun.nio.ch=ALL-UNNAMED
                 </argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -698,7 +698,6 @@ under the License.
                 <argLine>
                   --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
                   --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
-                  --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
                   --add-opens java.base/java.nio=ALL-UNNAMED
                   --add-opens java.base/sun.nio.ch=ALL-UNNAMED
                 </argLine>

--- a/src/main/java/org/apache/datasketches/theta/DirectCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectCompactSketch.java
@@ -19,10 +19,10 @@
 
 package org.apache.datasketches.theta;
 
+import static org.apache.datasketches.Util.checkSeedHashes;
 import static org.apache.datasketches.theta.CompactOperations.checkIllegalCurCountAndEmpty;
 import static org.apache.datasketches.theta.CompactOperations.memoryToCompact;
 import static org.apache.datasketches.theta.PreambleUtil.ORDERED_FLAG_MASK;
-import static org.apache.datasketches.theta.PreambleUtil.checkMemorySeedHash;
 import static org.apache.datasketches.theta.PreambleUtil.extractCurCount;
 import static org.apache.datasketches.theta.PreambleUtil.extractFlags;
 import static org.apache.datasketches.theta.PreambleUtil.extractPreLongs;
@@ -60,16 +60,16 @@ class DirectCompactSketch extends CompactSketch {
    * Wraps the given Memory, which must be a SerVer 3, ordered, CompactSketch image.
    * Must check the validity of the Memory before calling. The order bit must be set properly.
    * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
-   * @param seed The update seed.
-   * <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
+   * @param seedHash The update seedHash.
+   * <a href="{@docRoot}/resources/dictionary.html#seedHash">See Seed Hash</a>.
    * @return this sketch
    */
-  static DirectCompactSketch wrapInstance(final Memory srcMem, final long seed) {
-    checkMemorySeedHash(srcMem, seed);
+  static DirectCompactSketch wrapInstance(final Memory srcMem, final short seedHash) {
+    checkSeedHashes((short) extractSeedHash(srcMem), seedHash);
     return new DirectCompactSketch(srcMem);
   }
 
-  //Sketch
+  //Sketch Overrides
 
   @Override
   public CompactSketch compact(final boolean dstOrdered, final WritableMemory dstMem) {

--- a/src/main/java/org/apache/datasketches/theta/ForwardCompatibility.java
+++ b/src/main/java/org/apache/datasketches/theta/ForwardCompatibility.java
@@ -19,14 +19,12 @@
 
 package org.apache.datasketches.theta;
 
-import static org.apache.datasketches.theta.PreambleUtil.checkMemorySeedHash;
 import static org.apache.datasketches.theta.PreambleUtil.extractCurCount;
 import static org.apache.datasketches.theta.PreambleUtil.extractFamilyID;
 import static org.apache.datasketches.theta.PreambleUtil.extractPreLongs;
 import static org.apache.datasketches.theta.PreambleUtil.extractThetaLong;
 
 import org.apache.datasketches.SketchesArgumentException;
-import org.apache.datasketches.Util;
 import org.apache.datasketches.memory.Memory;
 
 /**
@@ -37,25 +35,6 @@ import org.apache.datasketches.memory.Memory;
  * @author Lee Rhodes
  */
 final class ForwardCompatibility {
-
-  /**
-   * Convert a serialization version (SerVer) 1 sketch (~Feb 2014) to a SerVer 3 sketch.
-   * Note: SerVer 1 sketches always have (metadata) preamble-longs of 3 and are always stored
-   * in a compact ordered form, but with 3 different sketch types.  All SerVer 1 sketches will
-   * be converted to a SerVer 3 sketches. There is no concept of p-sampling, no empty bit.
-   *
-   * @param srcMem the image of a SerVer 1 sketch
-   *
-   * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
-   * The seed used for building the sketch image in srcMem.
-   * Note: SerVer 1 sketches do not have the concept of the SeedHash, so the seed provided here
-   * MUST be the actual seed that was used when the SerVer 1 sketches were built.
-   * @return a SerVer 3 {@link CompactSketch}.
-   */
-  static final CompactSketch heapify1to3(final Memory srcMem, final long seed) {
-    final short seedHash = Util.computeSeedHash(seed);
-    return heapify1to3(srcMem, seedHash);
-  }
 
   /**
    * Convert a serialization version (SerVer) 1 sketch (~Feb 2014) to a SerVer 3 sketch.
@@ -108,12 +87,11 @@ final class ForwardCompatibility {
    * Note: SerVer 2 sketches can have metadata-longs of 1,2 or 3 and are always stored
    * in a compact ordered form (not as a hash table), but with 4 different sketch types.
    * @param srcMem the image of a SerVer 2 sketch
-   * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
+   * @param seedHash <a href="{@docRoot}/resources/dictionary.html#seedHash">See Seed Hash</a>.
    * The seed used for building the sketch image in srcMem
    * @return a SerVer 3 HeapCompactOrderedSketch
    */
-  static final CompactSketch heapify2to3(final Memory srcMem, final long seed) {
-    final short seedHash = checkMemorySeedHash(srcMem, seed);
+  static final CompactSketch heapify2to3(final Memory srcMem, final short seedHash) {
     final int memCap = (int) srcMem.getCapacity();
     final int preLongs = extractPreLongs(srcMem); //1,2 or 3
     final int familyId = extractFamilyID(srcMem); //1,2,3,4
@@ -139,7 +117,7 @@ final class ForwardCompatibility {
         reqBytesIn = (preLongs + 1) << 3;
         validateInputSize(reqBytesIn, memCap);
         final long hash = srcMem.getLong(preLongs << 3);
-        return new SingleItemSketch(hash, seed);
+        return new SingleItemSketch(hash, seedHash);
       }
       //curCount > 1
       reqBytesIn = (curCount + preLongs) << 3;
@@ -160,7 +138,7 @@ final class ForwardCompatibility {
         reqBytesIn = (preLongs + 1) << 3;
         validateInputSize(reqBytesIn, memCap);
         final long hash = srcMem.getLong(preLongs << 3);
-        return new SingleItemSketch(hash, seed);
+        return new SingleItemSketch(hash, seedHash);
       }
       //curCount > 1 and/or theta < 1.0
       reqBytesIn = (curCount + preLongs) << 3;

--- a/src/main/java/org/apache/datasketches/theta/HeapCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapCompactSketch.java
@@ -153,7 +153,7 @@ class HeapCompactSketch extends CompactSketch {
     return seedHash_;
   }
 
-  //use of Memory is convenient. The byteArray and Memory are loaded simulaneously.
+  //use of Memory is convenient. The byteArray and Memory are loaded simultaneously.
   @Override
   public byte[] toByteArray() {
     final int bytes = getCurrentBytes();

--- a/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
@@ -22,6 +22,7 @@ package org.apache.datasketches.theta;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.datasketches.ByteArrayUtil.putLongLE;
 import static org.apache.datasketches.Util.DEFAULT_UPDATE_SEED;
+import static org.apache.datasketches.Util.checkSeedHashes;
 import static org.apache.datasketches.Util.computeSeedHash;
 import static org.apache.datasketches.hash.MurmurHash3.hash;
 import static org.apache.datasketches.theta.PreambleUtil.SINGLEITEM_FLAG_MASK;
@@ -29,6 +30,7 @@ import static org.apache.datasketches.theta.PreambleUtil.checkMemorySeedHash;
 import static org.apache.datasketches.theta.PreambleUtil.extractFamilyID;
 import static org.apache.datasketches.theta.PreambleUtil.extractFlags;
 import static org.apache.datasketches.theta.PreambleUtil.extractPreLongs;
+import static org.apache.datasketches.theta.PreambleUtil.extractSeedHash;
 import static org.apache.datasketches.theta.PreambleUtil.extractSerVer;
 
 import org.apache.datasketches.Family;
@@ -98,6 +100,21 @@ final class SingleItemSketch extends CompactSketch {
     if (singleItem) { return new SingleItemSketch(srcMem.getLong(8), seedHashMem); }
     throw new SketchesArgumentException("Input Memory is not a SingleItemSketch.");
   }
+
+  /**
+   * Creates a SingleItemSketch on the heap given a SingleItemSketch Memory image and a seedHash.
+   * Checks the seed hash of the given Memory against a hash of the given seed.
+   * @param srcMem the Memory to be heapified.
+   * @param seedHash a given seedHash
+   * @return a SingleItemSketch
+   */ //does not override Sketch
+  public static SingleItemSketch heapify(final Memory srcMem, final short seedHash) {
+    checkSeedHashes((short) extractSeedHash(srcMem), seedHash);
+    final boolean singleItem = otherCheckForSingleItem(srcMem);
+    if (singleItem) { return new SingleItemSketch(srcMem.getLong(8), seedHash); }
+    throw new SketchesArgumentException("Input Memory is not a SingleItemSketch.");
+  }
+
 
   @Override
   public CompactSketch compact(final boolean dstOrdered, final WritableMemory dstMem) {

--- a/src/main/java/org/apache/datasketches/theta/Sketch.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketch.java
@@ -27,14 +27,10 @@ import static org.apache.datasketches.Util.LS;
 import static org.apache.datasketches.Util.ceilingPowerOf2;
 import static org.apache.datasketches.Util.zeroPad;
 import static org.apache.datasketches.theta.PreambleUtil.COMPACT_FLAG_MASK;
-import static org.apache.datasketches.theta.PreambleUtil.EMPTY_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.FAMILY_BYTE;
-import static org.apache.datasketches.theta.PreambleUtil.FLAGS_BYTE;
 import static org.apache.datasketches.theta.PreambleUtil.ORDERED_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.PREAMBLE_LONGS_BYTE;
-import static org.apache.datasketches.theta.PreambleUtil.READ_ONLY_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.SER_VER_BYTE;
-import static org.apache.datasketches.theta.SingleItemSketch.otherCheckForSingleItem;
 
 import org.apache.datasketches.BinomialBoundsN;
 import org.apache.datasketches.Family;
@@ -57,75 +53,120 @@ public abstract class Sketch {
   //public static factory constructor-type methods
 
   /**
-   * Heapify takes the sketch image in Memory and instantiates an on-heap
-   * Sketch using the
-   * <a href="{@docRoot}/resources/dictionary.html#defaultUpdateSeed">Default Update Seed</a>.
-   * The resulting sketch will not retain any link to the source Memory.
-   * @param srcMem an image of a Sketch where the image seed hash matches the default seed hash.
-   * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
-   * @return a Heap-based Sketch from the given Memory
+   * Heapify takes the sketch image in Memory and instantiates an on-heap Sketch.
+   *
+   * <p>The resulting sketch will not retain any link to the source Memory.</p>
+   *
+   * <p>For Update Sketches this method checks if the
+   * <a href="{@docRoot}/resources/dictionary.html#defaultUpdateSeed">Default Update Seed</a></p>
+   * was used to create the source Memory image.
+   *
+   * <p>For Compact Sketches this method assumes that the sketch image was created with the
+   * correct hash seed, so it is not checked.</p>
+   *
+   * @param srcMem an image of a Sketch.
+   * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>.
+   * @return a Sketch on the heap.
    */
   public static Sketch heapify(final Memory srcMem) {
-    return heapify(srcMem, DEFAULT_UPDATE_SEED);
+    final byte familyID = srcMem.getByte(FAMILY_BYTE);
+    final Family family = idToFamily(familyID);
+    if (family == Family.COMPACT) {
+      return CompactSketch.heapify(srcMem);
+    }
+    return heapifyUpdateFromMemory(srcMem, DEFAULT_UPDATE_SEED);
   }
 
   /**
-   * Heapify takes the sketch image in Memory and instantiates an on-heap
-   * Sketch using the given seed.
-   * The resulting sketch will not retain any link to the source Memory.
-   * @param srcMem an image of a Sketch where the image seed hash matches the given seed hash.
-   * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
+   * Heapify takes the sketch image in Memory and instantiates an on-heap Sketch.
+   *
+   * <p>The resulting sketch will not retain any link to the source Memory.</p>
+   *
+   * <p>For Update and Compact Sketches this method checks if the given seed was used to
+   * create the source Memory image.  However, SerialVersion 1 sketches cannot be checked.</p>
+   *
+   * @param srcMem an image of a Sketch that was created using the given seed.
+   * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>.
    * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
    * Compact sketches store a 16-bit hash of the seed, but not the seed itself.
-   * @return a Heap-based Sketch from the given Memory
+   * @return a Sketch on the heap.
    */
   public static Sketch heapify(final Memory srcMem, final long seed) {
-    final int serVer = srcMem.getByte(SER_VER_BYTE);
-    if (serVer == 3) {
-      return heapifyFromMemory(srcMem, seed);
+    final byte familyID = srcMem.getByte(FAMILY_BYTE);
+    final Family family = idToFamily(familyID);
+    if (family == Family.COMPACT) {
+      return CompactSketch.heapify(srcMem, seed);
     }
-    if (serVer == 1) {
-      return ForwardCompatibility.heapify1to3(srcMem, seed);
-    }
-    if (serVer == 2) {
-      return ForwardCompatibility.heapify2to3(srcMem, seed);
-    }
-    throw new SketchesArgumentException("Unknown Serialization Version: " + serVer);
+    return heapifyUpdateFromMemory(srcMem, seed);
   }
 
   /**
-   * Wrap takes the sketch image in Memory and refers to it directly. There is no data copying onto
-   * the java heap.  Only "Direct" Serialization Version 3 (i.e, OpenSource) sketches that have
-   * been explicitly stored as direct objects can be wrapped. This method assumes the
-   * {@link org.apache.datasketches.Util#DEFAULT_UPDATE_SEED}.
-   * <a href="{@docRoot}/resources/dictionary.html#defaultUpdateSeed">Default Update Seed</a>.
-   * @param srcMem an image of a Sketch where the image seed hash matches the default seed hash.
-   * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
-   * @return a Sketch backed by the given Memory
-   */
-  public static Sketch wrap(final Memory srcMem) {
-    return wrap(srcMem, DEFAULT_UPDATE_SEED);
-  }
-
-  /**
-   * Wrap takes the sketch image in Memory and refers to it directly with just a reference.
-   * There is no data copying onto the java heap.  Only "Direct" Serialization Version 3
-   * (i.e, OpenSource) sketches that have been explicitly stored as direct objects can be wrapped.
+   * Wrap takes the sketch image in the given Memory and refers to it directly.
+   * There is no data copying onto the java heap.
+   * The wrap operation enables fast read-only merging and access to all the public read-only API.
    *
-   * <p>The wrap operation enables fast read-only merging and access to all the public read-only API.</p>
-   *
-   * <p>Note: wrapping earlier serial version sketches will result in a on-heap form of the
-   * sketch where all data will be copied to the heap. These early versions were never designed to
+   * <p>Only "Direct" Serialization Version 3 (i.e, OpenSource) sketches that have
+   * been explicitly stored as direct sketches can be wrapped.
+   * Wrapping earlier serial version sketches will result in a on-heap CompactSketch
+   * where all data will be copied to the heap. These early versions were never designed to
    * "wrap".</p>
    *
    * <p>Wrapping any subclass of this class that is empty or contains only a single item will
    * result in on-heap equivalent forms of empty and single item sketch respectively.
    * This is actually faster and consumes less overall memory.</p>
    *
-   * @param srcMem an image of a Sketch where the image seed hash matches the given seed hash.
+   * <p>For Update Sketches this method checks if the
+   * <a href="{@docRoot}/resources/dictionary.html#defaultUpdateSeed">Default Update Seed</a></p>
+   * was used to create the source Memory image.
+   *
+   * <p>For Compact Sketches this method assumes that the sketch image was created with the
+   * correct hash seed, so it is not checked.</p>
+   *
+   * @param srcMem an image of a Sketch.
+   * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>.
+   * @return a Sketch backed by the given Memory
+   */
+  public static Sketch wrap(final Memory srcMem) {
+    final int  preLongs = srcMem.getByte(PREAMBLE_LONGS_BYTE) & 0X3F;
+    final int serVer = srcMem.getByte(SER_VER_BYTE) & 0XFF;
+    final int familyID = srcMem.getByte(FAMILY_BYTE) & 0XFF;
+    final Family family = Family.idToFamily(familyID);
+    if (family == Family.QUICKSELECT) {
+      if (serVer == 3 && preLongs == 3) {
+        return DirectQuickSelectSketchR.readOnlyWrap(srcMem, DEFAULT_UPDATE_SEED);
+      } else {
+        throw new SketchesArgumentException(
+            "Corrupted: " + family + " family image: must have SerVer = 3 and preLongs = 3");
+      }
+    }
+    if (family == Family.COMPACT) {
+      return CompactSketch.wrap(srcMem);
+    }
+    throw new SketchesArgumentException(
+        "Cannot wrap family: " + family + " as a Sketch");
+  }
+
+  /**
+   * Wrap takes the sketch image in the given Memory and refers to it directly.
+   * There is no data copying onto the java heap.
+   * The wrap operation enables fast read-only merging and access to all the public read-only API.
+   *
+   * <p>Only "Direct" Serialization Version 3 (i.e, OpenSource) sketches that have
+   * been explicitly stored as direct sketches can be wrapped.
+   * Wrapping earlier serial version sketches will result in a on-heap CompactSketch
+   * where all data will be copied to the heap. These early versions were never designed to
+   * "wrap".</p>
+   *
+   * <p>Wrapping any subclass of this class that is empty or contains only a single item will
+   * result in on-heap equivalent forms of empty and single item sketch respectively.
+   * This is actually faster and consumes less overall memory.</p>
+   *
+   * <p>For Update and Compact Sketches this method checks if the given seed was used to
+   * create the source Memory image.  However, SerialVersion 1 sketches cannot be checked.</p>
+   *
+   * @param srcMem an image of a Sketch.
    * <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
    * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
-   * Compact sketches store a 16-bit hash of the seed, but not the seed itself.
    * @return a UpdateSketch backed by the given Memory except as above.
    */
   public static Sketch wrap(final Memory srcMem, final long seed) {
@@ -133,49 +174,19 @@ public abstract class Sketch {
     final int serVer = srcMem.getByte(SER_VER_BYTE) & 0XFF;
     final int familyID = srcMem.getByte(FAMILY_BYTE) & 0XFF;
     final Family family = Family.idToFamily(familyID);
-    switch (family) {
-      case QUICKSELECT: { //Hash Table structure
-        if (serVer == 3 && preLongs == 3) {
-          return DirectQuickSelectSketchR.readOnlyWrap(srcMem, seed);
-        } else {
-          throw new SketchesArgumentException(
-              "Corrupted: " + family + " family image: must have SerVer = 3 and preLongs = 3");
-        }
-      }
-      case COMPACT: { //serVer 1, 2, 3; preLongs = 1, 2, or 3
-        if (serVer == 3) {
-          if (PreambleUtil.isEmptyFlag(srcMem)) {
-            return EmptyCompactSketch.getHeapInstance(srcMem);
-          }
-          if (otherCheckForSingleItem(srcMem)) { //SINGLEITEM?
-            return SingleItemSketch.heapify(srcMem, seed);
-          }
-          //not empty & not singleItem
-          final int flags = srcMem.getByte(FLAGS_BYTE);
-          final boolean compactFlag = (flags & COMPACT_FLAG_MASK) > 0;
-          if (!compactFlag) {
-            throw new SketchesArgumentException(
-                "Corrupted: COMPACT family sketch image must have compact flag set");
-          }
-          final boolean readOnly = (flags & READ_ONLY_FLAG_MASK) > 0;
-          if (!readOnly) {
-            throw new SketchesArgumentException(
-                "Corrupted: COMPACT family sketch image must have Read-Only flag set");
-          }
-          return DirectCompactSketch.wrapInstance(srcMem, seed);
-        } //end of serVer 3
-        else if (serVer == 1) {
-          return ForwardCompatibility.heapify1to3(srcMem, seed);
-        }
-        else if (serVer == 2) {
-          return ForwardCompatibility.heapify2to3(srcMem, seed);
-        }
+    if (family == Family.QUICKSELECT) {
+      if (serVer == 3 && preLongs == 3) {
+        return DirectQuickSelectSketchR.readOnlyWrap(srcMem, seed);
+      } else {
         throw new SketchesArgumentException(
-            "Corrupted: Serialization Version " + serVer + " not recognized.");
+            "Corrupted: " + family + " family image: must have SerVer = 3 and preLongs = 3");
       }
-      default: throw new SketchesArgumentException(
-          "Sketch cannot wrap family: " + family + " as a Sketch");
     }
+    if (family == Family.COMPACT) {
+      return CompactSketch.wrap(srcMem, seed);
+    }
+    throw new SketchesArgumentException(
+        "Cannot wrap family: " + family + " as a Sketch");
   }
 
   //Sketch interface
@@ -633,12 +644,12 @@ public abstract class Sketch {
   }
 
   /**
-   * Instantiates a Heap Sketch from Memory. SerVer 1 & 2 already handled.
+   * Instantiates a Heap Update Sketch from Memory. Only SerVer3. SerVer 1 & 2 already handled.
    * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
    * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
    * @return a Sketch
    */
-  private static final Sketch heapifyFromMemory(final Memory srcMem, final long seed) {
+  private static final Sketch heapifyUpdateFromMemory(final Memory srcMem, final long seed) {
     final long cap = srcMem.getCapacity();
     if (cap < 8) {
       throw new SketchesArgumentException(
@@ -646,32 +657,21 @@ public abstract class Sketch {
     }
     final byte familyID = srcMem.getByte(FAMILY_BYTE);
     final Family family = idToFamily(familyID);
-    final int flags = PreambleUtil.extractFlags(srcMem);
-    final boolean compactFlag = (flags & COMPACT_FLAG_MASK) != 0;
 
-    switch (family) {
-      case ALPHA: {
-        if (compactFlag) {
-          throw new SketchesArgumentException(
-              "Corrupted: ALPHA family image: cannot be compact");
-        }
-        return HeapAlphaSketch.heapifyInstance(srcMem, seed);
-      }
-      case QUICKSELECT: {
-        return HeapQuickSelectSketch.heapifyInstance(srcMem, seed);
-      }
-      case COMPACT: {
-        final boolean empty = (flags & EMPTY_FLAG_MASK) != 0;
-        if (!empty) { PreambleUtil.checkMemorySeedHash(srcMem, seed); }
-        final boolean srcOrdered = (flags & ORDERED_FLAG_MASK) != 0;
-        return CompactOperations.memoryToCompact(srcMem, srcOrdered, null);
-      } //end of Compact
-
-      default: {
+    if (family == Family.ALPHA) {
+      final int flags = PreambleUtil.extractFlags(srcMem);
+      final boolean compactFlag = (flags & COMPACT_FLAG_MASK) != 0;
+      if (compactFlag) {
         throw new SketchesArgumentException(
-            "Sketch cannot heapify family: " + family + " as a Sketch");
+            "Corrupted: ALPHA family image: cannot be compact");
       }
+      return HeapAlphaSketch.heapifyInstance(srcMem, seed);
     }
+    if (family == Family.QUICKSELECT) {
+      return HeapQuickSelectSketch.heapifyInstance(srcMem, seed);
+    }
+    throw new SketchesArgumentException(
+        "Sketch cannot heapify family: " + family + " as a Sketch");
   }
 
 }

--- a/src/main/java/org/apache/datasketches/theta/Sketches.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketches.java
@@ -44,244 +44,27 @@ public final class Sketches {
   private Sketches() {}
 
   /**
-   * Ref: {@link UpdateSketchBuilder UpdateSketchBuilder}
-   * @return {@link UpdateSketchBuilder UpdateSketchBuilder}
+   * Gets the unique count estimate from a valid memory image of a Sketch
+   * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
+   * @return the sketch's best estimate of the cardinality of the input stream.
    */
-  public static UpdateSketchBuilder updateSketchBuilder() {
-    return new UpdateSketchBuilder();
+  public static double getEstimate(final Memory srcMem) {
+    checkIfValidThetaSketch(srcMem);
+    return Sketch.estimate(getThetaLong(srcMem), getRetainedEntries(srcMem));
   }
 
   /**
-   * Ref: {@link Sketch#heapify(Memory) Sketch.heapify(Memory)}
-   * @param srcMem Ref: {@link Sketch#heapify(Memory) Sketch.heapify(Memory)} {@code srcMem}
-   * @return {@link Sketch Sketch}
+   * Gets the approximate lower error bound from a valid memory image of a Sketch
+   * given the specified number of Standard Deviations.
+   * This will return getEstimate() if isEmpty() is true.
+   *
+   * @param numStdDev
+   * <a href="{@docRoot}/resources/dictionary.html#numStdDev">See Number of Standard Deviations</a>
+   * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
+   * @return the lower bound.
    */
-  public static Sketch heapifySketch(final Memory srcMem) {
-    return Sketch.heapify(srcMem);
-  }
-
-  /**
-   * Ref: {@link Sketch#heapify(Memory, long) Sketch.heapify(Memory, long)}
-   * @param srcMem Ref: {@link Sketch#heapify(Memory, long) Sketch.heapify(Memory, long)} {@code srcMem}
-   * @param seed Ref: {@link Sketch#heapify(Memory, long) Sketch.heapify(Memory, long)} {@code seed}
-   * @return {@link Sketch Sketch}
-   */
-  public static Sketch heapifySketch(final Memory srcMem, final long seed) {
-    return Sketch.heapify(srcMem, seed);
-  }
-
-  /**
-   * Ref: {@link UpdateSketch#heapify(Memory) UpdateSketch.heapify(Memory)}
-   * @param srcMem Ref: {@link UpdateSketch#heapify(Memory) UpdateSketch.heapify(Memory)} {@code srcMem}
-   * @return {@link UpdateSketch UpdateSketch}
-   */
-  public static UpdateSketch heapifyUpdateSketch(final Memory srcMem) {
-    return UpdateSketch.heapify(srcMem);
-  }
-
-  /**
-   * Ref: {@link UpdateSketch#heapify(Memory, long) UpdateSketch.heapify(Memory, long)}
-   * @param srcMem Ref: {@link UpdateSketch#heapify(Memory, long) UpdateSketch.heapify(Memory, long)}
-   *   {@code srcMem}
-   * @param seed Ref: {@link UpdateSketch#heapify(Memory, long) UpdateSketch.heapify(Memory, long)}
-   *   {@code seed}
-   * @return {@link UpdateSketch UpdateSketch}
-   */
-  public static UpdateSketch heapifyUpdateSketch(final Memory srcMem, final long seed) {
-    return UpdateSketch.heapify(srcMem, seed);
-  }
-
-  /**
-   * Ref: {@link Sketch#wrap(Memory) Sketch.wrap(Memory)}
-   * @param srcMem Ref: {@link Sketch#wrap(Memory) Sketch.wrap(Memory)} {@code srcMem}
-   * @return {@link Sketch Sketch}
-   */
-  public static Sketch wrapSketch(final Memory srcMem) {
-    return Sketch.wrap(srcMem);
-  }
-
-  /**
-   * Ref: {@link Sketch#wrap(Memory, long) Sketch.wrap(Memory, long)}
-   * @param srcMem Ref: {@link Sketch#wrap(Memory, long) Sketch.wrap(Memory, long)} {@code srcMem}
-   * @param seed Ref: {@link Sketch#wrap(Memory, long) Sketch.wrap(Memory, long)} {@code seed}
-   * @return {@link Sketch Sketch}
-   */
-  public static Sketch wrapSketch(final Memory srcMem, final long seed) {
-    return Sketch.wrap(srcMem, seed);
-  }
-
-  /**
-   * Ref: {@link UpdateSketch#wrap(Memory) UpdateSketch.wrap(Memory)}
-   * @param srcMem Ref: {@link UpdateSketch#wrap(Memory) UpdateSketch.wrap(Memory)} {@code srcMem}
-   * @return {@link UpdateSketch UpdateSketch}
-   */
-  public static UpdateSketch wrapUpdateSketch(final WritableMemory srcMem) {
-    return wrapUpdateSketch(srcMem, DEFAULT_UPDATE_SEED);
-  }
-
-  /**
-   * Ref: {@link UpdateSketch#wrap(Memory, long) UpdateSketch.wrap(Memory, long)}
-   * @param srcMem Ref: {@link UpdateSketch#wrap(Memory, long) UpdateSketch.wrap(Memory, long)} {@code srcMem}
-   * @param seed Ref: {@link UpdateSketch#wrap(Memory, long) UpdateSketch.wrap(Memory, long)} {@code seed}
-   * @return {@link UpdateSketch UpdateSketch}
-   */
-  public static UpdateSketch wrapUpdateSketch(final WritableMemory srcMem, final long seed) {
-    return UpdateSketch.wrap(srcMem, seed);
-  }
-
-  /**
-   * Ref: {@link SetOperationBuilder SetOperationBuilder}
-   * @return {@link SetOperationBuilder SetOperationBuilder}
-   */
-  public static SetOperationBuilder setOperationBuilder() {
-    return new SetOperationBuilder();
-  }
-
-  /**
-   * Ref: {@link SetOperation#heapify(Memory) SetOperation.heapify(Memory)}
-   * @param srcMem Ref: {@link SetOperation#heapify(Memory) SetOperation.heapify(Memory)} {@code srcMem}
-   * @return {@link SetOperation SetOperation}
-   */
-  public static SetOperation heapifySetOperation(final Memory srcMem) {
-    return SetOperation.heapify(srcMem);
-  }
-
-  /**
-   * Ref: {@link SetOperation#heapify(Memory, long) SetOperation.heapify(Memory, long)}
-   * @param srcMem Ref: {@link SetOperation#heapify(Memory, long) SetOperation.heapify(Memory, long)}
-   * {@code srcMem}
-   * @param seed Ref: {@link SetOperation#heapify(Memory, long) SetOperation.heapify(Memory, long)}
-   * {@code seed}
-   * @return {@link SetOperation SetOperation}
-   */
-  public static SetOperation heapifySetOperation(final Memory srcMem, final long seed) {
-    return SetOperation.heapify(srcMem, seed);
-  }
-
-  /**
-   * Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)}
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)} {@code srcMem}
-   * @return {@link SetOperation SetOperation}
-   */
-  public static SetOperation wrapSetOperation(final Memory srcMem) {
-    return wrapSetOperation(srcMem, DEFAULT_UPDATE_SEED);
-  }
-
-  /**
-   * Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)}
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)} {@code srcMem}
-   * @return {@link SetOperation SetOperation}
-   */
-  public static SetOperation wrapSetOperation(final WritableMemory srcMem) {
-    return wrapSetOperation(srcMem, DEFAULT_UPDATE_SEED);
-  }
-
-  /**
-   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Union
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory)} {@code srcMem}
-   * @return a Union backed by the given Memory
-   */
-  public static Union wrapUnion(final Memory srcMem) {
-    return (Union) SetOperation.wrap(srcMem);
-  }
-
-  /**
-   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Union
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory)} {@code srcMem}
-   * @return a Union backed by the given Memory
-   */
-  public static Union wrapUnion(final WritableMemory srcMem) {
-    return (Union) SetOperation.wrap(srcMem);
-  }
-
-  /**
-   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Intersection
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory)} {@code srcMem}
-   * @return a Intersection backed by the given Memory
-   */
-  public static Intersection wrapIntersection(final Memory srcMem) {
-    return (Intersection) SetOperation.wrap(srcMem);
-  }
-
-  /**
-   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Intersection
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory)} {@code srcMem}
-   * @return a Intersection backed by the given Memory
-   */
-  public static Intersection wrapIntersection(final WritableMemory srcMem) {
-    return (Intersection) SetOperation.wrap(srcMem);
-  }
-
-  /**
-   * Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
-   * {@code srcMem}
-   * @param seed Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
-   * {@code seed}
-   * @return {@link SetOperation SetOperation}
-   */
-  public static SetOperation wrapSetOperation(final Memory srcMem, final long seed) {
-    return SetOperation.wrap(srcMem, seed);
-  }
-
-  /**
-   * Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
-   * @param srcMem Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
-   * {@code srcMem}
-   * @param seed Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
-   * {@code seed}
-   * @return {@link SetOperation SetOperation}
-   */
-  public static SetOperation wrapSetOperation(final WritableMemory srcMem, final long seed) {
-    return SetOperation.wrap(srcMem, seed);
-  }
-
-  //Get size methods, etc
-
-  /**
-   * Ref: {@link Sketch#getMaxCompactSketchBytes(int)}
-   * @param numberOfEntries  Ref: {@link Sketch#getMaxCompactSketchBytes(int)}
-   * {@code numberOfEntries}
-   * @return Ref: {@link Sketch#getMaxCompactSketchBytes(int)}
-   */
-  public static int getMaxCompactSketchBytes(final int numberOfEntries) {
-    return Sketch.getMaxCompactSketchBytes(numberOfEntries);
-  }
-
-  /**
-   * Ref: {@link Sketch#getMaxUpdateSketchBytes(int)}
-   * @param nomEntries Ref: {@link Sketch#getMaxUpdateSketchBytes(int)} {@code nomEntries}
-   * @return Ref: {@link Sketch#getMaxUpdateSketchBytes(int)}
-   */
-  public static int getMaxUpdateSketchBytes(final int nomEntries) {
-    return Sketch.getMaxUpdateSketchBytes(nomEntries);
-  }
-
-  /**
-   * Ref: {@link Sketch#getSerializationVersion(Memory)}
-   * @param srcMem Ref: {@link Sketch#getSerializationVersion(Memory)} {@code srcMem}
-   * @return Ref: {@link Sketch#getSerializationVersion(Memory)}
-   */
-  public static int getSerializationVersion(final Memory srcMem) {
-    return Sketch.getSerializationVersion(srcMem);
-  }
-
-  /**
-   * Ref: {@link SetOperation#getMaxUnionBytes(int)}
-   * @param nomEntries Ref: {@link SetOperation#getMaxUnionBytes(int)} {@code nomEntries}
-   * @return Ref: {@link SetOperation#getMaxUnionBytes(int)}
-   */
-  public static int getMaxUnionBytes(final int nomEntries) {
-    return SetOperation.getMaxUnionBytes(nomEntries);
-  }
-
-  /**
-   * Ref: {@link SetOperation#getMaxIntersectionBytes(int)}
-   * @param nomEntries Ref: {@link SetOperation#getMaxIntersectionBytes(int)} {@code nomEntries}
-   * @return Ref: {@link SetOperation#getMaxIntersectionBytes(int)}
-   */
-  public static int getMaxIntersectionBytes(final int nomEntries) {
-    return SetOperation.getMaxIntersectionBytes(nomEntries);
+  public static double getLowerBound(final int numStdDev, final Memory srcMem) {
+    return Sketch.lowerBound(getRetainedEntries(srcMem), getThetaLong(srcMem), numStdDev, getEmpty(srcMem));
   }
 
   /**
@@ -295,17 +78,50 @@ public final class Sketches {
     return SetOperation.getMaxAnotBResultBytes(maxNomEntries);
   }
 
-
-  //Get estimates and bounds from Memory
+  /**
+   * Ref: {@link Sketch#getMaxCompactSketchBytes(int)}
+   * @param numberOfEntries  Ref: {@link Sketch#getMaxCompactSketchBytes(int)},
+   * {@code numberOfEntries}
+   * @return Ref: {@link Sketch#getMaxCompactSketchBytes(int)}
+   */
+  public static int getMaxCompactSketchBytes(final int numberOfEntries) {
+    return Sketch.getMaxCompactSketchBytes(numberOfEntries);
+  }
 
   /**
-   * Gets the unique count estimate from a valid memory image of a Sketch
-   * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
-   * @return the sketch's best estimate of the cardinality of the input stream.
+   * Ref: {@link SetOperation#getMaxIntersectionBytes(int)}
+   * @param nomEntries Ref: {@link SetOperation#getMaxIntersectionBytes(int)}, {@code nomEntries}
+   * @return Ref: {@link SetOperation#getMaxIntersectionBytes(int)}
    */
-  public static double getEstimate(final Memory srcMem) {
-    checkIfValidThetaSketch(srcMem);
-    return Sketch.estimate(getThetaLong(srcMem), getRetainedEntries(srcMem));
+  public static int getMaxIntersectionBytes(final int nomEntries) {
+    return SetOperation.getMaxIntersectionBytes(nomEntries);
+  }
+
+  /**
+   * Ref: {@link SetOperation#getMaxUnionBytes(int)}
+   * @param nomEntries Ref: {@link SetOperation#getMaxUnionBytes(int)}, {@code nomEntries}
+   * @return Ref: {@link SetOperation#getMaxUnionBytes(int)}
+   */
+  public static int getMaxUnionBytes(final int nomEntries) {
+    return SetOperation.getMaxUnionBytes(nomEntries);
+  }
+
+  /**
+   * Ref: {@link Sketch#getMaxUpdateSketchBytes(int)}
+   * @param nomEntries Ref: {@link Sketch#getMaxUpdateSketchBytes(int)}, {@code nomEntries}
+   * @return Ref: {@link Sketch#getMaxUpdateSketchBytes(int)}
+   */
+  public static int getMaxUpdateSketchBytes(final int nomEntries) {
+    return Sketch.getMaxUpdateSketchBytes(nomEntries);
+  }
+
+  /**
+   * Ref: {@link Sketch#getSerializationVersion(Memory)}
+   * @param srcMem Ref: {@link Sketch#getSerializationVersion(Memory)}, {@code srcMem}
+   * @return Ref: {@link Sketch#getSerializationVersion(Memory)}
+   */
+  public static int getSerializationVersion(final Memory srcMem) {
+    return Sketch.getSerializationVersion(srcMem);
   }
 
   /**
@@ -323,21 +139,260 @@ public final class Sketches {
     return Sketch.upperBound(getRetainedEntries(srcMem), getThetaLong(srcMem), numStdDev, getEmpty(srcMem));
   }
 
+  //Heapify Operations
+
   /**
-   * Gets the approximate lower error bound from a valid memory image of a Sketch
-   * given the specified number of Standard Deviations.
-   * This will return getEstimate() if isEmpty() is true.
-   *
-   * @param numStdDev
-   * <a href="{@docRoot}/resources/dictionary.html#numStdDev">See Number of Standard Deviations</a>
-   * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
-   * @return the lower bound.
+   * Ref: {@link CompactSketch#heapify(Memory) CompactSketch.heapify(Memory)}
+   * @param srcMem Ref: {@link CompactSketch#heapify(Memory) CompactSketch.heapify(Memory)}, {@code srcMem}
+   * @return {@link CompactSketch CompactSketch}
    */
-  public static double getLowerBound(final int numStdDev, final Memory srcMem) {
-    return Sketch.lowerBound(getRetainedEntries(srcMem), getThetaLong(srcMem), numStdDev, getEmpty(srcMem));
+  public static CompactSketch heapifyCompactSketch(final Memory srcMem) {
+    return CompactSketch.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link CompactSketch#heapify(Memory, long) CompactSketch.heapify(Memory, long)}
+   * @param srcMem Ref: {@link CompactSketch#heapify(Memory, long) CompactSketch.heapify(Memory, long)}, {@code srcMem}
+   * @param seed Ref: {@link CompactSketch#heapify(Memory, long) CompactSketch.heapify(Memory, long)}, {@code seed}
+   * @return {@link CompactSketch CompactSketch}
+   */
+  public static CompactSketch heapifyCompactSketch(final Memory srcMem, final long seed) {
+    return CompactSketch.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link CompactSketch#wrap(Memory) CompactSketch.wrap(Memory)}
+   * @param srcMem Ref: {@link CompactSketch#wrap(Memory) CompactSketch.wrap(Memory)}, {@code srcMem}
+   * @return {@link CompactSketch CompactSketch}
+   */
+  public static CompactSketch wrapCompactSketch(final Memory srcMem) {
+    return CompactSketch.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link CompactSketch#wrap(Memory, long) CompactSketch.wrap(Memory, long)}
+   * @param srcMem Ref: {@link CompactSketch#wrap(Memory, long) CompactSketch.wrap(Memory, long)}, {@code srcMem}
+   * @param seed Ref: {@link CompactSketch#wrap(Memory, long) CompactSketch.wrap(Memory, long)}, {@code seed}
+   * @return {@link CompactSketch CompactSketch}
+   */
+  public static CompactSketch wrapCompactSketch(final Memory srcMem, final long seed) {
+    return CompactSketch.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link SetOperation#heapify(Memory) SetOperation.heapify(Memory)}
+   * @param srcMem Ref: {@link SetOperation#heapify(Memory) SetOperation.heapify(Memory)}, {@code srcMem}
+   * @return {@link SetOperation SetOperation}
+   */
+  public static SetOperation heapifySetOperation(final Memory srcMem) {
+    return SetOperation.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link SetOperation#heapify(Memory, long) SetOperation.heapify(Memory, long)}
+   * @param srcMem Ref: {@link SetOperation#heapify(Memory, long) SetOperation.heapify(Memory, long)},
+   * {@code srcMem}
+   * @param seed Ref: {@link SetOperation#heapify(Memory, long) SetOperation.heapify(Memory, long)},
+   * {@code seed}
+   * @return {@link SetOperation SetOperation}
+   */
+  public static SetOperation heapifySetOperation(final Memory srcMem, final long seed) {
+    return SetOperation.heapify(srcMem, seed);
+  }
+
+  /**
+   * Ref: {@link Sketch#heapify(Memory) Sketch.heapify(Memory)}
+   * @param srcMem Ref: {@link Sketch#heapify(Memory) Sketch.heapify(Memory)}, {@code srcMem}
+   * @return {@link Sketch Sketch}
+   */
+  public static Sketch heapifySketch(final Memory srcMem) {
+    return Sketch.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link Sketch#heapify(Memory, long) Sketch.heapify(Memory, long)}
+   * @param srcMem Ref: {@link Sketch#heapify(Memory, long) Sketch.heapify(Memory, long)}, {@code srcMem}
+   * @param seed Ref: {@link Sketch#heapify(Memory, long) Sketch.heapify(Memory, long)}, {@code seed}
+   * @return {@link Sketch Sketch}
+   */
+  public static Sketch heapifySketch(final Memory srcMem, final long seed) {
+    return Sketch.heapify(srcMem, seed);
+  }
+
+  /**
+   * Ref: {@link UpdateSketch#heapify(Memory) UpdateSketch.heapify(Memory)}
+   * @param srcMem Ref: {@link UpdateSketch#heapify(Memory) UpdateSketch.heapify(Memory)}, {@code srcMem}
+   * @return {@link UpdateSketch UpdateSketch}
+   */
+  public static UpdateSketch heapifyUpdateSketch(final Memory srcMem) {
+    return UpdateSketch.heapify(srcMem);
+  }
+
+  /**
+   * Ref: {@link UpdateSketch#heapify(Memory, long) UpdateSketch.heapify(Memory, long)}
+   * @param srcMem Ref: {@link UpdateSketch#heapify(Memory, long) UpdateSketch.heapify(Memory, long)},
+   *   {@code srcMem}
+   * @param seed Ref: {@link UpdateSketch#heapify(Memory, long) UpdateSketch.heapify(Memory, long)},
+   *   {@code seed}
+   * @return {@link UpdateSketch UpdateSketch}
+   */
+  public static UpdateSketch heapifyUpdateSketch(final Memory srcMem, final long seed) {
+    return UpdateSketch.heapify(srcMem, seed);
+  }
+
+  //Builders
+
+  /**
+   * Ref: {@link SetOperationBuilder SetOperationBuilder}
+   * @return {@link SetOperationBuilder SetOperationBuilder}
+   */
+  public static SetOperationBuilder setOperationBuilder() {
+    return new SetOperationBuilder();
+  }
+
+  /**
+   * Ref: {@link UpdateSketchBuilder UpdateSketchBuilder}
+   * @return {@link UpdateSketchBuilder UpdateSketchBuilder}
+   */
+  public static UpdateSketchBuilder updateSketchBuilder() {
+    return new UpdateSketchBuilder();
+  }
+
+  //Wrap operations
+
+  /**
+   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Intersection
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory)}, {@code srcMem}
+   * @return a Intersection backed by the given Memory
+   */
+  public static Intersection wrapIntersection(final Memory srcMem) {
+    return (Intersection) SetOperation.wrap(srcMem);
+  }
+
+  /**
+   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Intersection
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory)}, {@code srcMem}
+   * @return a Intersection backed by the given Memory
+   */
+  public static Intersection wrapIntersection(final WritableMemory srcMem) {
+    return (Intersection) SetOperation.wrap(srcMem);
+  }
+
+  /**
+   * Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)}
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)}, {@code srcMem}
+   * @return {@link SetOperation SetOperation}
+   */
+  public static SetOperation wrapSetOperation(final Memory srcMem) {
+    return wrapSetOperation(srcMem, DEFAULT_UPDATE_SEED);
+  }
+
+  /**
+   * Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)},
+   * {@code srcMem}
+   * @param seed Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)},
+   * {@code seed}
+   * @return {@link SetOperation SetOperation}
+   */
+  public static SetOperation wrapSetOperation(final Memory srcMem, final long seed) {
+    return SetOperation.wrap(srcMem, seed);
+  }
+
+  /**
+   * Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)}
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory) SetOperation.wrap(Memory)}, {@code srcMem}
+   * @return {@link SetOperation SetOperation}
+   */
+  public static SetOperation wrapSetOperation(final WritableMemory srcMem) {
+    return wrapSetOperation(srcMem, DEFAULT_UPDATE_SEED);
+  }
+
+  /**
+   * Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)},
+   * {@code srcMem}
+   * @param seed Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)},
+   * {@code seed}
+   * @return {@link SetOperation SetOperation}
+   */
+  public static SetOperation wrapSetOperation(final WritableMemory srcMem, final long seed) {
+    return SetOperation.wrap(srcMem, seed);
+  }
+
+  /**
+   * Ref: {@link Sketch#wrap(Memory) Sketch.wrap(Memory)}
+   * @param srcMem Ref: {@link Sketch#wrap(Memory) Sketch.wrap(Memory)}, {@code srcMem}
+   * @return {@link Sketch Sketch}
+   */
+  public static Sketch wrapSketch(final Memory srcMem) {
+    return Sketch.wrap(srcMem);
+  }
+
+  /**
+   * Ref: {@link Sketch#wrap(Memory, long) Sketch.wrap(Memory, long)}
+   * @param srcMem Ref: {@link Sketch#wrap(Memory, long) Sketch.wrap(Memory, long)}, {@code srcMem}
+   * @param seed Ref: {@link Sketch#wrap(Memory, long) Sketch.wrap(Memory, long)}, {@code seed}
+   * @return {@link Sketch Sketch}
+   */
+  public static Sketch wrapSketch(final Memory srcMem, final long seed) {
+    return Sketch.wrap(srcMem, seed);
+  }
+
+  /**
+   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Union
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory)}, {@code srcMem}
+   * @return a Union backed by the given Memory
+   */
+  public static Union wrapUnion(final Memory srcMem) {
+    return (Union) SetOperation.wrap(srcMem);
+  }
+
+  /**
+   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Union
+   * @param srcMem Ref: {@link SetOperation#wrap(Memory)}, {@code srcMem}
+   * @return a Union backed by the given Memory
+   */
+  public static Union wrapUnion(final WritableMemory srcMem) {
+    return (Union) SetOperation.wrap(srcMem);
+  }
+
+  /**
+   * Ref: {@link UpdateSketch#wrap(Memory) UpdateSketch.wrap(Memory)}
+   * @param srcMem Ref: {@link UpdateSketch#wrap(Memory) UpdateSketch.wrap(Memory)}, {@code srcMem}
+   * @return {@link UpdateSketch UpdateSketch}
+   */
+  public static UpdateSketch wrapUpdateSketch(final WritableMemory srcMem) {
+    return wrapUpdateSketch(srcMem, DEFAULT_UPDATE_SEED);
+  }
+
+  /**
+   * Ref: {@link UpdateSketch#wrap(Memory, long) UpdateSketch.wrap(Memory, long)}
+   * @param srcMem Ref: {@link UpdateSketch#wrap(Memory, long) UpdateSketch.wrap(Memory, long)}, {@code srcMem}
+   * @param seed Ref: {@link UpdateSketch#wrap(Memory, long) UpdateSketch.wrap(Memory, long)}, {@code seed}
+   * @return {@link UpdateSketch UpdateSketch}
+   */
+  public static UpdateSketch wrapUpdateSketch(final WritableMemory srcMem, final long seed) {
+    return UpdateSketch.wrap(srcMem, seed);
   }
 
   //Restricted static methods
+
+  static void checkIfValidThetaSketch(final Memory srcMem) {
+    final int fam = srcMem.getByte(FAMILY_BYTE);
+    if (!Sketch.isValidSketchID(fam)) {
+     throw new SketchesArgumentException("Source Memory not a valid Sketch. Family: "
+         + Family.idToFamily(fam).toString());
+    }
+  }
+
+  static boolean getEmpty(final Memory srcMem) {
+    final int serVer = srcMem.getByte(SER_VER_BYTE);
+    if (serVer == 1) {
+      return ((getThetaLong(srcMem) == Long.MAX_VALUE) && (getRetainedEntries(srcMem) == 0));
+    }
+    return (srcMem.getByte(FLAGS_BYTE) & EMPTY_FLAG_MASK) != 0; //for SerVer 2 & 3
+  }
 
   static int getPreambleLongs(final Memory srcMem) {
     return srcMem.getByte(PREAMBLE_LONGS_BYTE) & 0X3F; //for SerVer 1,2,3
@@ -365,21 +420,5 @@ public final class Sketches {
   static long getThetaLong(final Memory srcMem) {
     final int preLongs = getPreambleLongs(srcMem);
     return (preLongs < 3) ? Long.MAX_VALUE : srcMem.getLong(THETA_LONG); //for SerVer 1,2,3
-  }
-
-  static boolean getEmpty(final Memory srcMem) {
-    final int serVer = srcMem.getByte(SER_VER_BYTE);
-    if (serVer == 1) {
-      return ((getThetaLong(srcMem) == Long.MAX_VALUE) && (getRetainedEntries(srcMem) == 0));
-    }
-    return (srcMem.getByte(FLAGS_BYTE) & EMPTY_FLAG_MASK) != 0; //for SerVer 2 & 3
-  }
-
-  static void checkIfValidThetaSketch(final Memory srcMem) {
-    final int fam = srcMem.getByte(FAMILY_BYTE);
-    if (!Sketch.isValidSketchID(fam)) {
-     throw new SketchesArgumentException("Source Memory not a valid Sketch. Family: "
-         + Family.idToFamily(fam).toString());
-    }
   }
 }

--- a/src/main/java/org/apache/datasketches/theta/UnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/UnionImpl.java
@@ -21,7 +21,6 @@ package org.apache.datasketches.theta;
 
 import static java.lang.Math.min;
 import static org.apache.datasketches.QuickSelect.selectExcludingZeros;
-import static org.apache.datasketches.Util.DEFAULT_UPDATE_SEED;
 import static org.apache.datasketches.Util.computeSeedHash;
 import static org.apache.datasketches.theta.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.ORDERED_FLAG_MASK;
@@ -361,13 +360,13 @@ final class UnionImpl extends Union {
 
     if (serVer == 2) { //older Sketch, which is compact and ordered
       Util.checkSeedHashes(seedHash_, (short)extractSeedHash(skMem));
-      final CompactSketch csk = ForwardCompatibility.heapify2to3(skMem, DEFAULT_UPDATE_SEED);
+      final CompactSketch csk = ForwardCompatibility.heapify2to3(skMem,seedHash_);
       union(csk);
       return;
     }
 
-    if (serVer == 1) { //much older Sketch, which is compact and ordered
-      final CompactSketch csk = ForwardCompatibility.heapify1to3(skMem, DEFAULT_UPDATE_SEED);
+    if (serVer == 1) { //much older Sketch, which is compact and ordered, no seedHash
+      final CompactSketch csk = ForwardCompatibility.heapify1to3(skMem, seedHash_);
       union(csk);
       return;
     }

--- a/src/main/java/org/apache/datasketches/tuple/CompactSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/CompactSketch.java
@@ -197,9 +197,8 @@ public class CompactSketch<S extends Summary> extends Sketch<S> {
     final int preambleLongs = isEmpty() || isSingleItem ? 1 : isEstimationMode() ? 3 : 2;
 
     int summariesSizeBytes = 0;
-    byte[][] summariesBytes = null;
+    final byte[][] summariesBytes = new byte[count][];
     if (count > 0) {
-      summariesBytes = new byte[count][];
       for (int i = 0; i < count; i++) {
         summariesBytes[i] = summaryArr_[i].toByteArray();
         summariesSizeBytes += summariesBytes[i].length;


### PR DESCRIPTION
Added 4 methods to Sketches class:

heapifyCompactSketch(Memory)
heapifyCompactSketch(Memory, long)
wrapCompactSketch(Memory)
wrapCompactSketch(Memory, long)

Changed the behavior of heapifySketch(2) and wrapSketch(2) calls
so that if the given image is a CompactSketch the behavior will
be the same as above.

The basic behavior change is that a seed is no longer required to
heapify or wrap a CompactSketch image.
But if it is given, it will be used to check the
hashSeed of the image, if there is one.

This push represents the main code changes.
More test code needs to be added.