### PR TITLE
Theta compact iterator

### DIFF
--- a/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
@@ -113,7 +113,7 @@ final class EmptyCompactSketch extends CompactSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(new long[0], Long.MAX_VALUE);
+    return new HeapCompactHashIterator(new long[0]);
   }
 
   /**

--- a/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
@@ -113,7 +113,7 @@ final class EmptyCompactSketch extends CompactSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(new long[0], 0, Long.MAX_VALUE);
+    return new HeapHashIterator(new long[0], Long.MAX_VALUE);
   }
 
   /**

--- a/src/main/java/org/apache/datasketches/theta/HeapAlphaSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapAlphaSketch.java
@@ -163,7 +163,7 @@ final class HeapAlphaSketch extends HeapUpdateSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(cache_, 1 << lgArrLongs_, thetaLong_);
+    return new HeapHashIterator(cache_, thetaLong_);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/HeapCompactHashIterator.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapCompactHashIterator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.theta;
+
+class HeapCompactHashIterator implements HashIterator {
+  private long[] cache;
+  private int index;
+
+  HeapCompactHashIterator(final long[] cache) {
+    this.cache = cache;
+    index = -1;
+  }
+
+  @Override
+  public long get() {
+    return cache[index];
+  }
+
+  @Override
+  public boolean next() {
+    return ++index < cache.length;
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/theta/HeapCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapCompactSketch.java
@@ -123,7 +123,7 @@ class HeapCompactSketch extends CompactSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(cache_, cache_.length, thetaLong_);
+    return new HeapCompactHashIterator(cache_);
   }
 
   //restricted methods

--- a/src/main/java/org/apache/datasketches/theta/HeapHashIterator.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapHashIterator.java
@@ -24,14 +24,12 @@ package org.apache.datasketches.theta;
  */
 class HeapHashIterator implements HashIterator {
   private long[] cache;
-  private int arrLongs;
   private long thetaLong;
   private int index;
   private long hash;
 
-  HeapHashIterator(final long[] cache, final int arrLongs, final long thetaLong) {
+  HeapHashIterator(final long[] cache, final long thetaLong) {
     this.cache = cache;
-    this.arrLongs = arrLongs;
     this.thetaLong = thetaLong;
     index = -1;
     hash = 0;
@@ -44,7 +42,7 @@ class HeapHashIterator implements HashIterator {
 
   @Override
   public boolean next() {
-    while (++index < arrLongs) {
+    while (++index < cache.length) {
       hash = cache[index];
       if ((hash != 0) && (hash < thetaLong)) {
         return true;

--- a/src/main/java/org/apache/datasketches/theta/HeapQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapQuickSelectSketch.java
@@ -166,7 +166,7 @@ class HeapQuickSelectSketch extends HeapUpdateSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(cache_, 1 << lgArrLongs_, thetaLong_);
+    return new HeapHashIterator(cache_, thetaLong_);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
@@ -320,7 +320,7 @@ final class SingleItemSketch extends CompactSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(new long[] { hash_ }, Long.MAX_VALUE);
+    return new HeapCompactHashIterator(new long[] { hash_ });
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
@@ -320,7 +320,7 @@ final class SingleItemSketch extends CompactSketch {
 
   @Override
   public HashIterator iterator() {
-    return new HeapHashIterator(new long[] { hash_ }, 1, Long.MAX_VALUE);
+    return new HeapHashIterator(new long[] { hash_ }, Long.MAX_VALUE);
   }
 
   @Override


### PR DESCRIPTION
Added HeapCompactHashIterator that does not need to check hash values for 0 and less than theta.
Removed unnecessary member in HeapHashIterator.