### PR TITLE
Cleanup warnings

### DIFF
--- a/src/main/java/org/apache/datasketches/cpc/CompressionCharacterization.java
+++ b/src/main/java/org/apache/datasketches/cpc/CompressionCharacterization.java
@@ -42,7 +42,6 @@ import org.apache.datasketches.memory.WritableMemory;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
-@SuppressWarnings("javadoc")
 public class CompressionCharacterization {
   private String hfmt;
   private String dfmt;

--- a/src/main/java/org/apache/datasketches/cpc/MergingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/MergingValidation.java
@@ -37,7 +37,6 @@ import java.io.PrintWriter;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
-@SuppressWarnings("javadoc")
 public class MergingValidation {
   private String hfmt;
   private String dfmt;

--- a/src/main/java/org/apache/datasketches/cpc/QuickMergingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/QuickMergingValidation.java
@@ -37,7 +37,6 @@ import java.io.PrintWriter;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
-@SuppressWarnings("javadoc")
 public class QuickMergingValidation {
   private String hfmt;
   private String dfmt;

--- a/src/main/java/org/apache/datasketches/cpc/StreamingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/StreamingValidation.java
@@ -35,7 +35,6 @@ import java.io.PrintWriter;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
-@SuppressWarnings("javadoc")
 public class StreamingValidation {
   private String hfmt;
   private String dfmt;

--- a/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
@@ -482,7 +482,6 @@ public class ItemsSketch<T> {
    * @param serDe an instance of ArrayOfItemsSerDe
    * @return a byte array representation of this sketch
    */
-  @SuppressWarnings("null")
   public byte[] toByteArray(final ArrayOfItemsSerDe<T> serDe) {
     final int preLongs;
     final int outBytes;

--- a/src/main/java/org/apache/datasketches/hash/XxHash.java
+++ b/src/main/java/org/apache/datasketches/hash/XxHash.java
@@ -24,14 +24,13 @@ import org.apache.datasketches.memory.Memory;
 /**
  * The XxHash is a fast, non-cryptographic, 64-bit hash function that has
  * excellent avalanche and 2-way bit independence properties.
- *  
- * <p>This class wraps the   
+ *
+ * <p>This class wraps the
  * <a href="https://github.com/apache/datasketches-memory/blob/master/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/XxHash.java">Memory Component XxHash</a>
  * implementation.
  *
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class XxHash {
 
   /**

--- a/src/main/java/org/apache/datasketches/hll/TgtHllType.java
+++ b/src/main/java/org/apache/datasketches/hll/TgtHllType.java
@@ -51,7 +51,6 @@ package org.apache.datasketches.hll;
 
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public enum TgtHllType { HLL_4, HLL_6, HLL_8;
 
   private static final TgtHllType values[] = values();

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesUnionImpl.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesUnionImpl.java
@@ -145,7 +145,6 @@ final class DoublesUnionImpl extends DoublesUnionImplR {
   }
 
   //@formatter:off
-  @SuppressWarnings("null")
   static UpdateDoublesSketch updateLogic(final int myMaxK, final UpdateDoublesSketch myQS,
                                          final DoublesSketch other) {
     int sw1 = ((myQS  == null) ? 0 :  myQS.isEmpty() ? 4 : 8);

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
@@ -532,7 +532,6 @@ public final class ItemsSketch<T> {
   /**
    * @return true if this sketch is off-heap
    */
-  @SuppressWarnings("static-method")
   public boolean isDirect() {
     return false;
   }

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsUnion.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsUnion.java
@@ -254,7 +254,7 @@ public final class ItemsUnion<T> {
   }
 
   //@formatter:off
-  @SuppressWarnings({"null", "unchecked"})
+  @SuppressWarnings("unchecked")
   static <T> ItemsSketch<T> updateLogic(final int myMaxK, final Comparator<? super T> comparator,
       final ItemsSketch<T> myQS, final ItemsSketch<T> other) {
     int sw1 = ((myQS   == null) ? 0 :   myQS.isEmpty() ? 4 : 8);

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirItemsSketch.java
@@ -460,7 +460,7 @@ public final class ReservoirItemsSketch<T> {
    * @param clazz The class represented by &lt;T&gt;
    * @return a byte array representation of this sketch
    */
-  @SuppressWarnings("null") // bytes will be null only if empty == true
+  // bytes will be null only if empty == true
   public byte[] toByteArray(final ArrayOfItemsSerDe<? super T> serDe, final Class<?> clazz) {
     final int preLongs, outBytes;
     final boolean empty = itemsSeen_ == 0;

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirItemsUnion.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirItemsUnion.java
@@ -286,7 +286,7 @@ public final class ReservoirItemsUnion<T> {
    * @param clazz A class to which the items are cast before serialization
    * @return a byte array representation of this union
    */
-  @SuppressWarnings("null") // gadgetBytes will be null only if gadget_ == null AND empty == true
+  // gadgetBytes will be null only if gadget_ == null AND empty == true
   public byte[] toByteArray(final ArrayOfItemsSerDe<T> serDe, final Class<?> clazz) {
     final int preLongs, outBytes;
     final boolean empty = gadget_ == null;
@@ -326,7 +326,7 @@ public final class ReservoirItemsUnion<T> {
     if ((sketchIn.getK() < maxK_) && (sketchIn.getN() <= sketchIn.getK())) {
       // incoming sketch is in exact mode with sketch's k < maxK,
       // so we can create a gadget at size maxK and keep everything
-      // NOTE: assumes twoWayMergeInternal first checks if sketchIn is in exact mode
+      //Assumes twoWayMergeInternal first checks if sketchIn is in exact mode
       gadget_ = ReservoirItemsSketch.newInstance(maxK_);
       twoWayMergeInternal(sketchIn, isModifiable); // isModifiable could be fixed to false here
     } else {

--- a/src/main/java/org/apache/datasketches/sampling/ReservoirLongsUnion.java
+++ b/src/main/java/org/apache/datasketches/sampling/ReservoirLongsUnion.java
@@ -239,7 +239,7 @@ public final class ReservoirLongsUnion {
    *
    * @return a byte array representation of this union
    */
-  @SuppressWarnings("null") // gadgetBytes will be null only if gadget_ == null AND empty == true
+  // gadgetBytes will be null only if gadget_ == null AND empty == true
   public byte[] toByteArray() {
     final int preLongs, outBytes;
     final boolean empty = gadget_ == null;

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
@@ -258,7 +258,6 @@ public final class VarOptItemsSketch<T> {
     return sketch;
   }
 
-
   /**
    * Returns a sketch instance of this class from the given srcMem,
    * which must be a Memory representation of this sketch class.

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsSketch.java
@@ -269,7 +269,6 @@ public final class VarOptItemsSketch<T> {
    * @param serDe  An instance of ArrayOfItemsSerDe
    * @return a sketch instance of this class
    */
-  @SuppressWarnings("null")
   public static <T> VarOptItemsSketch<T> heapify(final Memory srcMem,
                                                  final ArrayOfItemsSerDe<T> serDe) {
     final int numPreLongs = getAndCheckPreLongs(srcMem);
@@ -566,7 +565,7 @@ public final class VarOptItemsSketch<T> {
    * @param clazz The class represented by &lt;T&gt;
    * @return a byte array representation of this sketch
    */
-  @SuppressWarnings("null") // bytes will be null only if empty == true
+  // bytes will be null only if empty == true
   public byte[] toByteArray(final ArrayOfItemsSerDe<? super T> serDe, final Class<?> clazz) {
     final int preLongs, numMarkBytes, outBytes;
     final boolean empty = (r_ == 0) && (h_ == 0);

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsUnion.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsUnion.java
@@ -314,7 +314,7 @@ public final class VarOptItemsUnion<T> {
    * @param clazz A class to which the items are cast before serialization
    * @return a byte array representation of this union
    */
-  @SuppressWarnings("null") // gadgetBytes will be null only if gadget_ == null AND empty == true
+  // gadgetBytes will be null only if gadget_ == null AND empty == true
   public byte[] toByteArray(final ArrayOfItemsSerDe<T> serDe, final Class<?> clazz) {
     final int preLongs, outBytes;
     final boolean empty = gadget_.getNumSamples() == 0;

--- a/src/main/java/org/apache/datasketches/theta/ConcurrentPropagationService.java
+++ b/src/main/java/org/apache/datasketches/theta/ConcurrentPropagationService.java
@@ -58,7 +58,6 @@ final class ConcurrentPropagationService {
     return getInstance().propagationExecutorService[(int) id % NUM_POOL_THREADS] = null;
   }
 
-  @SuppressWarnings("static-method")
   private ExecutorService initExecutorService(final int i) {
     if (propagationExecutorService[i] == null) {
       propagationExecutorService[i] = Executors.newSingleThreadExecutor();

--- a/src/main/java/org/apache/datasketches/tuple/AnotB.java
+++ b/src/main/java/org/apache/datasketches/tuple/AnotB.java
@@ -109,7 +109,6 @@ public final class AnotB<S extends Summary> {
    *
    * @param skA The incoming sketch for the first argument, <i>A</i>.
    */
-  @SuppressWarnings("unchecked")
   public void setA(final Sketch<S> skA) {
     if (skA == null) {
       reset();
@@ -141,7 +140,6 @@ public final class AnotB<S extends Summary> {
    *
    * @param skB The incoming Tuple sketch for the second (or following) argument <i>B</i>.
    */
-  @SuppressWarnings("unchecked")
   public void notB(final Sketch<S> skB) {
     if (skB == null) { return; } //ignore
 
@@ -214,7 +212,6 @@ public final class AnotB<S extends Summary> {
    *
    * @param skB The incoming Theta sketch for the second (or following) argument <i>B</i>.
    */
-  @SuppressWarnings("unchecked")
   public void notB(final org.apache.datasketches.theta.Sketch skB) {
     if (skB == null) { return; } //ignore
 
@@ -311,7 +308,6 @@ public final class AnotB<S extends Summary> {
    * @param <S> Type of Summary
    * @return the result as an unordered {@link CompactSketch}
    */
-  @SuppressWarnings("unchecked")
   public static <S extends Summary> CompactSketch<S> aNotB(
       final Sketch<S> skA,
       final Sketch<S> skB) {
@@ -403,7 +399,6 @@ public final class AnotB<S extends Summary> {
    * @param <S> Type of Summary
    * @return the result as an unordered {@link CompactSketch}
    */
-  @SuppressWarnings("unchecked")
   public static <S extends Summary> CompactSketch<S> aNotB(
       final Sketch<S> skA,
       final org.apache.datasketches.theta.Sketch skB) {
@@ -480,7 +475,6 @@ public final class AnotB<S extends Summary> {
     S[] summaryArr;
   }
 
-  @SuppressWarnings("unchecked")
   private static <S extends Summary> DataArrays<S> getCopyOfDataArraysTuple(
       final Sketch<S> sk) {
     final CompactSketch<S> csk;

--- a/src/main/java/org/apache/datasketches/tuple/CompactSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/CompactSketch.java
@@ -71,7 +71,6 @@ public class CompactSketch<S extends Summary> extends Sketch<S> {
    * @param mem Memory object with serialized CompactSketch
    * @param deserializer the SummaryDeserializer
    */
-  @SuppressWarnings({"unchecked"})
   CompactSketch(final Memory mem, final SummaryDeserializer<S> deserializer) {
     int offset = 0;
     final byte preambleLongs = mem.getByte(offset++);
@@ -189,7 +188,6 @@ public class CompactSketch<S extends Summary> extends Sketch<S> {
   // Adr:
   //      ||    7   |    6   |    5   |    4   |    3   |    2   |    1   |     0              |
   //  0   ||    seed hash    |  Flags | unused | SkType | FamID  | SerVer |  Preamble_Longs    |
-  @SuppressWarnings("null")
   @Override
   public byte[] toByteArray() {
   final int count = getRetainedEntries();

--- a/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
@@ -349,7 +349,6 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
    * Serializing a CompactSketch is not deprecated.
    */
   @Deprecated
-  @SuppressWarnings("null")
   @Override
   public byte[] toByteArray() {
     byte[][] summariesBytes = null;
@@ -507,7 +506,6 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
     thetaLong_ = QuickSelect.select(hashArr, 0, count_ - 1, nomEntries_);
   }
 
-  @SuppressWarnings({"unchecked"})
   private void resize(final int newSize) {
     final long[] oldHashTable = hashTable_;
     final S[] oldSummaryTable = summaryTable_;

--- a/src/main/java/org/apache/datasketches/tuple/SerializerDeserializer.java
+++ b/src/main/java/org/apache/datasketches/tuple/SerializerDeserializer.java
@@ -31,7 +31,6 @@ public final class SerializerDeserializer {
   /**
    * Defines the sketch classes that this SerializerDeserializer can handle.
    */
-  @SuppressWarnings("javadoc")
   public static enum SketchType { QuickSelectSketch, CompactSketch, ArrayOfDoublesQuickSelectSketch,
     ArrayOfDoublesCompactSketch, ArrayOfDoublesUnion }
 

--- a/src/main/java/org/apache/datasketches/tuple/Union.java
+++ b/src/main/java/org/apache/datasketches/tuple/Union.java
@@ -135,7 +135,6 @@ public class Union<S extends Summary> {
     unionThetaLong_ = min(unionThetaLong_, qsk_.thetaLong_);
   }
 
-
   /**
    * Gets the result of a sequence of stateful <i>union</i> operations as an unordered CompactSketch
    * @return result of the stateful unions so far. The state of this operation is not reset after the

--- a/src/main/java/org/apache/datasketches/tuple/Union.java
+++ b/src/main/java/org/apache/datasketches/tuple/Union.java
@@ -121,7 +121,6 @@ public class Union<S extends Summary> {
    * @param summary the given proxy summary for the theta sketch, which doesn't have one. This may
    * not be null.
    */
-  @SuppressWarnings("unchecked")
   public void union(final org.apache.datasketches.theta.Sketch thetaSketch, final S summary) {
     if (summary == null) {
       throw new SketchesArgumentException("Summary cannot be null."); }
@@ -142,7 +141,6 @@ public class Union<S extends Summary> {
    * @return result of the stateful unions so far. The state of this operation is not reset after the
    * result is returned.
    */
-  @SuppressWarnings("unchecked")
   public CompactSketch<S> getResult() {
     return getResult(false);
   }

--- a/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
@@ -86,7 +86,6 @@ public class UpdatableSketch<U, S extends UpdatableSummary<U>> extends QuickSele
   /**
    * @return a deep copy of this sketch
    */
-  @SuppressWarnings("unchecked")
   @Override
   public UpdatableSketch<U,S> copy() {
     return new UpdatableSketch<U,S>(this);

--- a/src/main/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketch.java
@@ -84,7 +84,6 @@ public class ArrayOfStringsSketch extends UpdatableSketch<String[], ArrayOfStrin
   /**
    * @return a deep copy of this sketch
    */
-  @SuppressWarnings("unchecked")
   @Override
   public ArrayOfStringsSketch copy() {
     return new ArrayOfStringsSketch(this);

--- a/src/test/java/org/apache/datasketches/BinarySearchTest.java
+++ b/src/test/java/org/apache/datasketches/BinarySearchTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class BinarySearchTest {
   static Random rand = new Random(1);
   private static final String LS = System.getProperty("line.separator");

--- a/src/test/java/org/apache/datasketches/BinomialBoundsNTest.java
+++ b/src/test/java/org/apache/datasketches/BinomialBoundsNTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 /**
  * @author Kevin Lang
  */
-@SuppressWarnings("javadoc")
 public class BinomialBoundsNTest {
 
   public static double[] runTestAux(final long max_numSamplesI, final int ci, final double min_p) {

--- a/src/test/java/org/apache/datasketches/BoundsOnBinomialProportionsTest.java
+++ b/src/test/java/org/apache/datasketches/BoundsOnBinomialProportionsTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /**
  * @author Kevin Lang
  */
-@SuppressWarnings("javadoc")
 public class BoundsOnBinomialProportionsTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/BoundsOnRatiosInSampledSetsTest.java
+++ b/src/test/java/org/apache/datasketches/BoundsOnRatiosInSampledSetsTest.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class BoundsOnRatiosInSampledSetsTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/BoundsOnRatiosInThetaSketchedSetsTest.java
+++ b/src/test/java/org/apache/datasketches/BoundsOnRatiosInThetaSketchedSetsTest.java
@@ -28,7 +28,6 @@ import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.UpdateSketch;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class BoundsOnRatiosInThetaSketchedSetsTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/BoundsOnRatiosInTupleSketchedSetsTest.java
+++ b/src/test/java/org/apache/datasketches/BoundsOnRatiosInTupleSketchedSetsTest.java
@@ -37,7 +37,6 @@ import static org.testng.Assert.assertTrue;
  * @author Lee Rhodes
  * @author David Cromberge
  */
-@SuppressWarnings("javadoc")
 public class BoundsOnRatiosInTupleSketchedSetsTest {
 
   private final DoubleSummary.Mode umode = DoubleSummary.Mode.Sum;

--- a/src/test/java/org/apache/datasketches/ByteArrayUtilTest.java
+++ b/src/test/java/org/apache/datasketches/ByteArrayUtilTest.java
@@ -46,7 +46,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ByteArrayUtilTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/FamilyTest.java
+++ b/src/test/java/org/apache/datasketches/FamilyTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class FamilyTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/GenericInequalitySearchTest.java
+++ b/src/test/java/org/apache/datasketches/GenericInequalitySearchTest.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class GenericInequalitySearchTest {
   static Random rand = new Random(1);
   private static final String LS = System.getProperty("line.separator");

--- a/src/test/java/org/apache/datasketches/HashOperationsTest.java
+++ b/src/test/java/org/apache/datasketches/HashOperationsTest.java
@@ -38,7 +38,6 @@ import static org.testng.Assert.fail;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class HashOperationsTest {
 
   //Not otherwise already covered

--- a/src/test/java/org/apache/datasketches/QuickSelectTest.java
+++ b/src/test/java/org/apache/datasketches/QuickSelectTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class QuickSelectTest {
   private static final String LS = System.getProperty("line.separator");
   private static final Random random = new Random(); // pseudo-random number generator

--- a/src/test/java/org/apache/datasketches/SketchesExceptionTest.java
+++ b/src/test/java/org/apache/datasketches/SketchesExceptionTest.java
@@ -21,7 +21,6 @@ package org.apache.datasketches;
 
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class SketchesExceptionTest {
 
   @Test(expectedExceptions = SketchesException.class)

--- a/src/test/java/org/apache/datasketches/UtilTest.java
+++ b/src/test/java/org/apache/datasketches/UtilTest.java
@@ -61,7 +61,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class UtilTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/cpc/CompressedStateTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CompressedStateTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CompressedStateTest {
   static PrintStream ps = System.out;
   long vIn = 0;

--- a/src/test/java/org/apache/datasketches/cpc/CompressionDataTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CompressionDataTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CompressionDataTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/cpc/CpcCBinariesTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcCBinariesTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
  * Checks sketch images obtained from C++.
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CpcCBinariesTest {
   static PrintStream ps = System.out;
   static final String LS = System.getProperty("line.separator");

--- a/src/test/java/org/apache/datasketches/cpc/CpcCompressionTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcCompressionTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CpcCompressionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/cpc/CpcSketchTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcSketchTest.java
@@ -35,7 +35,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CpcSketchTest {
   static PrintStream ps = System.out;
 

--- a/src/test/java/org/apache/datasketches/cpc/CpcUnionTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcUnionTest.java
@@ -32,7 +32,6 @@ import org.apache.datasketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CpcUnionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/cpc/CpcWrapperTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcWrapperTest.java
@@ -32,7 +32,6 @@ import org.apache.datasketches.Family;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CpcWrapperTest {
   static PrintStream ps = System.out;
 

--- a/src/test/java/org/apache/datasketches/cpc/IconEstimatorTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/IconEstimatorTest.java
@@ -30,7 +30,6 @@ import org.apache.datasketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class IconEstimatorTest {
 
   //SLOW EXACT VERSION, Eventually move to characterization

--- a/src/test/java/org/apache/datasketches/cpc/PairTableTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/PairTableTest.java
@@ -32,7 +32,6 @@ import org.apache.datasketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class PairTableTest {
   Random rand = new Random();
 

--- a/src/test/java/org/apache/datasketches/cpc/PreambleUtilTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/PreambleUtilTest.java
@@ -64,7 +64,6 @@ import org.apache.datasketches.cpc.PreambleUtil.HiField;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
   static final short defaultSeedHash = computeSeedHash(DEFAULT_UPDATE_SEED) ;
 

--- a/src/test/java/org/apache/datasketches/cpc/RuntimeAssertsTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/RuntimeAssertsTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class RuntimeAssertsTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/cpc/TestAllTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/TestAllTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class TestAllTest {
   // Enable these as desired for all tests.
   private PrintStream ps = null; //System.out; //prints to console

--- a/src/test/java/org/apache/datasketches/fdt/FdtSketchTest.java
+++ b/src/test/java/org/apache/datasketches/fdt/FdtSketchTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class FdtSketchTest {
   private static final String LS = System.getProperty("line.separator");
   private static final char sep = '|'; //string separator

--- a/src/test/java/org/apache/datasketches/fdt/GroupTest.java
+++ b/src/test/java/org/apache/datasketches/fdt/GroupTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class GroupTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/frequencies/DistTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/DistTest.java
@@ -22,7 +22,6 @@ package org.apache.datasketches.frequencies;
 import org.testng.Assert;
 //import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class DistTest {
 
   /**

--- a/src/test/java/org/apache/datasketches/frequencies/HashMapStressTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/HashMapStressTest.java
@@ -22,7 +22,6 @@ package org.apache.datasketches.frequencies;
 import org.apache.datasketches.hash.MurmurHash3;
 //import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class HashMapStressTest {
 
   //@Test

--- a/src/test/java/org/apache/datasketches/frequencies/ItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/ItemsSketchTest.java
@@ -41,7 +41,6 @@ import org.apache.datasketches.ArrayOfUtf16StringsSerDe;
 import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.frequencies.ItemsSketch.Row;
 
-@SuppressWarnings("javadoc")
 public class ItemsSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/frequencies/LongsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/LongsSketchTest.java
@@ -41,7 +41,6 @@ import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.Util;
 import org.apache.datasketches.frequencies.LongsSketch.Row;
 
-@SuppressWarnings("javadoc")
 public class LongsSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/frequencies/ReversePurgeLongHashMapTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/ReversePurgeLongHashMapTest.java
@@ -25,7 +25,6 @@ import org.testng.annotations.Test;
 
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class ReversePurgeLongHashMapTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/org/apache/datasketches/frequencies/SerDeCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/SerDeCompatibilityTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class SerDeCompatibilityTest {
 
   static final ArrayOfItemsSerDe<Long> serDe = new ArrayOfLongsSerDe();

--- a/src/test/java/org/apache/datasketches/hash/MurmurHash3AdaptorTest.java
+++ b/src/test/java/org/apache/datasketches/hash/MurmurHash3AdaptorTest.java
@@ -33,7 +33,6 @@ import org.apache.datasketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class MurmurHash3AdaptorTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hash/MurmurHash3Test.java
+++ b/src/test/java/org/apache/datasketches/hash/MurmurHash3Test.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
  *
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class MurmurHash3Test {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hash/MurmurHash3v2Test.java
+++ b/src/test/java/org/apache/datasketches/hash/MurmurHash3v2Test.java
@@ -34,7 +34,6 @@ import org.apache.datasketches.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class MurmurHash3v2Test {
   private Random rand = new Random();
   private static final int trials = 1 << 20;

--- a/src/test/java/org/apache/datasketches/hash/XxHashTest.java
+++ b/src/test/java/org/apache/datasketches/hash/XxHashTest.java
@@ -28,7 +28,6 @@ import org.apache.datasketches.memory.Memory;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class XxHashTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/AuxHashMapTest.java
+++ b/src/test/java/org/apache/datasketches/hll/AuxHashMapTest.java
@@ -30,7 +30,6 @@ import org.apache.datasketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class AuxHashMapTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/hll/BaseHllSketchTest.java
+++ b/src/test/java/org/apache/datasketches/hll/BaseHllSketchTest.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
  * @author Lee Rhodes
  *
  */
-@SuppressWarnings("javadoc")
 public class BaseHllSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/CouponListTest.java
+++ b/src/test/java/org/apache/datasketches/hll/CouponListTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CouponListTest {
 
   @Test //visual check

--- a/src/test/java/org/apache/datasketches/hll/CrossCountingTest.java
+++ b/src/test/java/org/apache/datasketches/hll/CrossCountingTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings({"unused", "javadoc"})
+@SuppressWarnings("unused")
 public class CrossCountingTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/hll/DirectAuxHashMapTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectAuxHashMapTest.java
@@ -41,7 +41,6 @@ import org.apache.datasketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectAuxHashMapTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/DirectCouponListTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectCouponListTest.java
@@ -34,7 +34,6 @@ import org.apache.datasketches.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectCouponListTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/DirectHllSketchTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectHllSketchTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectHllSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/DirectUnionTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectUnionTest.java
@@ -37,7 +37,6 @@ import org.apache.datasketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectUnionTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/hll/HllArrayTest.java
+++ b/src/test/java/org/apache/datasketches/hll/HllArrayTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class HllArrayTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/HllSketchTest.java
+++ b/src/test/java/org/apache/datasketches/hll/HllSketchTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class HllSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/IsomorphicTest.java
+++ b/src/test/java/org/apache/datasketches/hll/IsomorphicTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings({"javadoc", "unused"})
+@SuppressWarnings("unused")
 public class IsomorphicTest {
   long v = 0;
 

--- a/src/test/java/org/apache/datasketches/hll/PreambleUtilTest.java
+++ b/src/test/java/org/apache/datasketches/hll/PreambleUtilTest.java
@@ -40,7 +40,6 @@ import org.apache.datasketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/TablesTest.java
+++ b/src/test/java/org/apache/datasketches/hll/TablesTest.java
@@ -33,7 +33,6 @@ import org.apache.datasketches.SketchesArgumentException;
  * @author Lee Rhodes
  *
  */
-@SuppressWarnings("javadoc")
 public class TablesTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/ToFromByteArrayTest.java
+++ b/src/test/java/org/apache/datasketches/hll/ToFromByteArrayTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ToFromByteArrayTest {
 
   static final int[] nArr = new int[] {1, 3, 10, 30, 100, 300, 1000, 3000, 10000, 30000};

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class UnionCaseTest {
   private static final String LS = System.getProperty("line.separator");
   long v = 0;

--- a/src/test/java/org/apache/datasketches/hll/UnionTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionTest.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class UnionTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/hllmap/CouponHashMapTest.java
+++ b/src/test/java/org/apache/datasketches/hllmap/CouponHashMapTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class CouponHashMapTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hllmap/CouponTraverseMapTest.java
+++ b/src/test/java/org/apache/datasketches/hllmap/CouponTraverseMapTest.java
@@ -24,7 +24,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class CouponTraverseMapTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hllmap/HllMapTest.java
+++ b/src/test/java/org/apache/datasketches/hllmap/HllMapTest.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 
 import org.apache.datasketches.Util;
 
-@SuppressWarnings("javadoc")
 public class HllMapTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hllmap/SingleCouponMapTest.java
+++ b/src/test/java/org/apache/datasketches/hllmap/SingleCouponMapTest.java
@@ -24,7 +24,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class SingleCouponMapTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/hllmap/UniqueCountMapTest.java
+++ b/src/test/java/org/apache/datasketches/hllmap/UniqueCountMapTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.Util;
 
-@SuppressWarnings("javadoc")
 public class UniqueCountMapTest {
   private final static int INIT_ENTRIES = 211;
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/AccuracyTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/AccuracyTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class AccuracyTest {
   static Random rand = new Random();
 

--- a/src/test/java/org/apache/datasketches/quantiles/DebugUnionTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DebugUnionTest.java
@@ -33,7 +33,6 @@ import org.apache.datasketches.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DebugUnionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DirectCompactDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectCompactDoublesSketchTest.java
@@ -36,7 +36,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class DirectCompactDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
@@ -38,7 +38,6 @@ import org.apache.datasketches.memory.WritableMemory;
  * implementation that <i>owns</i> the native memory allocations, thus is responsible for
  * allocating larger Memory when requested and the actual freeing of the old memory allocations.
  */
-@SuppressWarnings("javadoc")
 public class DirectQuantilesMemoryRequestTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketchTest.java
@@ -35,7 +35,6 @@ import org.testng.annotations.Test;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class DirectUpdateDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchBuilderTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchBuilderTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 
 import org.apache.datasketches.memory.WritableMemory;
 
-@SuppressWarnings("javadoc")
 public class DoublesSketchBuilderTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchIteratorTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchIteratorTest.java
@@ -22,7 +22,6 @@ package org.apache.datasketches.quantiles;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class DoublesSketchIteratorTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -32,7 +32,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class DoublesSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesUnionBuilderTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesUnionBuilderTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 
-@SuppressWarnings("javadoc")
 public class DoublesUnionBuilderTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesUnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesUnionImplTest.java
@@ -34,7 +34,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class DoublesUnionImplTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesUtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesUtilTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 
-@SuppressWarnings("javadoc")
 public class DoublesUtilTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/ForwardCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ForwardCompatibilityTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.Memory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ForwardCompatibilityTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/quantiles/HeapCompactDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/HeapCompactDoublesSketchTest.java
@@ -32,7 +32,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class HeapCompactDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
@@ -43,7 +43,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class HeapUpdateDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/quantiles/ItemsSketchIteratorTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ItemsSketchIteratorTest.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ItemsSketchIteratorTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/ItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ItemsSketchTest.java
@@ -36,7 +36,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ItemsSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/quantiles/ItemsUnionTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ItemsUnionTest.java
@@ -31,7 +31,6 @@ import org.apache.datasketches.ArrayOfItemsSerDe;
 import org.apache.datasketches.ArrayOfLongsSerDe;
 import org.apache.datasketches.ArrayOfStringsSerDe;
 
-@SuppressWarnings("javadoc")
 public class ItemsUnionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/KolmogorovSmirnovTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/KolmogorovSmirnovTest.java
@@ -27,7 +27,6 @@ import java.util.Random;
 
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class KolmogorovSmirnovTest {
 
  @Test

--- a/src/test/java/org/apache/datasketches/quantiles/PreambleUtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/PreambleUtilTest.java
@@ -43,7 +43,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 
-@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/ReadOnlyMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ReadOnlyMemoryTest.java
@@ -28,7 +28,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.SketchesReadOnlyException;
 
-@SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/SerDeCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/SerDeCompatibilityTest.java
@@ -27,7 +27,6 @@ import org.apache.datasketches.memory.Memory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class SerDeCompatibilityTest {
 
   private static final ArrayOfItemsSerDe<Double> serDe = new ArrayOfDoublesSerDe();

--- a/src/test/java/org/apache/datasketches/quantiles/UtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/UtilTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class UtilTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/req/FloatBufferTest.java
+++ b/src/test/java/org/apache/datasketches/req/FloatBufferTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class FloatBufferTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/req/ReqAuxiliaryTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqAuxiliaryTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
+
 public class ReqAuxiliaryTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/req/ReqCompactorTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqCompactorTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ReqCompactorTest {
   final ReqSketchTest reqSketchTest = new ReqSketchTest();
 

--- a/src/test/java/org/apache/datasketches/req/ReqSketchBuilderTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchBuilderTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ReqSketchBuilderTest {
 
   @Test
@@ -44,7 +43,9 @@ public class ReqSketchBuilderTest {
     println(bldr.toString());
   }
 
-  @SuppressWarnings("unused")
+  /**
+   * @param o object to be printed
+   */
   static void println(final Object o) {
     //System.out.println(o.toString());
   }

--- a/src/test/java/org/apache/datasketches/req/ReqSketchOtherTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchOtherTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings({"javadoc", "unused"})
+@SuppressWarnings("unused")
 public class ReqSketchOtherTest {
   final ReqSketchTest reqSketchTest = new ReqSketchTest();
   static InequalitySearch critLT = LT;

--- a/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings({"javadoc", "unused"})
+@SuppressWarnings("unused")
 public class ReqSketchTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/sampling/ReservoirItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/ReservoirItemsSketchTest.java
@@ -46,7 +46,6 @@ import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.SketchesException;
 import org.apache.datasketches.SketchesStateException;
 
-@SuppressWarnings("javadoc")
 public class ReservoirItemsSketchTest {
   private static final double EPS = 1e-8;
 

--- a/src/test/java/org/apache/datasketches/sampling/ReservoirItemsUnionTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/ReservoirItemsUnionTest.java
@@ -44,7 +44,6 @@ import org.apache.datasketches.Family;
 import org.apache.datasketches.SketchesArgumentException;
 
 // Tests mostly focus on Long since other types are already tested in ReservoirItemsSketchTest.
-@SuppressWarnings("javadoc")
 public class ReservoirItemsUnionTest {
   @Test
   public void checkEmptyUnion() {

--- a/src/test/java/org/apache/datasketches/sampling/ReservoirLongsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/ReservoirLongsSketchTest.java
@@ -42,7 +42,6 @@ import org.apache.datasketches.SketchesArgumentException;
 import org.apache.datasketches.SketchesException;
 import org.apache.datasketches.SketchesStateException;
 
-@SuppressWarnings("javadoc")
 public class ReservoirLongsSketchTest {
   private static final double EPS = 1e-8;
 

--- a/src/test/java/org/apache/datasketches/sampling/ReservoirLongsUnionTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/ReservoirLongsUnionTest.java
@@ -37,7 +37,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.Family;
 import org.apache.datasketches.SketchesArgumentException;
 
-@SuppressWarnings("javadoc")
 public class ReservoirLongsUnionTest {
   @Test
   public void checkEmptyUnion() {

--- a/src/test/java/org/apache/datasketches/sampling/ReservoirSizeTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/ReservoirSizeTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.fail;
 import org.apache.datasketches.SketchesArgumentException;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ReservoirSizeTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/sampling/VarOptItemsSamplesTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptItemsSamplesTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /**
  * @author Jon Malkin
  */
-@SuppressWarnings("javadoc")
 public class VarOptItemsSamplesTest {
   @Test
   public void compareIteratorToArrays() {

--- a/src/test/java/org/apache/datasketches/sampling/VarOptItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptItemsSketchTest.java
@@ -37,7 +37,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class VarOptItemsSketchTest {
   static final double EPS = 1e-10;
 

--- a/src/test/java/org/apache/datasketches/sampling/VarOptItemsUnionTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptItemsUnionTest.java
@@ -39,7 +39,6 @@ import org.apache.datasketches.SketchesArgumentException;
 /**
  * @author Jon Malkin
  */
-@SuppressWarnings("javadoc")
 public class VarOptItemsUnionTest {
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkBadSerVer() {

--- a/src/test/java/org/apache/datasketches/theta/AnotBimplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/AnotBimplTest.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class AnotBimplTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/CompactSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/CompactSketchTest.java
@@ -35,7 +35,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class CompactSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/ConcurrentDirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ConcurrentDirectQuickSelectSketchTest.java
@@ -39,7 +39,6 @@ import org.testng.annotations.Test;
 /**
  * @author eshcar
  */
-@SuppressWarnings("javadoc")
 public class ConcurrentDirectQuickSelectSketchTest {
   private static final long SEED = DEFAULT_UPDATE_SEED;
 
@@ -535,7 +534,6 @@ public class ConcurrentDirectQuickSelectSketchTest {
     for (int i = 0; i < u; i++) { local.update(i); }
   }
 
-  @SuppressWarnings("unused")
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkConstructorKtooSmall() {
     int lgK = 3;

--- a/src/test/java/org/apache/datasketches/theta/ConcurrentHeapQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ConcurrentHeapQuickSelectSketchTest.java
@@ -39,7 +39,6 @@ import org.testng.annotations.Test;
 /**
  * @author eshcar
  */
-@SuppressWarnings("javadoc")
 public class ConcurrentHeapQuickSelectSketchTest {
 
 
@@ -491,7 +490,6 @@ public class ConcurrentHeapQuickSelectSketchTest {
     println(sl.bldr.toString());
   }
 
-  @SuppressWarnings("unused")
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkBuilderSmallNominal() {
     int lgK = 2; //too small

--- a/src/test/java/org/apache/datasketches/theta/DirectIntersectionTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectIntersectionTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectIntersectionTest {
   private static final int PREBYTES = CONST_PREAMBLE_LONGS << 3; //24
 

--- a/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
@@ -54,7 +54,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectQuickSelectSketchTest {
 
   @Test//(expectedExceptions = SketchesArgumentException.class)
@@ -426,7 +425,7 @@ public class DirectQuickSelectSketchTest {
       assertEquals(csk3.getClass().getSimpleName(), "DirectCompactSketch");
     } catch (final Exception e) {
       //if (e instanceof SketchesArgumentException) {}
-      throw new RuntimeException(e); 
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/test/java/org/apache/datasketches/theta/DirectUnionTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectUnionTest.java
@@ -41,7 +41,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class DirectUnionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/EmptyTest.java
+++ b/src/test/java/org/apache/datasketches/theta/EmptyTest.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
  *
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class EmptyTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/ExamplesTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ExamplesTest.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ExamplesTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/ForwardCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ForwardCompatibilityTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ForwardCompatibilityTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/HeapAlphaSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/HeapAlphaSketchTest.java
@@ -49,7 +49,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class HeapAlphaSketchTest {
   private Family fam_ = ALPHA;
 

--- a/src/test/java/org/apache/datasketches/theta/HeapIntersectionTest.java
+++ b/src/test/java/org/apache/datasketches/theta/HeapIntersectionTest.java
@@ -38,7 +38,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class HeapIntersectionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/HeapQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/HeapQuickSelectSketchTest.java
@@ -50,7 +50,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class HeapQuickSelectSketchTest {
   private Family fam_ = QUICKSELECT;
 

--- a/src/test/java/org/apache/datasketches/theta/HeapUnionTest.java
+++ b/src/test/java/org/apache/datasketches/theta/HeapUnionTest.java
@@ -38,7 +38,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class HeapUnionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/IteratorTest.java
+++ b/src/test/java/org/apache/datasketches/theta/IteratorTest.java
@@ -29,7 +29,6 @@ import org.apache.datasketches.Family;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class IteratorTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/JaccardSimilarityTest.java
+++ b/src/test/java/org/apache/datasketches/theta/JaccardSimilarityTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class JaccardSimilarityTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/PairwiseSetOperationsTest.java
+++ b/src/test/java/org/apache/datasketches/theta/PairwiseSetOperationsTest.java
@@ -25,7 +25,7 @@ import static org.testng.Assert.fail;
 import org.apache.datasketches.SketchesArgumentException;
 import org.testng.annotations.Test;
 
-@SuppressWarnings({"javadoc","deprecation"})
+@SuppressWarnings("deprecation")
 public class PairwiseSetOperationsTest {
 
   // Intersection

--- a/src/test/java/org/apache/datasketches/theta/PreambleUtilTest.java
+++ b/src/test/java/org/apache/datasketches/theta/PreambleUtilTest.java
@@ -65,7 +65,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/ReadOnlyMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ReadOnlyMemoryTest.java
@@ -30,7 +30,6 @@ import org.apache.datasketches.memory.Memory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/SetOperationTest.java
+++ b/src/test/java/org/apache/datasketches/theta/SetOperationTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class SetOperationTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/SetOpsCornerCasesTest.java
+++ b/src/test/java/org/apache/datasketches/theta/SetOpsCornerCasesTest.java
@@ -33,7 +33,7 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings({"javadoc","deprecation"})
+@SuppressWarnings("deprecation")
 public class SetOpsCornerCasesTest {
 
   /*******************************************/

--- a/src/test/java/org/apache/datasketches/theta/SingleItemSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/SingleItemSketchTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class SingleItemSketchTest {
   final static short DEFAULT_SEED_HASH = (short) (computeSeedHash(DEFAULT_UPDATE_SEED) & 0XFFFFL);
 

--- a/src/test/java/org/apache/datasketches/theta/SketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/SketchTest.java
@@ -50,7 +50,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class SketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/SketchesTest.java
+++ b/src/test/java/org/apache/datasketches/theta/SketchesTest.java
@@ -44,7 +44,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class SketchesTest {
 
   private static Memory getCompactSketchMemory(final int k, final int from, final int to) {

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -33,7 +33,6 @@ import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class UnionImplTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/UpdateSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UpdateSketchTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class UpdateSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/CompactSketchWithDoubleSummaryTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/CompactSketchWithDoubleSummaryTest.java
@@ -30,7 +30,6 @@ import org.apache.datasketches.tuple.adouble.DoubleSummaryFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class CompactSketchWithDoubleSummaryTest {
   private final DoubleSummary.Mode mode = Mode.Sum;
 

--- a/src/test/java/org/apache/datasketches/tuple/JaccardSimilarityTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/JaccardSimilarityTest.java
@@ -37,7 +37,6 @@ import static org.testng.Assert.assertTrue;
  * @author Lee Rhodes
  * @author David Cromberge
  */
-@SuppressWarnings("javadoc")
 public class JaccardSimilarityTest {
   private final DoubleSummary.Mode umode = DoubleSummary.Mode.Sum;
   private final DoubleSummarySetOperations dsso = new DoubleSummarySetOperations();

--- a/src/test/java/org/apache/datasketches/tuple/MiscTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/MiscTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class MiscTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/ReadOnlyMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/ReadOnlyMemoryTest.java
@@ -30,7 +30,6 @@ import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketc
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/SerialVersion3Test.java
+++ b/src/test/java/org/apache/datasketches/tuple/SerialVersion3Test.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.Memory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class SerialVersion3Test {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/SerializerDeserializerTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/SerializerDeserializerTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.Memory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class SerializerDeserializerTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/TestUtil.java
+++ b/src/test/java/org/apache/datasketches/tuple/TestUtil.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("javadoc")
 public class TestUtil {
   public static List<Double> asList(final double[] array) {
     final List<Double> list = new ArrayList<>(array.length);

--- a/src/test/java/org/apache/datasketches/tuple/TupleExamples2Test.java
+++ b/src/test/java/org/apache/datasketches/tuple/TupleExamples2Test.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
    * Tests for Version 2.0.0
    * @author Lee Rhodes
    */
-  @SuppressWarnings("javadoc")
   public class TupleExamples2Test {
     private final DoubleSummary.Mode umode = Mode.Sum;
     private final DoubleSummary.Mode imode = Mode.AlwaysOne;

--- a/src/test/java/org/apache/datasketches/tuple/TupleExamplesTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/TupleExamplesTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
  * Tests for Version 2.0.0
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class TupleExamplesTest {
   private final IntegerSummary.Mode umode = Mode.Sum;
   private final IntegerSummary.Mode imode = Mode.AlwaysOne;

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleAnotBTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleAnotBTest.java
@@ -39,7 +39,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class AdoubleAnotBTest {
   private static final DoubleSummary.Mode mode = Mode.Sum;
   private final Results results = new Results();

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleIntersectionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleIntersectionTest.java
@@ -39,7 +39,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class AdoubleIntersectionTest {
   private final DoubleSummary.Mode mode = Mode.Sum;
 

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleTest.java
@@ -33,7 +33,6 @@ import org.apache.datasketches.tuple.adouble.DoubleSummary.Mode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class AdoubleTest {
   private final DoubleSummary.Mode mode = Mode.Sum;
 

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleUnionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleUnionTest.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class AdoubleUnionTest {
   private final DoubleSummary.Mode mode = Mode.Sum;
 

--- a/src/test/java/org/apache/datasketches/tuple/adouble/FilterTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/FilterTest.java
@@ -30,7 +30,6 @@ import org.apache.datasketches.tuple.adouble.DoubleSummary.Mode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class FilterTest {
     private static final int numberOfElements = 100;
     private static final Random random = new Random(1);//deterministic for this class

--- a/src/test/java/org/apache/datasketches/tuple/aninteger/EngagementTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/aninteger/EngagementTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class EngagementTest {
   public static final int numStdDev = 2;
 

--- a/src/test/java/org/apache/datasketches/tuple/aninteger/IntegerSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/aninteger/IntegerSketchTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class IntegerSketchTest {
 
   @SuppressWarnings("deprecation")

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesAnotBTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesAnotBTest.java
@@ -27,7 +27,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ArrayOfDoublesAnotBTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesCompactSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesCompactSketchTest.java
@@ -27,7 +27,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ArrayOfDoublesCompactSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesIntersectionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesIntersectionTest.java
@@ -26,7 +26,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ArrayOfDoublesIntersectionTest {
 
   private static ArrayOfDoublesCombiner combiner = new ArrayOfDoublesCombiner() {

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketchTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ArrayOfDoublesQuickSelectSketchTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnionTest.java
@@ -29,7 +29,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class ArrayOfDoublesUnionTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesCompactSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesCompactSketchTest.java
@@ -27,7 +27,6 @@ import org.apache.datasketches.tuple.Util;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class DirectArrayOfDoublesCompactSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketchTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class DirectArrayOfDoublesQuickSelectSketchTest {
   @Test
   public void isEmpty() {

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/HeapArrayOfDoublesCompactSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/HeapArrayOfDoublesCompactSketchTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class HeapArrayOfDoublesCompactSketchTest {
 
   @Test

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/HeapArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/HeapArrayOfDoublesQuickSelectSketchTest.java
@@ -25,7 +25,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("javadoc")
 public class HeapArrayOfDoublesQuickSelectSketchTest {
   @Test
   public void isEmpty() {

--- a/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketchTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ArrayOfStringsSketchTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSummaryTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSummaryTest.java
@@ -32,7 +32,6 @@ import org.apache.datasketches.tuple.DeserializeResult;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("javadoc")
 public class ArrayOfStringsSummaryTest {
 
   @Test


### PR DESCRIPTION
This is a lot of files but THERE ARE NO CODE CHANGES!  

This is a cleanup of unnecessary SuppressWarnings  across the whole datasketches-java library.

The vast majority of these warnings were unnecessary SuppressWarnings("javadoc") which were placed at the top of every test file. We don't require javadocs of our test files and they should never be published. This kind of suppression should be done at a global level and not in each file, which just added clutter to the code.

There were also a few Checkstyle warnings of extra empty lines.  

I wanted to clean this up before we start working on the next release.