### PR TITLE
Test windows

### DIFF
--- a/.github/workflows/auto-jdk-matrix.yml
+++ b/.github/workflows/auto-jdk-matrix.yml
@@ -1,4 +1,4 @@
-name: Java Test Coverage with Maven, Coveralls
+name: DataSketches-Java Auto JDK Matrix Test & Install
 
 on:
     pull_request:
@@ -7,18 +7,16 @@ on:
     workflow_dispatch:
 
 env:
-    MAVEN_OPTS: -Xmx4g -Xms1g
-    repo_token: ${{secrets.coveralls_token}}
+    MAVEN_OPTS: -Xmx4g -Xms1g #for JVM
 
 jobs:
     build:
-        name: Build, Test, Coverage
+        name: Build, Test, Install
         runs-on: ubuntu-latest
         strategy:
           fail-fast: false
           matrix:
-              #jdk: [ 8,11,12,13 ]
-              jdk: [ 8 ]
+              jdk: [ 8,11 ]
         env:
           JDK_VERSION: ${{ matrix.jdk }}
 
@@ -43,8 +41,6 @@ jobs:
               java-package: jdk
               architecture: x64 #options: x86, x64, armv7, aarch64, ppc64le
               #cache #option
-              #impl: hotspot #deprecated
-              #targets: 'JAVA_HOME' #deprecated
 
         - name: Echo Java Version
           run: >
@@ -56,16 +52,9 @@ jobs:
               -Dmaven.javadoc.skip=true
               -Dgpg.skip=true
 
-        - name: Install Dependencies
+        - name: Install
           run: >
-              mvn clean install -B -V -q
+              mvn clean install -B -q
               -DskipTests=true
               -Dgpg.skip=true
 
-        - name: Report
-          if: ${{ matrix.jdk == 8 && success() }}
-          run: >
-              mvn verify coveralls:report -B -V -q
-              -Dcoveralls-repo-token=${repo_token}
-              -Dmaven.javadoc.skip=true
-              -Dgpg.skip=true

--- a/.github/workflows/manual-coverage.yml
+++ b/.github/workflows/manual-coverage.yml
@@ -1,0 +1,67 @@
+name: Datasketches-Java Manual Coverage Report
+
+on:
+    workflow_dispatch:
+
+env:
+    MAVEN_OPTS: -Xmx4g -Xms1g #for JVM
+
+jobs:
+    build:
+        name: Build, Test, Coverage
+        runs-on: ${{matrix.os}}
+        strategy:
+          fail-fast: false
+          matrix:
+            jdk: [ 8 ] # must include 8
+            os: [ ubuntu-latest ]
+            include:
+              - os: macos-latest
+                skip_javadoc: -Dmaven.javadoc.skip=true
+                skip_gpg: -Dgpg.skip=true
+              - os: ubuntu-latest
+                skip_javadoc: -Dmaven.javadoc.skip=true
+                skip_gpg: -Dgpg.skip=true
+              - os: windows-latest
+                skip_javadoc: "`-Dmaven`.javadoc`.skip=true"
+                skip_gpg: "`-Dgpg`.skip=true"
+
+        env:
+          JDK_VERSION: ${{ matrix.jdk }}
+
+        steps:
+        - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+          uses: actions/checkout@v3
+          with:
+              persist-credentials: false
+
+        - name: Cache local Maven repository
+          uses: actions/cache@v3
+          with:
+              path: ~/.m2/repository
+              key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+              restore-keys: build-${{ runner.os }}-maven-
+
+        - name: Install Matrix JDK
+          uses: actions/setup-java@v3
+          with:
+              java-version: ${{ matrix.jdk }}
+              distribution: 'temurin'
+              java-package: jdk
+              architecture: x64 #options: x86, x64, armv7, aarch64, ppc64le
+              #cache #option
+
+        - name: Echo Java Version
+          run: >
+              java -version
+
+        - name: Test, Package, Verify, Coverage Report
+          if: ${{ matrix.jdk == 8 && success() }}
+          run: >
+              # Lifecycle: validate, compile, test, package, verify, install, deploy
+              # Coverage reports are available after the verify phase
+              # -B batch mode, -V show Version without stoppping, -q quiet, only show errors
+              mvn verify coveralls:report -B
+              -DrepoToken=${{secrets.coveralls_token}}
+              ${{matrix.os.skip_javadoc}}
+              ${{matrix.os.skip_gpg}}

--- a/.github/workflows/manual-os-matrix.yml
+++ b/.github/workflows/manual-os-matrix.yml
@@ -1,21 +1,19 @@
-name: Test Java with OS Matrix
+name: DataSketches-Java Manual OS Matrix Test & Install
 
 on:
     workflow_dispatch:
-        
+
 env:
-    MAVEN_OPTS: -Xmx4g -Xms1g
+    MAVEN_OPTS: -Xmx4g -Xms1g #for JVM
 
 jobs:
     build:
-        name: Build, Test, Coverage
+        name: Build, Test, Install
         runs-on: ${{matrix.os}}
         strategy:
           fail-fast: false
           matrix:
-            #jdk: [ 8,11,12,13 ]
             jdk: [ 8 ]
-            # OS options: windows-latest, ubuntu-latest, macos-latest
             os: [ windows-latest, ubuntu-latest, macos-latest ]
             include:
               - os: windows-latest
@@ -45,12 +43,13 @@ jobs:
               restore-keys: build-${{ runner.os }}-maven-
 
         - name: Install Matrix JDK
-          uses: AdoptOpenJDK/install-jdk@v1
+          uses: actions/setup-java@v3
           with:
-              version: ${{ matrix.jdk }}
-              architecture: x64
-              impl: hotspot
-              targets: 'JAVA_HOME'
+              java-version: ${{ matrix.jdk }}
+              distribution: 'temurin'
+              java-package: jdk
+              architecture: x64 #options: x86, x64, armv7, aarch64, ppc64le
+              #cache #option
 
         - name: Echo Java Version
           run: >
@@ -62,20 +61,13 @@ jobs:
               ${{matrix.os.skip_javadoc}}
               ${{matrix.os.skip_gpg}}
 
-        - name: Install Dependencies
+        - name: Install
           run: >
-              #-B batch mode, -V show Version without stoppping, -q quiet, only show errors
-              mvn clean install -B -V -q
+              # -B batch mode
+              # -V show Version without stoppping
+              # -q quiet, only show errors
+              mvn clean install -B -q
+              ${{matrix.os.skip_javadoc}}
               -D skipTests=true
               ${{matrix.os.skip_gpg}}
 
-        - name: Report
-          if: ${{ matrix.jdk == 8 && success() }}
-          run: >
-              #Lifecycle:validate,compile,test,package,verify,install,deploy
-              #test and coverage reports are available after the verify phase
-              #Javadocs are available after compile
-              mvn verify coveralls:report -B -V -q
-              -DrepoToken=${{secrets.coveralls_token}}
-              ${{matrix.os.skip_javadoc}}
-              ${{matrix.os.skip_gpg}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,31 +17,34 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-              jdk: [ 8,11,12,13 ]
-
+              #jdk: [ 8,11,12,13 ]
+              jdk: [ 8 ]
         env:
           JDK_VERSION: ${{ matrix.jdk }}
 
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
               persist-credentials: false
 
         - name: Cache local Maven repository
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
               path: ~/.m2/repository
               key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
               restore-keys: build-${{ runner.os }}-maven-
 
         - name: Install Matrix JDK
-          uses: AdoptOpenJDK/install-jdk@v1
+          uses: actions/setup-java@v3
           with:
-              version: ${{ matrix.jdk }}
-              architecture: x64
-              impl: hotspot
-              targets: 'JAVA_HOME'
+              java-version: ${{ matrix.jdk }}
+              distribution: 'temurin'
+              java-package: jdk
+              architecture: x64 #options: x86, x64, armv7, aarch64, ppc64le
+              #cache #option
+              #impl: hotspot #deprecated
+              #targets: 'JAVA_HOME' #deprecated
 
         - name: Echo Java Version
           run: >

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -69,6 +69,6 @@ jobs:
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q
-              -D coveralls-repo-token=${{repo_token}}
+              -D coveralls-repo-token="${repo_token}"
               ${{matrix.os.skip_javadoc}}
               ${{matrix.os.skip_gpg}}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -5,7 +5,6 @@ on:
         
 env:
     MAVEN_OPTS: -Xmx4g -Xms1g
-    #repo_token: ${{secrets.coveralls_token}}
 
 jobs:
     build:
@@ -16,12 +15,16 @@ jobs:
           matrix:
             #jdk: [ 8,11,12,13 ]
             jdk: [ 8 ]
-            os: [ windows-latest, ubuntu-latest ]
+            # OS options: windows-latest, ubuntu-latest, macos-latest
+            os: [ windows-latest, ubuntu-latest, macos-latest ]
             include:
               - os: windows-latest
                 skip_javadoc: "`-Dmaven`.javadoc`.skip=true"
                 skip_gpg: "`-Dgpg`.skip=true"
               - os: ubuntu-latest
+                skip_javadoc: -Dmaven.javadoc.skip=true
+                skip_gpg: -Dgpg.skip=true
+              - os: macos-latest
                 skip_javadoc: -Dmaven.javadoc.skip=true
                 skip_gpg: -Dgpg.skip=true
 
@@ -30,12 +33,12 @@ jobs:
 
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
               persist-credentials: false
 
         - name: Cache local Maven repository
-          uses: actions/cache@v2
+          uses: actions/cache@v3
           with:
               path: ~/.m2/repository
               key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -61,6 +64,7 @@ jobs:
 
         - name: Install Dependencies
           run: >
+              #-B batch mode, -V show Version without stoppping, -q quiet, only show errors
               mvn clean install -B -V -q
               -D skipTests=true
               ${{matrix.os.skip_gpg}}
@@ -68,6 +72,9 @@ jobs:
         - name: Report
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
+              #Lifecycle:validate,compile,test,package,verify,install,deploy
+              #test and coverage reports are available after the verify phase
+              #Javadocs are available after compile
               mvn verify coveralls:report -B -V -q
               -DrepoToken=${{secrets.coveralls_token}}
               ${{matrix.os.skip_javadoc}}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -5,7 +5,7 @@ on:
         
 env:
     MAVEN_OPTS: -Xmx4g -Xms1g
-    repo_token: ${{secrets.coveralls_token}}
+    #repo_token: ${{secrets.coveralls_token}}
 
 jobs:
     build:
@@ -69,6 +69,6 @@ jobs:
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q
-              -D coveralls-repo-token=${{secrets.coveralls_token}}
+              -DrepoToken=${{secrets.coveralls_token}}
               ${{matrix.os.skip_javadoc}}
               ${{matrix.os.skip_gpg}}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -10,11 +10,25 @@ env:
 jobs:
     build:
         name: Build, Test, Coverage
-        runs-on: windows-latest
+        runs-on: ${{matrix.os.os_name}}
         strategy:
           fail-fast: false
           matrix:
               jdk: [ 8,11,12,13 ]
+	      os:
+	      - {
+	          name: "Windows",
+		  os_name: windows-latest
+		  skip_javadoc: `-Dmaven`.javadoc`.skip=true
+		  skip_gpg: `-Dgpg`.skip=true
+		}
+	      - {
+	          name: "Ubuntu",
+		  os_name: ubuntu-latest
+		  skip_javadoc: -Dmaven.javadoc.skip=true
+		  skip_gpg: -Dgpg.skip=true
+		}
+	          
 
         env:
           JDK_VERSION: ${{ matrix.jdk }}
@@ -47,19 +61,19 @@ jobs:
         - name: Test
           run: >
               mvn clean test
-              -Dmaven.javadoc.skip=true
-              -Dgpg.skip=true
+              ${{matrix.os.skip_javadoc}}
+              ${{matrix.os.skip_gpg}}
 
         - name: Install Dependencies
           run: >
               mvn clean install -B -V -q
-              -DskipTests=true
-              -Dgpg.skip=true
+              -D skipTests=true
+              ${{matrix.os.skip_gpg}}
 
         - name: Report
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q
-              -Dcoveralls-repo-token=${repo_token}
-              -Dmaven.javadoc.skip=true
-              -Dgpg.skip=true
+              -D coveralls-repo-token=${repo_token}
+              ${{matrix.os.skip_javadoc}}
+              ${{matrix.os.skip_gpg}}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -14,7 +14,8 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            jdk: [ 8,11,12,13 ]
+            #jdk: [ 8,11,12,13 ]
+            jdk: [ 8 ]
             os: [ windows-latest, ubuntu-latest ]
             include:
               - os: windows-latest
@@ -68,6 +69,6 @@ jobs:
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q
-              -D coveralls-repo-token=${repo_token}
+              -D coveralls-repo-token=${{repo_token}}
               ${{matrix.os.skip_javadoc}}
               ${{matrix.os.skip_gpg}}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -69,6 +69,6 @@ jobs:
           if: ${{ matrix.jdk == 8 && success() }}
           run: >
               mvn verify coveralls:report -B -V -q
-              -D coveralls-repo-token="${repo_token}"
+              -D coveralls-repo-token=${{secrets.coveralls_token}}
               ${{matrix.os.skip_javadoc}}
               ${{matrix.os.skip_gpg}}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -18,8 +18,8 @@ jobs:
             os: [ windows-latest, ubuntu-latest ]
             include:
               - os: windows-latest
-                skip_javadoc: `-Dmaven`.javadoc`.skip=true
-                skip_gpg: `-Dgpg`.skip=true
+                skip_javadoc: "`-Dmaven`.javadoc`.skip=true"
+                skip_gpg: "`-Dgpg`.skip=true"
               - os: ubuntu-latest
                 skip_javadoc: -Dmaven.javadoc.skip=true
                 skip_gpg: -Dgpg.skip=true

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -10,25 +10,19 @@ env:
 jobs:
     build:
         name: Build, Test, Coverage
-        runs-on: ${{matrix.os.os_name}}
+        runs-on: ${{matrix.os}}
         strategy:
           fail-fast: false
           matrix:
               jdk: [ 8,11,12,13 ]
-	      os:
-	      - {
-	          name: "Windows",
-		  os_name: windows-latest
+	      os: [ windows-latest, ubuntu-latest ]
+	      include:
+	        - os: windows-latest
 		  skip_javadoc: `-Dmaven`.javadoc`.skip=true
 		  skip_gpg: `-Dgpg`.skip=true
-		}
-	      - {
-	          name: "Ubuntu",
-		  os_name: ubuntu-latest
+	        - os: ubuntu-latest
 		  skip_javadoc: -Dmaven.javadoc.skip=true
 		  skip_gpg: -Dgpg.skip=true
-		}
-	          
 
         env:
           JDK_VERSION: ${{ matrix.jdk }}

--- a/.github/workflows/test_os_matrix.yml
+++ b/.github/workflows/test_os_matrix.yml
@@ -14,15 +14,15 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-              jdk: [ 8,11,12,13 ]
-	      os: [ windows-latest, ubuntu-latest ]
-	      include:
-	        - os: windows-latest
-		  skip_javadoc: `-Dmaven`.javadoc`.skip=true
-		  skip_gpg: `-Dgpg`.skip=true
-	        - os: ubuntu-latest
-		  skip_javadoc: -Dmaven.javadoc.skip=true
-		  skip_gpg: -Dgpg.skip=true
+            jdk: [ 8,11,12,13 ]
+            os: [ windows-latest, ubuntu-latest ]
+            include:
+              - os: windows-latest
+                skip_javadoc: `-Dmaven`.javadoc`.skip=true
+                skip_gpg: `-Dgpg`.skip=true
+              - os: ubuntu-latest
+                skip_javadoc: -Dmaven.javadoc.skip=true
+                skip_gpg: -Dgpg.skip=true
 
         env:
           JDK_VERSION: ${{ matrix.jdk }}

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@ under the License.
     <project.build.sourceEncoding>${charset.encoding}</project.build.sourceEncoding>
     <project.build.resourceEncoding>${charset.encoding}</project.build.resourceEncoding>
     <project.reporting.outputEncoding>${charset.encoding}</project.reporting.outputEncoding>
+    <maven.build.timestamp.format>yyyy-MM-dd'T'HH-mm-ss'Z'</maven.build.timestamp.format>
 
     <!-- org.codehaus plugins -->
     <!-- used for strict profile testing-->


### PR DESCRIPTION
Added a separate coverage workflow, simplified the manual OS matrix, and removed coverage from the auto-jdk-matrix