### PR TITLE
gitignore needed to be updated to ignore *.iml files in directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # IntelliJ project files
 *.idea
-*.iml
+**/*.iml
 *.ipr
 *.iws
 
@@ -14,7 +14,7 @@
 .clover/
 
 # OSX files
-.DS_Store
+**/.DS_Store
 
 # Compiler output, class files
 *.class

--- a/src/test/java/org/apache/datasketches/quantilescommon/GenericInequalitySearchTest.java
+++ b/src/test/java/org/apache/datasketches/quantilescommon/GenericInequalitySearchTest.java
@@ -287,7 +287,7 @@ public class GenericInequalitySearchTest {
     return "";
   }
 
-  private final static boolean enablePrinting = true;
+  private final static boolean enablePrinting = false;
 
   /**
    * @param format the format


### PR DESCRIPTION
below the root.

Test printing was accidentally left on in the
GenericInequalitySearchTest. Fixed.