### PR TITLE
Get union size

### DIFF
--- a/src/main/java/org/apache/datasketches/theta/SetOperationBuilder.java
+++ b/src/main/java/org/apache/datasketches/theta/SetOperationBuilder.java
@@ -26,6 +26,7 @@ import static org.apache.datasketches.Util.MAX_LG_NOM_LONGS;
 import static org.apache.datasketches.Util.MIN_LG_NOM_LONGS;
 import static org.apache.datasketches.Util.TAB;
 import static org.apache.datasketches.Util.ceilingPowerOf2;
+import static org.apache.datasketches.Util.checkNomLongs;
 
 import org.apache.datasketches.Family;
 import org.apache.datasketches.ResizeFactor;
@@ -66,8 +67,8 @@ public class SetOperationBuilder {
 
   /**
    * Sets the Maximum Nominal Entries (max K) for this set operation. The effective value of K of the result of a
-   * Set Operation can be less than max K, but never greater.  
-   * The minimum value is 16 and the maximum value is 67,108,864, which is 2^26. 
+   * Set Operation can be less than max K, but never greater.
+   * The minimum value is 16 and the maximum value is 67,108,864, which is 2^26.
    * @param nomEntries <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entres</a>
    * This will become the ceiling power of 2 if it is not a power of 2.
    * @return this SetOperationBuilder
@@ -78,6 +79,20 @@ public class SetOperationBuilder {
       throw new SketchesArgumentException("Nominal Entries must be >= 16 and <= 67108864: "
         + nomEntries);
     }
+    return this;
+  }
+
+  /**
+   * Alternative method of setting the Nominal Entries for this set operation from the log_base2 value.
+   * The minimum value is 4 and the maximum value is 26.
+   * Be aware that set operations as large as this maximum value may not have been
+   * thoroughly characterized for performance.
+   *
+   * @param lgNomEntries the log_base2 Nominal Entries.
+   * @return this SetOperationBuilder
+   */
+  public SetOperationBuilder setLogNominalEntries(final int lgNomEntries) {
+    bLgNomLongs = checkNomLongs(1 << lgNomEntries);
     return this;
   }
 

--- a/src/main/java/org/apache/datasketches/theta/Sketch.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketch.java
@@ -301,7 +301,7 @@ public abstract class Sketch {
   /**
    * Returns the maximum number of storage bytes required for an UpdateSketch with the given
    * number of nominal entries (power of 2).
-   * @param nomEntries <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entres</a>
+   * @param nomEntries <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entries</a>
    * This will become the ceiling power of 2 if it is not.
    * @return the maximum number of storage bytes required for a UpdateSketch with the given
    * nomEntries

--- a/src/main/java/org/apache/datasketches/theta/Union.java
+++ b/src/main/java/org/apache/datasketches/theta/Union.java
@@ -31,10 +31,24 @@ import org.apache.datasketches.memory.WritableMemory;
  */
 public abstract class Union extends SetOperation {
 
+
+  /**
+   * Returns the number of storage bytes required for this union in its current state.
+   *
+   * @return the number of storage bytes required for this union in its current state.
+   */
+  public abstract int getCurrentBytes();
+
   @Override
   public Family getFamily() {
     return Family.UNION;
   }
+
+  /**
+   * Returns the maximum required storage bytes for this union.
+   * @return the maximum required storage bytes for this union.
+   */
+  public abstract int getMaxUnionBytes();
 
   /**
    * Gets the result of this operation as an ordered CompactSketch on the Java heap.

--- a/src/main/java/org/apache/datasketches/theta/UnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/UnionImpl.java
@@ -216,9 +216,14 @@ final class UnionImpl extends Union {
   }
 
   @Override
-  public boolean isSameResource(final Memory that) {
-    return gadget_ instanceof DirectQuickSelectSketchR
-        ? gadget_.getMemory().isSameResource(that) : false;
+  public int getCurrentBytes() {
+    return gadget_.getCurrentBytes();
+  }
+
+  @Override
+  public int getMaxUnionBytes() {
+    final int lgK = gadget_.getLgNomLongs();
+    return (16 << lgK) + (Family.UNION.getMaxPreLongs() << 3);
   }
 
   @Override
@@ -254,6 +259,12 @@ final class UnionImpl extends Union {
     final short seedHash = gadget_.getSeedHash();
     return CompactOperations.componentsToCompact(
         minThetaLong, curCountOut, seedHash, empty, true, dstOrdered, dstOrdered, dstMem, compactCacheOut);
+  }
+
+  @Override
+  public boolean isSameResource(final Memory that) {
+    return gadget_ instanceof DirectQuickSelectSketchR
+        ? gadget_.getMemory().isSameResource(that) : false;
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/UpdateSketchBuilder.java
+++ b/src/main/java/org/apache/datasketches/theta/UpdateSketchBuilder.java
@@ -113,7 +113,7 @@ public class UpdateSketchBuilder {
    * This value is also used for building a shared concurrent sketch.
    * The minimum value is 4 and the maximum value is 26.
    * Be aware that sketches as large as this maximum value may not have been
-   * thoroughly tested or characterized for performance.
+   * thoroughly characterized for performance.
    *
    * @param lgNomEntries the Log Nominal Entries. Also for the concurrent shared sketch
    * @return this UpdateSketchBuilder

--- a/src/test/java/org/apache/datasketches/hash/MurmurHash3v2Test.java
+++ b/src/test/java/org/apache/datasketches/hash/MurmurHash3v2Test.java
@@ -38,7 +38,7 @@ import org.apache.datasketches.memory.WritableMemory;
 public class MurmurHash3v2Test {
   private Random rand = new Random();
   private static final int trials = 1 << 20;
-  
+
   @Test
   public void compareLongArrLong() { //long[]
     int arrLen = 3;
@@ -54,7 +54,7 @@ public class MurmurHash3v2Test {
       assertEquals(res2, res1);
     }
   }
-  
+
   @Test
   public void compareIntArr() { //int[]
     int bytes = Integer.BYTES;
@@ -63,7 +63,7 @@ public class MurmurHash3v2Test {
     int iPer = 8 / bytes;
     int nLongs = arrLen / iPer;
     int shift = 64 / iPer;
-    
+
     for (int i = 0; i < trials; i++) { //trials
       for (int j = 0; j < nLongs; j++) { //longs
         long r = rand.nextLong();
@@ -77,7 +77,7 @@ public class MurmurHash3v2Test {
       assertEquals(res2, res1);
     }
   }
-  
+
   @Test
   public void compareCharArr() { //char[]
     int bytes = Character.BYTES;
@@ -86,7 +86,7 @@ public class MurmurHash3v2Test {
     int iPer = 8 / bytes;
     int nLongs = arrLen / iPer;
     int shift = 64 / iPer;
-    
+
     for (int i = 0; i < trials; i++) { //trials
       for (int j = 0; j < nLongs; j++) { //longs
         long r = rand.nextLong();
@@ -100,7 +100,7 @@ public class MurmurHash3v2Test {
       assertEquals(res2, res1);
     }
   }
-  
+
   @Test
   public void compareByteArr() { //byte[]
     int bytes = Byte.BYTES;
@@ -109,7 +109,7 @@ public class MurmurHash3v2Test {
     int iPer = 8 / bytes;
     int nLongs = arrLen / iPer;
     int shift = 64 / iPer;
-    
+
     for (int i = 0; i < trials; i++) { //trials
       for (int j = 0; j < nLongs; j++) { //longs
         long r = rand.nextLong();
@@ -123,7 +123,7 @@ public class MurmurHash3v2Test {
       assertEquals(res2, res1);
     }
   }
-  
+
   @Test
   public void compareLongVsLongArr() {
     int arrLen = 1;
@@ -137,11 +137,11 @@ public class MurmurHash3v2Test {
       assertEquals(res2, res1);
     }
   }
-  
+
   private static final long[] hashV1(long[] key, long seed) {
     return MurmurHash3.hash(key, seed);
   }
-  
+
   private static final long[] hashV1(int[] key, long seed) {
     return MurmurHash3.hash(key, seed);
   }
@@ -149,15 +149,15 @@ public class MurmurHash3v2Test {
   private static final long[] hashV1(char[] key, long seed) {
     return MurmurHash3.hash(key, seed);
   }
-  
+
   private static final long[] hashV1(byte[] key, long seed) {
     return MurmurHash3.hash(key, seed);
   }
-  
+
   private static final long[] hashV2(long[] key, long seed) {
     return MurmurHash3v2.hash(key, seed);
   }
-  
+
   private static final long[] hashV2(int[] key2, long seed) {
     return MurmurHash3v2.hash(key2, seed);
   }
@@ -165,27 +165,27 @@ public class MurmurHash3v2Test {
   private static final long[] hashV2(char[] key, long seed) {
     return MurmurHash3v2.hash(key, seed);
   }
-  
+
   private static final long[] hashV2(byte[] key, long seed) {
     return MurmurHash3v2.hash(key, seed);
   }
-  
+
   //V2 single primitives
-  
+
   private static final long[] hashV2(long key, long seed, long[] out) {
     return MurmurHash3v2.hash(key, seed, out);
   }
-  
+
 //  private static final long[] hashV2(double key, long seed, long[] out) {
 //    return MurmurHash3v2.hash(key, seed, out);
 //  }
-  
+
 //  private static final long[] hashV2(String key, long seed, long[] out) {
 //    return MurmurHash3v2.hash(key, seed, out);
 //  }
-  
-  
-  
+
+
+
   @Test
   public void offsetChecks() {
     long seed = 12345;

--- a/src/test/java/org/apache/datasketches/kll/MiscDoublesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/MiscDoublesTest.java
@@ -20,7 +20,12 @@
 package org.apache.datasketches.kll;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
+import java.util.Objects;
+
+import org.apache.datasketches.SketchesArgumentException;
+import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
 /**
@@ -55,6 +60,63 @@ public class MiscDoublesTest {
     println("Ext     : " + est);
     println("UB      : " + ub);
     println("LB      : " + lb);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkHeapifyExceptions1() {
+    KllDoublesSketch sk = new KllDoublesSketch();
+    WritableMemory wmem = WritableMemory.writableWrap(sk.toByteArray());
+    wmem.putByte(6, (byte)4); //corrupt M
+    KllDoublesSketch.heapify(wmem);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkHeapifyExceptions2() {
+    KllDoublesSketch sk = new KllDoublesSketch();
+    WritableMemory wmem = WritableMemory.writableWrap(sk.toByteArray());
+    wmem.putByte(0, (byte)1); //corrupt preamble ints, should be 2
+    KllDoublesSketch.heapify(wmem);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkHeapifyExceptions3() {
+    KllDoublesSketch sk = new KllDoublesSketch();
+    sk.update(1.0f);
+    sk.update(2.0f);
+    WritableMemory wmem = WritableMemory.writableWrap(sk.toByteArray());
+    wmem.putByte(0, (byte)1); //corrupt preamble ints, should be 5
+    KllDoublesSketch.heapify(wmem);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkHeapifyExceptions4() {
+    KllDoublesSketch sk = new KllDoublesSketch();
+    WritableMemory wmem = WritableMemory.writableWrap(sk.toByteArray());
+    wmem.putByte(1, (byte)0); //corrupt SerVer, should be 1 or 2
+    KllDoublesSketch.heapify(wmem);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkHeapifyExceptions5() {
+    KllDoublesSketch sk = new KllDoublesSketch();
+    WritableMemory wmem = WritableMemory.writableWrap(sk.toByteArray());
+    wmem.putByte(2, (byte)0); //corrupt FamilyID, should be 15
+    KllDoublesSketch.heapify(wmem);
+  }
+
+  @Test
+  public void checkMisc() {
+    KllDoublesSketch sk = new KllDoublesSketch(8, true);
+    assertTrue(Objects.isNull(sk.getQuantiles(10)));
+    sk.toString(true, true);
+    for (int i = 0; i < 20; i++) { sk.update(i); }
+    sk.toString(true, true);
+    sk.toByteArray();
+    final double[] items = sk.getItems();
+    assertEquals(items.length, 16);
+    final int[] levels = sk.getLevels();
+    assertEquals(levels.length, 3);
+    assertEquals(sk.getNumLevels(), 2);
   }
 
   //@Test //requires visual check

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -278,9 +278,6 @@ public class UnionImplTest {
     //println(csk.toString(true, true, 1, true));
   }
 
-
-
-
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -37,6 +37,14 @@ import org.testng.annotations.Test;
 public class UnionImplTest {
 
   @Test
+  public void checkGetCurrentAndMaxBytes() {
+    final int lgK = 10;
+    final Union union = Sketches.setOperationBuilder().setLogNominalEntries(lgK).buildUnion();
+    assertEquals(union.getCurrentBytes(), 288);
+    assertEquals(union.getMaxUnionBytes(), 16416);
+  }
+
+  @Test
   public void checkUpdateWithSketch() {
     final int k = 16;
     final WritableMemory mem = WritableMemory.writableWrap(new byte[k*8 + 24]);
@@ -270,6 +278,9 @@ public class UnionImplTest {
     //println(csk.toString(true, true, 1, true));
   }
 
+
+
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
@@ -279,7 +290,7 @@ public class UnionImplTest {
    * @param o value to print
    */
   static void println(final Object o) {
-    //System.out.println(o.toString()); //disable here
+    System.out.println(o.toString()); //disable here
   }
 
 }

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -290,7 +290,7 @@ public class UnionImplTest {
    * @param o value to print
    */
   static void println(final Object o) {
-    System.out.println(o.toString()); //disable here
+    //System.out.println(o.toString()); //disable here
   }
 
 }


### PR DESCRIPTION
This PR adds two new methods to Theta Union:
- getCurrentBytes()  This behaves similarly to the Sketch method by the same name.
- getMaxUnionBytes()  This behaves similarly to the static Sketches method by the same name, but is non-static and returns the maximum stored bytes for this union given its nominal entries configuration.

This PR is based on the discussion on [Druid issue # 12261](https://github.com/apache/druid/issues/12261)