### PR TITLE
Fixes problems found when running latest version of SpotBugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,23 @@ See the pom.xml file for test dependencies.
 
 Building and running tests using JDK 8 should not be a problem. 
 
-However, with JDK 9+, and Eclipse version up to and including 4.22.0 (2021-12), Eclipse fails to translate the required JPMS JVM arguments specified in the POM into the *.classpath* file, causing illegal reflection access errors.
+However, with JDK 9+, and Eclipse versions up to and including 4.22.0 (2021-12), Eclipse fails to translate the required JPMS JVM arguments specified in the POM compiler or surefire plugins into the *.classpath* file, causing illegal reflection access errors 
+[eclipse-m2e/m2e-core Bug 543631](https://github.com/eclipse-m2e/m2e-core/issues/129).
 
 There are two ways to fix this:
 
-#### Manually update *.classpath* file:
-Open the *.classpath* file in a text editor and insert the following *classpathentry* element (this assumes JDK11, change to suit) then *refresh*.:
+#### Method 1: Manually update *.classpath* file:
+Open the *.classpath* file in a text editor and find the following *classpathentry* element (this assumes JDK11, change to suit):
+
+```
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+```
+Then edit it as follows:
 
 ```
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
@@ -109,8 +120,9 @@ Open the *.classpath* file in a text editor and insert the following *classpathe
 		</attributes>
 	</classpathentry>
 ```
+Finally, *refresh*.
 
-#### Manually update *Module Dependencies*
+#### Method 2: Manually update *Module Dependencies*
 
 In Eclipse, open the project *Properties / Java Build Path / Module Dependencies ...*
 

--- a/src/main/java/org/apache/datasketches/Util.java
+++ b/src/main/java/org/apache/datasketches/Util.java
@@ -33,6 +33,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 /**
  * Common utility functions.
@@ -846,13 +847,15 @@ public final class Util {
    * @return the absolute path of the given resource file's shortName.
    */
   public static String getResourcePath(final String shortFileName) {
+    Objects.requireNonNull(shortFileName, "input parameter " + shortFileName + " cannot be null.");
     try {
       final URL url = Util.class.getClassLoader().getResource(shortFileName);
+      Objects.requireNonNull(url, "resource " + shortFileName + " could not be acquired.");
       final URI uri = url.toURI();
       //decodes any special characters
       final String path = uri.isAbsolute() ? Paths.get(uri).toAbsolutePath().toString() : uri.getPath();
       return path;
-    } catch (final NullPointerException | URISyntaxException e) {
+    } catch (final URISyntaxException e) {
       throw new SketchesArgumentException("Cannot find resource: " + shortFileName + LS + e);
     }
   }

--- a/src/main/java/org/apache/datasketches/fdt/FdtSketch.java
+++ b/src/main/java/org/apache/datasketches/fdt/FdtSketch.java
@@ -83,6 +83,23 @@ public class FdtSketch extends ArrayOfStringsSketch {
   }
 
   /**
+   * Copy Constructor
+   * @param sketch the sketch to copy
+   */
+  public FdtSketch(final FdtSketch sketch) {
+    super(sketch);
+  }
+
+  /**
+   * @return a deep copy of this sketch
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public FdtSketch copy() {
+    return new FdtSketch(this);
+  }
+
+  /**
    * Update the sketch with the given string array tuple.
    * @param tuple the given string array tuple.
    */

--- a/src/main/java/org/apache/datasketches/fdt/PostProcessor.java
+++ b/src/main/java/org/apache/datasketches/fdt/PostProcessor.java
@@ -58,7 +58,7 @@ public class PostProcessor {
    * @param sep the separator character
    */
   public PostProcessor(final FdtSketch sketch, final Group group, final char sep) {
-    this.sketch = sketch;
+    this.sketch = sketch.copy();
     this.sep = sep;
     final int numEntries = sketch.getRetainedEntries();
     mapArrSize = ceilingPowerOf2((int)(numEntries / 0.75));

--- a/src/main/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketch.java
@@ -253,7 +253,7 @@ final class DirectUpdateDoublesSketch extends DirectUpdateDoublesSketchR {
     memReqSvr = (memReqSvr == null) ? mem_.getMemoryRequestServer() : memReqSvr;
     if (memReqSvr == null) {
       throw new SketchesArgumentException(
-          "A reequest for more memory has been denied, "
+          "A request for more memory has been denied, "
           + "or a default MemoryRequestServer has not been provided. Must abort. ");
     }
 

--- a/src/main/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketch.java
@@ -42,6 +42,7 @@ import static org.apache.datasketches.quantiles.PreambleUtil.insertSerVer;
 import static org.apache.datasketches.quantiles.Util.computeBitPattern;
 
 import org.apache.datasketches.Family;
+import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 
@@ -250,6 +251,11 @@ final class DirectUpdateDoublesSketch extends DirectUpdateDoublesSketchR {
     assert needBytes > memBytes;
 
     memReqSvr = (memReqSvr == null) ? mem_.getMemoryRequestServer() : memReqSvr;
+    if (memReqSvr == null) {
+      throw new SketchesArgumentException(
+          "A reequest for more memory has been denied, "
+          + "or a default MemoryRequestServer has not been provided. Must abort. ");
+    }
 
     final WritableMemory newMem = memReqSvr.request(mem_, needBytes);
 

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
@@ -785,10 +785,6 @@ public final class VarOptItemsSketch<T> {
     return weights_.get(idx);
   }
 
-  boolean isMarksValid() {
-    return marks_ != null;
-  }
-
   // package-private: Relies on ArrayList for bounds checking and assumes caller knows how to
   // handle a null from the middle of the list.
   boolean getMark(final int idx) { return marks_.get(idx); }

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
@@ -785,6 +785,10 @@ public final class VarOptItemsSketch<T> {
     return weights_.get(idx);
   }
 
+  boolean isMarksValid() {
+    return marks_ != null;
+  }
+
   // package-private: Relies on ArrayList for bounds checking and assumes caller knows how to
   // handle a null from the middle of the list.
   boolean getMark(final int idx) { return marks_.get(idx); }

--- a/src/main/java/org/apache/datasketches/theta/AnotBimpl.java
+++ b/src/main/java/org/apache/datasketches/theta/AnotBimpl.java
@@ -78,7 +78,6 @@ final class AnotBimpl extends AnotB {
 
     //process A
     hashArr_ = getHashArrA(skA);
-    hashArr_ = (hashArr_ == null) ? new long[0] : hashArr_;
     empty_ = false;
     thetaLong_ = skA.getThetaLong();
     curCount_ = hashArr_.length;
@@ -94,7 +93,6 @@ final class AnotBimpl extends AnotB {
 
     //process B
     hashArr_ = getResultHashArr(thetaLong_, curCount_, hashArr_, skB);
-    hashArr_ = (hashArr_ == null) ? new long[0] : hashArr_;
     curCount_ = hashArr_.length;
     empty_ = curCount_ == 0 && thetaLong_ == Long.MAX_VALUE;
   }
@@ -135,7 +133,7 @@ final class AnotBimpl extends AnotB {
 
     //process A
     final long[] hashArrA = getHashArrA(skA);
-    final int countA = (hashArrA == null) ? 0 : hashArrA.length;
+    final int countA = hashArrA.length;
 
 
     //process B

--- a/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
@@ -135,6 +135,24 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   }
 
   /**
+   * Copy constructor
+   * @param sketch the QuickSelectSketch to be copied.
+   */
+  QuickSelectSketch(final QuickSelectSketch<S> sketch) {
+    nomEntries_ = sketch.nomEntries_;
+    lgCurrentCapacity_ = sketch.lgCurrentCapacity_;
+    lgResizeFactor_ = sketch.lgResizeFactor_;
+    count_ = sketch.count_;
+    samplingProbability_ = sketch.samplingProbability_;
+    rebuildThreshold_ = sketch.rebuildThreshold_;
+    thetaLong_ = sketch.thetaLong_;
+    empty_ = sketch.empty_;
+    summaryFactory_ = sketch.summaryFactory_;
+    hashTable_ = sketch.hashTable_.clone();
+    summaryTable_ = Util.copySummaryArray(sketch.summaryTable_);
+  }
+
+  /**
    * This is to create an instance of a QuickSelectSketch given a serialized form
    * @param mem Memory object with serialized QukckSelectSketch
    * @param deserializer the SummaryDeserializer
@@ -203,6 +221,13 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
     }
     empty_ = (flags & 1 << Flags.IS_EMPTY.ordinal()) > 0;
     setRebuildThreshold();
+  }
+
+  /**
+   * @return a deep copy of this sketch
+   */
+  QuickSelectSketch<S> copy() {
+    return new QuickSelectSketch<S>(this);
   }
 
   long[] getHashTable() {

--- a/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
@@ -76,6 +76,23 @@ public class UpdatableSketch<U, S extends UpdatableSummary<U>> extends QuickSele
   }
 
   /**
+   * Copy Constructor
+   * @param sketch the sketch to copy
+   */
+  public UpdatableSketch(final UpdatableSketch<U, S> sketch) {
+    super(sketch);
+  }
+
+  /**
+   * @return a deep copy of this sketch
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public UpdatableSketch<U,S> copy() {
+    return new UpdatableSketch<U,S>(this);
+  }
+
+  /**
    * Updates this sketch with a long key and U value.
    * The value is passed to update() method of the Summary object associated with the key
    *

--- a/src/main/java/org/apache/datasketches/tuple/Util.java
+++ b/src/main/java/org/apache/datasketches/tuple/Util.java
@@ -137,12 +137,20 @@ public final class Util {
     return hashCharArr(s.toCharArray(), 0, s.length(), PRIME);
   }
 
+  /**
+   * Will copy compact summary arrays as well as hashed summary tables (with nulls).
+   * @param <S> type of summary
+   * @param summaryArr the given summary array or table
+   * @return the copy
+   */
   @SuppressWarnings("unchecked")
   public static <S extends Summary> S[] copySummaryArray(final S[] summaryArr) {
     final int len = summaryArr.length;
     final S[] tmpSummaryArr = newSummaryArray(summaryArr, len);
     for (int i = 0; i < len; i++) {
-      tmpSummaryArr[i] = (S) summaryArr[i].copy();
+      final S summary = summaryArr[i];
+      if (summary == null) { continue; }
+      tmpSummaryArr[i] = (S) summary.copy();
     }
     return tmpSummaryArr;
   }

--- a/src/main/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketch.java
@@ -74,6 +74,23 @@ public class ArrayOfStringsSketch extends UpdatableSketch<String[], ArrayOfStrin
   }
 
   /**
+   * Copy Constructor
+   * @param sketch the sketch to copy
+   */
+  public ArrayOfStringsSketch(final ArrayOfStringsSketch sketch) {
+    super(sketch);
+  }
+
+  /**
+   * @return a deep copy of this sketch
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public ArrayOfStringsSketch copy() {
+    return new ArrayOfStringsSketch(this);
+  }
+
+  /**
    * Updates the sketch with String arrays for both key and value.
    * @param strArrKey the given String array key
    * @param strArr the given String array value

--- a/src/test/java/org/apache/datasketches/UtilTest.java
+++ b/src/test/java/org/apache/datasketches/UtilTest.java
@@ -89,7 +89,7 @@ public class UtilTest {
   public void checkBoundsTest() {
     Util.checkBounds(999, 2, 1000);
   }
-  
+
   @Test
   public void checkIsPowerOf2() {
     Assert.assertEquals(isPowerOf2(0), false);
@@ -396,7 +396,7 @@ public class UtilTest {
     assertTrue(file.exists());
   }
 
-  @Test(expectedExceptions = SketchesArgumentException.class)
+  @Test(expectedExceptions = NullPointerException.class)
   public void resourceFileNotFound() {
     final String shortFileName = "cpc-empty.sk";
     getResourceFile(shortFileName + "123");
@@ -409,7 +409,7 @@ public class UtilTest {
     assertTrue(bytes.length == 8);
   }
 
-  @Test(expectedExceptions = SketchesArgumentException.class)
+  @Test(expectedExceptions = NullPointerException.class)
   public void resourceBytesFileNotFound() {
     final String shortFileName = "cpc-empty.sk";
     getResourceBytes(shortFileName + "123");

--- a/src/test/java/org/apache/datasketches/fdt/FdtSketchTest.java
+++ b/src/test/java/org/apache/datasketches/fdt/FdtSketchTest.java
@@ -151,6 +151,17 @@ public class FdtSketchTest {
     }
   }
 
+  @Test
+  public void checkCopyCtor() {
+    final int lgK = 14;
+    final FdtSketch sk = new FdtSketch(lgK);
+
+    final String[] nodesArr = {"abc", "def" };
+    sk.update(nodesArr);
+    assertEquals(sk.getRetainedEntries(), 1);
+    final FdtSketch sk2 = sk.copy();
+    assertEquals(sk2.getRetainedEntries(), 1);
+  }
 
   @Test
   public void printlnTest() {

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -152,15 +152,17 @@ public class DoublesSketchTest {
 
   @Test
   public void directSketchShouldMoveOntoHeapEventually2() {
-    try (WritableHandle wdh = WritableMemory.allocateDirect(50)) {
+    int i = 0;
+    try (WritableHandle wdh =
+        WritableMemory.allocateDirect(50, ByteOrder.LITTLE_ENDIAN, new DefaultMemoryRequestServer())) {
       WritableMemory mem = wdh.getWritable();
       UpdateDoublesSketch sketch = DoublesSketch.builder().build(mem);
       Assert.assertTrue(sketch.isSameResource(mem));
-      for (int i = 0; i < 1000; i++) {
-        try {
+      for (; i < 1000; i++) {
+        if (sketch.isSameResource(mem)) {
           sketch.update(i);
-          if (sketch.isSameResource(mem)) { continue; }
-        } catch (NullPointerException e) {
+        } else {
+          System.out.println("MOVED at i = " + i);
           break;
         }
       }

--- a/src/test/java/org/apache/datasketches/sampling/VarOptItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptItemsSketchTest.java
@@ -23,7 +23,6 @@ import static org.apache.datasketches.sampling.PreambleUtil.FAMILY_BYTE;
 import static org.apache.datasketches.sampling.PreambleUtil.PREAMBLE_LONGS_BYTE;
 import static org.apache.datasketches.sampling.PreambleUtil.SER_VER_BYTE;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -519,7 +518,6 @@ public class VarOptItemsSketchTest {
     assertEquals(sketch.getN(), 2 * k);
     assertEquals(sketch.getHRegionCount(), 0);
     assertEquals(sketch.getRRegionCount(), k);
-    assertFalse(sketch.isMarksValid());
     sketch.reset();
     assertEquals(sketch.getN(), 0);
     assertEquals(sketch.getHRegionCount(), 0);

--- a/src/test/java/org/apache/datasketches/sampling/VarOptItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptItemsSketchTest.java
@@ -23,6 +23,7 @@ import static org.apache.datasketches.sampling.PreambleUtil.FAMILY_BYTE;
 import static org.apache.datasketches.sampling.PreambleUtil.PREAMBLE_LONGS_BYTE;
 import static org.apache.datasketches.sampling.PreambleUtil.SER_VER_BYTE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -515,17 +516,10 @@ public class VarOptItemsSketchTest {
     for (int i = 0; i < (2 * k); ++i) {
       sketch.update("a", 100.0 + i);
     }
-
     assertEquals(sketch.getN(), 2 * k);
     assertEquals(sketch.getHRegionCount(), 0);
     assertEquals(sketch.getRRegionCount(), k);
-    try {
-      sketch.getMark(0);
-      fail();
-    } catch (final NullPointerException e) {
-      // expected
-    }
-
+    assertFalse(sketch.isMarksValid());
     sketch.reset();
     assertEquals(sketch.getN(), 0);
     assertEquals(sketch.getHRegionCount(), 0);

--- a/src/test/java/org/apache/datasketches/theta/CornerCaseThetaSetOperationsTest.java
+++ b/src/test/java/org/apache/datasketches/theta/CornerCaseThetaSetOperationsTest.java
@@ -115,7 +115,7 @@ public class CornerCaseThetaSetOperationsTest {
   }
 
   @Test
-  public void EmptyEstimation() {
+  public void emptyEstimation() {
     UpdateSketch thetaA = getSketch(SkType.EMPTY, 0, 0);
     UpdateSketch thetaB = getSketch(SkType.ESTIMATION, LOWP, LT_LOWP_V);
     final double expectedIntersectTheta = 1.0;
@@ -301,7 +301,7 @@ public class CornerCaseThetaSetOperationsTest {
   //=================================
 
   @Test
-  public void DegenerateEmpty() {
+  public void degenerateEmpty() {
     UpdateSketch thetaA = getSketch(SkType.DEGENERATE, LOWP, GT_LOWP_V); //entries = 0
     UpdateSketch thetaB = getSketch(SkType.EMPTY, 0, 0);
     final double expectedIntersectTheta = 1.0;
@@ -321,7 +321,7 @@ public class CornerCaseThetaSetOperationsTest {
   }
 
   @Test
-  public void DegenerateExact() {
+  public void degenerateExact() {
     UpdateSketch thetaA = getSketch(SkType.DEGENERATE,  LOWP, GT_LOWP_V); //entries = 0
     UpdateSketch thetaB = getSketch(SkType.EXACT, 0, LT_LOWP_V);
     final double expectedIntersectTheta = LOWP_THETA;
@@ -341,7 +341,7 @@ public class CornerCaseThetaSetOperationsTest {
   }
 
   @Test
-  public void DegenerateDegenerate() {
+  public void degenerateDegenerate() {
     UpdateSketch thetaA = getSketch(SkType.DEGENERATE, MIDP, GT_MIDP_V); //entries = 0
     UpdateSketch thetaB = getSketch(SkType.DEGENERATE, LOWP, GT_LOWP_V);
     final double expectedIntersectTheta = LOWP_THETA;
@@ -361,7 +361,7 @@ public class CornerCaseThetaSetOperationsTest {
   }
 
   @Test
-  public void DegenerateEstimation() {
+  public void degenerateEstimation() {
     UpdateSketch thetaA = getSketch(SkType.DEGENERATE, MIDP, GT_MIDP_V); //entries = 0
     UpdateSketch thetaB = getSketch(SkType.ESTIMATION, LOWP, LT_LOWP_V);
     final double expectedIntersectTheta = LOWP_THETA;

--- a/src/test/java/org/apache/datasketches/theta/HeapifyWrapSerVer1and2Test.java
+++ b/src/test/java/org/apache/datasketches/theta/HeapifyWrapSerVer1and2Test.java
@@ -378,7 +378,7 @@ public class HeapifyWrapSerVer1and2Test {
     assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
     assertEquals(sv3cskResult.getSeedHash(), seedHash);
     assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    try { wh.close(); } catch (Exception e) {/* ignore */}
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/MiscTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/MiscTest.java
@@ -19,13 +19,13 @@
 
 package org.apache.datasketches.tuple;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import org.apache.datasketches.SetOperationCornerCases.CornerCase;
 import org.apache.datasketches.tuple.adouble.DoubleSummary;
 import org.apache.datasketches.tuple.adouble.DoubleSummary.Mode;
 import org.apache.datasketches.tuple.adouble.DoubleSummaryFactory;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -52,7 +52,7 @@ public class MiscTest {
   @Test
   public void checkDoubleToLongArray() {
     final long[] v = Util.doubleToLongArray(-0.0);
-    Assert.assertEquals(v[0], 0);
+    assertEquals(v[0], 0);
   }
 
   //@Test
@@ -71,6 +71,20 @@ public class MiscTest {
     }
   }
 
+  @Test
+  public void checkCopyCtor() {
+    final DoubleSummary.Mode mode = Mode.Sum;
+    final UpdatableSketchBuilder<Double, DoubleSummary> bldr =
+        new UpdatableSketchBuilder<>(new DoubleSummaryFactory(mode));
+    bldr.reset();
+    final UpdatableSketch<Double,DoubleSummary> sk = bldr.build();
+    sk.update(1.0, 1.0);
+    assertEquals(sk.getRetainedEntries(), 1);
+    final  UpdatableSketch<Double,DoubleSummary> sk2 = sk.copy();
+    assertEquals(sk2.getRetainedEntries(), 1);
+  }
+
+
   /**
    *
    * @param o object to print
@@ -78,8 +92,5 @@ public class MiscTest {
   private static void println(final Object o) {
     //System.out.println(o.toString()); //disable here
   }
-
-
-
 
 }

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/CornerCaseArrayOfDoublesSetOperationsTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/CornerCaseArrayOfDoublesSetOperationsTest.java
@@ -58,6 +58,8 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   private static final long LOWP_THETALONG = (long)(MAX_LONG * LOWP_FLT);
   private static final long HASH_LT_LOWP = getLongHash(LT_LOWP_KEY);
 
+  private static final String LS = System.getProperty("line.separator");
+
   private enum SkType {
     EMPTY,      // { 1.0,  0, T} Bin: 101  Oct: 05
     EXACT,      // { 1.0, >0, F} Bin: 110  Oct: 06, specify only value
@@ -139,7 +141,7 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   }
 
   @Test
-  public void EmptyEstimation() {
+  public void emptyEstimation() {
     ArrayOfDoublesUpdatableSketch thetaA = getSketch(SkType.EMPTY, 0, 0);
     ArrayOfDoublesUpdatableSketch thetaB = getSketch(SkType.ESTIMATION, LOWP_FLT, LT_LOWP_KEY);
     final double expectedIntersectTheta = 1.0;
@@ -325,7 +327,7 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   //=================================
 
   @Test
-  public void DegenerateEmpty() {
+  public void degenerateEmpty() {
     ArrayOfDoublesUpdatableSketch thetaA = getSketch(SkType.DEGENERATE, LOWP_FLT, GT_LOWP_KEY); //entries = 0
     ArrayOfDoublesUpdatableSketch thetaB = getSketch(SkType.EMPTY, 0, 0);
     final double expectedIntersectTheta = 1.0;
@@ -345,7 +347,7 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   }
 
   @Test
-  public void DegenerateExact() {
+  public void degenerateExact() {
     ArrayOfDoublesUpdatableSketch thetaA = getSketch(SkType.DEGENERATE,  LOWP_FLT, GT_LOWP_KEY); //entries = 0
     ArrayOfDoublesUpdatableSketch thetaB = getSketch(SkType.EXACT, 0, LT_LOWP_KEY);
     final double expectedIntersectTheta = LOWP_FLT;
@@ -365,7 +367,7 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   }
 
   @Test
-  public void DegenerateDegenerate() {
+  public void degenerateDegenerate() {
     ArrayOfDoublesUpdatableSketch thetaA = getSketch(SkType.DEGENERATE, MIDP_FLT, GT_MIDP_KEY); //entries = 0
     ArrayOfDoublesUpdatableSketch thetaB = getSketch(SkType.DEGENERATE, LOWP_FLT, GT_LOWP_KEY);
     final double expectedIntersectTheta = LOWP_FLT;
@@ -385,7 +387,7 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   }
 
   @Test
-  public void DegenerateEstimation() {
+  public void degenerateEstimation() {
     ArrayOfDoublesUpdatableSketch thetaA = getSketch(SkType.DEGENERATE, MIDP_FLT, GT_MIDP_KEY); //entries = 0
     ArrayOfDoublesUpdatableSketch thetaB = getSketch(SkType.ESTIMATION, LOWP_FLT, LT_LOWP_KEY);
     final double expectedIntersectTheta = LOWP_FLT;
@@ -540,15 +542,15 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   //@Test
   public void printTable() {
     println("              Top8bits  Hex               Decimal");
-    printf("MAX:           %8s, %16x, %19d\n", getTop8(MAX_LONG), MAX_LONG, MAX_LONG);
-    printf("GT_MIDP:       %8s, %16x, %19d\n", getTop8(HASH_GT_MIDP), HASH_GT_MIDP, HASH_GT_MIDP);
-    printf("MIDP_THETALONG:%8s, %16x, %19d\n", getTop8(MIDP_THETALONG), MIDP_THETALONG, MIDP_THETALONG);
-    printf("GT_LOWP:       %8s, %16x, %19d\n", getTop8(HASH_GT_LOWP), HASH_GT_LOWP, HASH_GT_LOWP);
-    printf("LOWP_THETALONG:%8s, %16x, %19d\n", getTop8(LOWP_THETALONG), LOWP_THETALONG, LOWP_THETALONG);
-    printf("LT_LOWP:       %8s, %16x, %19d\n", getTop8(HASH_LT_LOWP), HASH_LT_LOWP, HASH_LT_LOWP);
-    println("\nDoubles");
+    printf("MAX:           %8s, %16x, %19d" + LS, getTop8(MAX_LONG), MAX_LONG, MAX_LONG);
+    printf("GT_MIDP:       %8s, %16x, %19d" + LS, getTop8(HASH_GT_MIDP), HASH_GT_MIDP, HASH_GT_MIDP);
+    printf("MIDP_THETALONG:%8s, %16x, %19d" + LS, getTop8(MIDP_THETALONG), MIDP_THETALONG, MIDP_THETALONG);
+    printf("GT_LOWP:       %8s, %16x, %19d" + LS, getTop8(HASH_GT_LOWP), HASH_GT_LOWP, HASH_GT_LOWP);
+    printf("LOWP_THETALONG:%8s, %16x, %19d" + LS, getTop8(LOWP_THETALONG), LOWP_THETALONG, LOWP_THETALONG);
+    printf("LT_LOWP:       %8s, %16x, %19d" + LS, getTop8(HASH_LT_LOWP), HASH_LT_LOWP, HASH_LT_LOWP);
+    println(LS +"Doubles");
 
-    println("\nLongs");
+    println(LS + "Longs");
     for (long v = 1L; v < 10; v++) {
       long hash = (hash(v, DEFAULT_UPDATE_SEED)[0]) >>> 1;
       printLong(v, hash);
@@ -560,7 +562,7 @@ public class CornerCaseArrayOfDoublesSetOperationsTest {
   }
 
   static void printLong(long v, long hash) {
-    System.out.printf("     %8d, %8s, %16x, %19d\n",v, getTop8(hash), hash, hash);
+    System.out.printf("     %8d, %8s, %16x, %19d" + LS,v, getTop8(hash), hash, hash);
   }
 
   static String getTop8(final long v) {

--- a/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketchTest.java
@@ -99,6 +99,18 @@ public class ArrayOfStringsSketchTest {
     }
   }
 
+  @Test
+  public void checkCopyCtor() {
+    ArrayOfStringsSketch sk1 = new ArrayOfStringsSketch();
+    String[][] strArrArr = {{"a","b"},{"c","d"},{"e","f"}};
+    int len = strArrArr.length;
+    for (int i = 0; i < len; i++) {
+      sk1.update(strArrArr[i], strArrArr[i]);
+    }
+    assertEquals(sk1.getRetainedEntries(), 3);
+    final ArrayOfStringsSketch sk2 = sk1.copy();
+    assertEquals(sk2.getRetainedEntries(), 3);
+  }
 
   @Test
   public void printlnTest() {

--- a/tools/FindBugsExcludeFilter.xml
+++ b/tools/FindBugsExcludeFilter.xml
@@ -78,9 +78,52 @@ under the License.
 
   <Match> <!-- Too many False Positives -->
     <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE" />
-    
-  </Match>  
+  </Match>
   
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- False positive -->
+    <Class name="org.apache.datasketches.cpc.CpcWrapper" />
+  </Match>
+  
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- False positive -->
+    <Class name="org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesAnotBImpl" />
+    <Method name="update" />
+  </Match>
+  
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- Only used in test -->
+    <Class name="org.apache.datasketches.cpc.CompressionCharacterization" />
+  </Match>
+  
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- Only used in test -->
+    <Class name="org.apache.datasketches.cpc.MergingValidation" />
+  </Match>
+
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- Only used in test -->
+    <Class name="org.apache.datasketches.cpc.QuickMergingValidation" />
+  </Match>
+  
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- Only used in test -->
+    <Class name="org.apache.datasketches.cpc.StreamingValidation" />
+  </Match>
+  
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2" /> <!-- Only used in test -->
+    <Class name="org.apache.datasketches.req.ReqDebugImpl" />
+  </Match>
+  
+  <Match> <!-- Exclude Test clases and packages -->
+    <Class name="~.*Test$"/>
+  </Match>
+  
+  <Match>
+    <Package name="~test\..*"/>
+  </Match>
+
 </FindBugsFilter>
 
 


### PR DESCRIPTION
The latest version of SpotBugs is much more aggressive especially in finding potential security issues.  Some of these were false-positives, and a number only involved test code, which I'm not concerned about.  

However, there was one that did concern me of SpotBugs type "EI_EXPOSE_REP2", "This code stores a reference to an externally mutable object into the internal representation of the object."

We do this in a number of places so I was surprised that SpotBugs did not find more.  Nonetheless, the fix for this involved providing copy constructors in one hierarchy of tuple sketches.  Although I fixed the bug that SpotBugs found, I'm sure there are more.  This will require a more extensive review in the near future.