### PR TITLE
Minor updates

### DIFF
--- a/src/main/java/org/apache/datasketches/common/Util.java
+++ b/src/main/java/org/apache/datasketches/common/Util.java
@@ -59,13 +59,13 @@ public final class Util {
   /**
    * The inverse golden ratio as an unsigned long.
    */
-  public static final long iGoldenU64 = 0x9e3779b97f4a7c13L;
+  public static final long INVERSE_GOLDEN_U64 = 0x9e3779b97f4a7c13L;
 
   /**
    * The inverse golden ratio as a fraction.
    * This has more precision than using the formula: (Math.sqrt(5.0) - 1.0) / 2.0.
    */
-  public static final double iGolden = 0.6180339887498949025; // the inverse golden ratio
+  public static final double INVERSE_GOLDEN = 0.6180339887498949025;
 
   /**
    * Long.MAX_VALUE as a double.
@@ -139,12 +139,12 @@ public final class Util {
   //Byte array conversions
 
   static long[] convertToLongArray(final byte[] byteArr, final boolean littleEndian) {
-    int len = byteArr.length;
-    long[] longArr = new long[len / 8 + (len % 8 != 0 ? 1 : 0)];
+    final int len = byteArr.length;
+    final long[] longArr = new long[len / 8 + (len % 8 != 0 ? 1 : 0)];
     int off = 0;
     int longArrIdx = 0;
     while (off < len) {
-      int rem = Math.min(len - 1 - off, 7);
+      final int rem = Math.min(len - 1 - off, 7);
       long tgt = 0;
       if (littleEndian) {
         for (int j = off + rem, k = 0; j >= off; --j, k++) {
@@ -160,9 +160,6 @@ public final class Util {
     }
     return longArr;
   }
-
-
-
 
   //String Related
 

--- a/src/main/java/org/apache/datasketches/cpc/CompressionCharacterization.java
+++ b/src/main/java/org/apache/datasketches/cpc/CompressionCharacterization.java
@@ -20,7 +20,7 @@
 package org.apache.datasketches.cpc;
 
 import static org.apache.datasketches.common.Util.ceilingIntPowerOf2;
-import static org.apache.datasketches.common.Util.iGoldenU64;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN_U64;
 import static org.apache.datasketches.common.Util.log2;
 import static org.apache.datasketches.common.Util.powerSeriesNextDouble;
 import static org.apache.datasketches.cpc.CompressedState.importFromMemory;
@@ -157,7 +157,7 @@ public class CompressionCharacterization {
       for (int trial = 0; trial < trialsPerWave; trial++) {
         final CpcSketch sketch = streamSketches[trial];
         for (long i = 0; i < n; i++) { //increment loop
-          sketch.update(vIn += iGoldenU64);
+          sketch.update(vIn += INVERSE_GOLDEN_U64);
         }
       }
       nanoEnd = System.nanoTime();

--- a/src/main/java/org/apache/datasketches/cpc/CpcUnion.java
+++ b/src/main/java/org/apache/datasketches/cpc/CpcUnion.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.cpc;
 
-import static org.apache.datasketches.common.Util.iGolden;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN;
 import static org.apache.datasketches.cpc.CpcUtil.countBitsSetInMatrix;
 import static org.apache.datasketches.cpc.Flavor.EMPTY;
 import static org.apache.datasketches.cpc.Flavor.SPARSE;
@@ -187,7 +187,7 @@ public class CpcUnion {
     /* Using the inverse golden ratio stride fixes the
      * <a href="{@docRoot}/resources/dictionary.html#SnowPlow">Snow Plow Effect</a>.
      */
-    int stride =  (int) (iGolden * numSlots);
+    int stride =  (int) (INVERSE_GOLDEN * numSlots);
     assert stride >= 2;
     if (stride == ((stride >>> 1) << 1)) { stride += 1; } //force the stride to be odd
     assert (stride >= 3) && (stride < numSlots);

--- a/src/main/java/org/apache/datasketches/cpc/MergingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/MergingValidation.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.cpc;
 
-import static org.apache.datasketches.common.Util.iGoldenU64;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN_U64;
 import static org.apache.datasketches.common.Util.powerSeriesNextDouble;
 import static org.apache.datasketches.cpc.IconEstimator.getIconEstimate;
 import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssert;
@@ -128,12 +128,12 @@ public class MergingValidation {
     final CpcSketch skB = new CpcSketch(lgKb);
 
     for (long i = 0; i < nA; i++) {
-      final long in = (vIn += iGoldenU64);
+      final long in = (vIn += INVERSE_GOLDEN_U64);
       skA.update(in);
       skD.update(in);
     }
     for (long i = 0; i < nB; i++) {
-      final long in = (vIn += iGoldenU64);
+      final long in = (vIn += INVERSE_GOLDEN_U64);
       skB.update(in);
       skD.update(in);
     }

--- a/src/main/java/org/apache/datasketches/cpc/QuickMergingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/QuickMergingValidation.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.cpc;
 
-import static org.apache.datasketches.common.Util.iGoldenU64;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN_U64;
 import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssert;
 
 import java.io.PrintStream;
@@ -102,13 +102,13 @@ public class QuickMergingValidation {
 
     t0 = System.nanoTime();
     while (skA.numCoupons < cA) {
-      final long in = vIn += iGoldenU64;
+      final long in = vIn += INVERSE_GOLDEN_U64;
       skA.update(in);
       skD.update(in);
     }
     t1 = System.nanoTime();
     while (skB.numCoupons < cB) {
-      final long in = vIn += iGoldenU64;
+      final long in = vIn += INVERSE_GOLDEN_U64;
       skB.update(in);
       skD.update(in);
     }

--- a/src/main/java/org/apache/datasketches/cpc/StreamingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/StreamingValidation.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.cpc;
 
-import static org.apache.datasketches.common.Util.iGoldenU64;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN_U64;
 import static org.apache.datasketches.common.Util.powerSeriesNextDouble;
 import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssertEquals;
 
@@ -112,7 +112,7 @@ public class StreamingValidation {
       sketch.reset();
       matrix.reset();
       for (long i = 0; i < n; i++) {
-        final long in = (vIn += iGoldenU64);
+        final long in = (vIn += INVERSE_GOLDEN_U64);
         sketch.update(in);
         matrix.update(in);
       }

--- a/src/main/java/org/apache/datasketches/fdt/Group.java
+++ b/src/main/java/org/apache/datasketches/fdt/Group.java
@@ -121,7 +121,7 @@ public class Group implements Comparable<Group> {
   }
 
   @Override
-  public boolean equals(Object that) {
+  public boolean equals(final Object that) {
     if (this == that) { return true; }
     if (!(that instanceof Group)) { return false; }
     return ((Group)that).count == count;

--- a/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/frequencies/ItemsSketch.java
@@ -278,7 +278,7 @@ public class ItemsSketch<T> {
 
     //Get countArray
     final long[] countArray = new long[activeItems];
-    int reqBytes = preBytes + activeItems * Long.BYTES; //count Arr only
+    final int reqBytes = preBytes + activeItems * Long.BYTES; //count Arr only
     checkBounds(0, reqBytes, srcMem.getCapacity()); //check Memory capacity
     srcMem.getLongArray(preBytes, countArray, 0, activeItems);
 

--- a/src/main/java/org/apache/datasketches/frequencies/ReversePurgeLongHashMap.java
+++ b/src/main/java/org/apache/datasketches/frequencies/ReversePurgeLongHashMap.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.frequencies;
 
 import static org.apache.datasketches.common.Util.LS;
 import static org.apache.datasketches.common.Util.exactLog2OfInt;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN;
 import static org.apache.datasketches.frequencies.Util.hash;
 
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -373,8 +374,6 @@ class ReversePurgeLongHashMap {
 
   // This iterator uses strides based on golden ratio to avoid clustering during merge
   static class Iterator {
-    private static final double GOLDEN_RATIO_RECIPROCAL = (Math.sqrt(5) - 1) / 2; //.618...
-
     private final long[] keys_;
     private final long[] values_;
     private final short[] states_;
@@ -389,7 +388,7 @@ class ReversePurgeLongHashMap {
       values_ = values;
       states_ = states;
       numActive_ = numActive;
-      stride_ = (int) (keys.length * GOLDEN_RATIO_RECIPROCAL) | 1;
+      stride_ = (int) (keys.length * INVERSE_GOLDEN) | 1;
       mask_ = keys.length - 1;
       i_ = -stride_;
       count_ = 0;

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -200,7 +200,6 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
     return kllDoublesSV.getQuantile(rank, searchCrit);
   }
 
-  @Deprecated
   @Override
   public double[] getQuantiles(final double[] ranks, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -213,7 +212,6 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
     return quantiles;
   }
 
-  @Deprecated
   @Override
   public double[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -268,7 +266,6 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
     return min(1.0, rank + KllHelper.getNormalizedRankError(getMinK(), false));
   }
 
-  @Deprecated
   @Override
   public double[] getRanks(final double[] quantiles, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -200,7 +200,6 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
     return kllFloatsSV.getQuantile(rank, searchCrit);
   }
 
-  @Deprecated
   @Override
   public float[] getQuantiles(final double[] ranks, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -213,7 +212,6 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
     return quantiles;
   }
 
-  @Deprecated
   @Override
   public float[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -268,7 +266,6 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
     return min(1.0, rank + KllHelper.getNormalizedRankError(getMinK(), false));
   }
 
-  @Deprecated
   @Override
   public double[] getRanks(final float[] quantiles, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesSketch.java
@@ -166,26 +166,25 @@ public abstract class DoublesSketch implements QuantilesDoublesAPI {
 
   @Override
   public double[] getCDF(final double[] splitPoints, final QuantileSearchCriteria searchCrit) {
-	if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+  if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();
     return classicQdsSV.getCDF(splitPoints, searchCrit);
   }
 
   @Override
   public double[] getPMF(final double[] splitPoints, final QuantileSearchCriteria searchCrit) {
-	if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+  if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();
     return classicQdsSV.getPMF(splitPoints, searchCrit);
   }
 
   @Override
   public double getQuantile(final double rank, final QuantileSearchCriteria searchCrit) {
-	if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+  if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();
     return classicQdsSV.getQuantile(rank, searchCrit);
   }
 
-  @Deprecated
   @Override
   public double[] getQuantiles(final double[] ranks, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -198,7 +197,6 @@ public abstract class DoublesSketch implements QuantilesDoublesAPI {
     return quantiles;
   }
 
-  @Deprecated
   @Override
   public double[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -253,7 +251,6 @@ public abstract class DoublesSketch implements QuantilesDoublesAPI {
     return min(1.0, rank + ClassicUtil.getNormalizedRankError(k_, false));
   }
 
-  @Deprecated
   @Override
   public double[] getRanks(final double[] quantiles, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
@@ -324,8 +324,8 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @throws IllegalArgumentException if sketch is empty.
    */
   public T getMaxItem() {
-	  if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-	  return maxItem_;
+    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+    return maxItem_;
   }
 
   /**
@@ -338,8 +338,8 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @throws IllegalArgumentException if sketch is empty.
    */
   public T getMinItem() {
-	  if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-	  return minItem_;
+    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+    return minItem_;
   }
 
   /**
@@ -395,7 +395,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @throws IllegalArgumentException if sketch is empty.
    */
   public double[] getPMF(final T[] splitPoints, final QuantileSearchCriteria searchCrit) {
-	if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+  if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();
     return classicQisSV.getPMF(splitPoints, searchCrit);
   }
@@ -425,7 +425,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   public T getQuantile(final double rank, final QuantileSearchCriteria searchCrit) {
-	if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();
     return classicQisSV.getQuantile(rank, searchCrit);
   }
@@ -478,10 +478,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * in the interval [0.0,1.0].
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   public T[] getQuantiles(final double[] ranks) {
     return getQuantiles(ranks, INCLUSIVE);
   }
@@ -498,13 +495,10 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   @SuppressWarnings("unchecked")
   public T[] getQuantiles(final double[] ranks, final QuantileSearchCriteria searchCrit) {
-	if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();
     final int len = ranks.length;
     final T[] quantiles = (T[]) Array.newInstance(minItem_.getClass(), len);
@@ -519,10 +513,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @param numEvenlySpaced number of evenly spaced normalized ranks
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   public T[] getQuantiles(final int numEvenlySpaced) {
     return getQuantiles(numEvenlySpaced, INCLUSIVE);
   }
@@ -550,10 +541,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   public T[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     return getQuantiles(org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, numEvenlySpaced),
@@ -611,10 +599,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @param quantiles the given array of quantiles
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getRank(Object, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   public double[] getRanks(final T[] quantiles) {
     return getRanks(quantiles, INCLUSIVE);
   }
@@ -629,10 +614,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    * @throws IllegalArgumentException if sketch is empty.
    *
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getRank(Object, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   public double[] getRanks(final T[] quantiles, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     refreshSortedView();

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -206,10 +206,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * in the interval [0.0,1.0].
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   default double[] getQuantiles(double[] ranks) {
     return getQuantiles(ranks, INCLUSIVE);
   }
@@ -224,10 +221,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   double[] getQuantiles(double[] ranks, QuantileSearchCriteria searchCrit);
 
   /**
@@ -235,10 +229,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @param numEvenlySpaced number of evenly spaced normalized ranks
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   default double[] getQuantiles(int numEvenlySpaced) {
     return getQuantiles(numEvenlySpaced, INCLUSIVE);
   }
@@ -264,10 +255,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   double[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);
 
   /**
@@ -296,10 +284,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @param quantiles the given array of quantiles
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getRank(double, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   default double[] getRanks(double[] quantiles) {
     return getRanks(quantiles, INCLUSIVE);
   }
@@ -313,10 +298,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getRank(double, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   double[] getRanks(double[] quantiles, QuantileSearchCriteria searchCrit);
 
   /**

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -205,10 +205,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * in the interval [0.0,1.0].
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   default float[] getQuantiles(double[] ranks) {
     return getQuantiles(ranks, INCLUSIVE);
   }
@@ -223,10 +220,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   float[] getQuantiles(double[] ranks, QuantileSearchCriteria searchCrit);
 
   /**
@@ -234,10 +228,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @param numEvenlySpaced number of evenly spaced normalized ranks
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   default float[] getQuantiles(int numEvenlySpaced) {
     return getQuantiles(numEvenlySpaced, INCLUSIVE);
   }
@@ -263,10 +254,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   float[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);
 
   /**
@@ -295,10 +283,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @param quantiles the given array of quantiles
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getRank(float, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   default double[] getRanks(float[] quantiles) {
     return getRanks(quantiles, INCLUSIVE);
   }
@@ -312,10 +297,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getRank(float, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   double[] getRanks(float[] quantiles, QuantileSearchCriteria searchCrit);
 
   /**

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -206,10 +206,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * in the interval [0.0,1.0].
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   default T[] getQuantiles(double[] ranks) {
     return getQuantiles(ranks, INCLUSIVE);
   }
@@ -224,10 +221,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * @return an array of quantiles corresponding to the given array of normalized ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   T[] getQuantiles(double[] ranks, QuantileSearchCriteria searchCrit);
 
   /**
@@ -235,10 +229,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * @param numEvenlySpaced number of evenly spaced normalized ranks
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   default T[] getQuantiles(int numEvenlySpaced) {
     return getQuantiles(numEvenlySpaced, INCLUSIVE);
   }
@@ -264,10 +255,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * @return an array of quantiles that are evenly spaced by their ranks.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getQuantile(double, QuantileSearchCriteria)
-   * getQuantile(rank, searchCrit) in a loop.}
    */
-  @Deprecated
   T[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);
 
   /**
@@ -296,10 +284,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * @param quantiles the given array of quantiles
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
-   * @deprecated Use {@link #getRank(Object, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   default double[] getRanks(T[] quantiles) {
     return getRanks(quantiles, INCLUSIVE);
   }
@@ -313,10 +298,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * @return an array of normalized ranks corresponding to the given array of quantiles.
    * @throws IllegalArgumentException if sketch is empty.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   * @deprecated Use {@link #getRank(Object, QuantileSearchCriteria)
-   * getRank(quantile, searchCrit) in a loop.}
    */
-  @Deprecated
   double[] getRanks(T[] quantiles, QuantileSearchCriteria searchCrit);
 
   /**

--- a/src/main/java/org/apache/datasketches/req/BaseReqSketch.java
+++ b/src/main/java/org/apache/datasketches/req/BaseReqSketch.java
@@ -85,11 +85,9 @@ abstract class BaseReqSketch implements QuantilesFloatsAPI {
   @Override
   public abstract float getQuantile(double rank, QuantileSearchCriteria searchCrit);
 
-  @Deprecated
   @Override
   public abstract float[] getQuantiles(double[] normRanks, QuantileSearchCriteria searchCrit);
 
-  @Deprecated
   @Override
   public float[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -118,7 +116,6 @@ abstract class BaseReqSketch implements QuantilesFloatsAPI {
    */
   public abstract double getRankLowerBound(double rank, int numStdDev);
 
-  @Deprecated
   @Override
   public abstract double[] getRanks(float[] quantiles, QuantileSearchCriteria searchCrit);
 

--- a/src/main/java/org/apache/datasketches/req/ReqSketch.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSketch.java
@@ -248,7 +248,6 @@ public class ReqSketch extends BaseReqSketch {
     return reqSV.getQuantile(normRank, searchCrit);
   }
 
-  @Deprecated
   @Override
   public float[] getQuantiles(final double[] normRanks, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
@@ -313,7 +312,6 @@ public class ReqSketch extends BaseReqSketch {
     return getRankLB(k, getNumLevels(), rank, numStdDev, hra, getN());
   }
 
-  @Deprecated
   @Override
   public double[] getRanks(final float[] quantiles, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }

--- a/src/main/java/org/apache/datasketches/theta/BitPacking.java
+++ b/src/main/java/org/apache/datasketches/theta/BitPacking.java
@@ -23,7 +23,8 @@ import org.apache.datasketches.common.SketchesArgumentException;
 
 public class BitPacking {
 
-  public static void packBits(long value, int bits, byte[] buffer, int bufOffset, int bitOffset) {
+  public static void packBits(final long value, int bits, final byte[] buffer, int bufOffset, 
+      final int bitOffset) {
     if (bitOffset > 0) {
       final int chunkBits = 8 - bitOffset;
       final int mask = (1 << chunkBits) - 1;
@@ -43,7 +44,8 @@ public class BitPacking {
     }
   }
 
-  public static void unpackBits(long[] value, int index, int bits, byte[] buffer, int bufOffset, int bitOffset) {
+  public static void unpackBits(final long[] value, final int index, int bits, final byte[] buffer, 
+      int bufOffset,final int bitOffset) {
     final int availBits = 8 - bitOffset;
     final int chunkBits = availBits <= bits ? availBits : bits;
     final int mask = (1 << chunkBits) - 1;
@@ -66,7 +68,7 @@ public class BitPacking {
   // we assume that higher bits (which we are not packing) are zeros
   // this assumption allows to avoid masking operations
 
-  static void packBitsBlock8(long[] values, int i, byte[] buf, int off, int bits) {
+  static void packBitsBlock8(final long[] values, final int i, final byte[] buf, final int off, final int bits) {
     switch (bits) {
       case 1: packBits1(values, i, buf, off); break;
       case 2: packBits2(values, i, buf, off); break;
@@ -135,7 +137,7 @@ public class BitPacking {
     }
   }
 
-  static void unpackBitsBlock8(long[] values, int i, byte[] buf, int off, int bits) {
+  static void unpackBitsBlock8(final long[] values, final int i, final byte[] buf, final int off, final int bits) {
     switch (bits) {
       case 1: unpackBits1(values, i, buf, off); break;
       case 2: unpackBits2(values, i, buf, off); break;
@@ -204,7 +206,7 @@ public class BitPacking {
     }
   }
 
-  static void packBits1(long[] values, int i, byte[] buf, int off) {
+  static void packBits1(final long[] values, final int i, final byte[] buf, final int off) {
     buf[off] = (byte) (values[i + 0] << 7);
     buf[off] |= values[i + 1] << 6;
     buf[off] |= values[i + 2] << 5;
@@ -215,7 +217,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits2(long[] values, int i, byte[] buf, int off) {
+  static void packBits2(final long[] values, final int i, final byte[] buf, int off) {
     buf[off] = (byte) (values[i + 0] << 6);
     buf[off] |= values[i + 1] << 4;
     buf[off] |= values[i + 2] << 2;
@@ -227,7 +229,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits3(long[] values, int i, byte[] buf, int off) {
+  static void packBits3(final long[] values, final int i, final byte[] buf, int off) {
     buf[off] = (byte) (values[i + 0] << 5);
     buf[off] |= values[i + 1] << 2;
     buf[off++] |= values[i + 2] >>> 1;
@@ -242,7 +244,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits4(long[] values, int i, byte[] buf, int off) {
+  static void packBits4(final long[] values, final int i, final byte[] buf, int off) {
     buf[off] = (byte) (values[i + 0] << 4);
     buf[off++] |= values[i + 1];
 
@@ -256,7 +258,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits5(long[] values, int i, byte[] buf, int off) {
+  static void packBits5(final long[] values, final int i, final byte[] buf, int off) {
     buf[off] = (byte) (values[i + 0] << 3);
     buf[off++] |= values[i + 1] >>> 2;
 
@@ -275,7 +277,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits6(long[] values, int i, byte[] buf, int off) {
+  static void packBits6(final long[] values, final int i, final byte[] buf, int off) {
     buf[off] = (byte) (values[i + 0] << 2);
     buf[off++] |= values[i + 1] >>> 4;
 
@@ -295,7 +297,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits7(long[] values, int i, byte[] buf, int off) {
+  static void packBits7(final long[] values, final int i, final byte[] buf, int off) {
     buf[off] = (byte) (values[i + 0] << 1);
     buf[off++] |= values[i + 1] >>> 6;
 
@@ -318,7 +320,7 @@ public class BitPacking {
     buf[off] |= values[i + 7];
   }
 
-  static void packBits8(long[] values, int i, byte[] buf, int off) {
+  static void packBits8(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0]);
     buf[off++] = (byte) (values[i + 1]);
     buf[off++] = (byte) (values[i + 2]);
@@ -329,7 +331,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits9(long[] values, int i, byte[] buf, int off) {
+  static void packBits9(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 1);
 
     buf[off] = (byte) (values[i + 0] << 7);
@@ -356,7 +358,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits10(long[] values, int i, byte[] buf, int off) {
+  static void packBits10(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 2);
 
     buf[off] = (byte) (values[i + 0] << 6);
@@ -384,7 +386,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits11(long[] values, int i, byte[] buf, int off) {
+  static void packBits11(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 3);
 
     buf[off] = (byte) (values[i + 0] << 5);
@@ -415,7 +417,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits12(long[] values, int i, byte[] buf, int off) {
+  static void packBits12(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 4);
 
     buf[off] = (byte) (values[i + 0] << 4);
@@ -445,7 +447,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits13(long[] values, int i, byte[] buf, int off) {
+  static void packBits13(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 5);
 
     buf[off] = (byte) (values[i + 0] << 3);
@@ -480,7 +482,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits14(long[] values, int i, byte[] buf, int off) {
+  static void packBits14(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 6);
 
     buf[off] = (byte) (values[i + 0] << 2);
@@ -516,7 +518,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits15(long[] values, int i, byte[] buf, int off) {
+  static void packBits15(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 7);
 
     buf[off] = (byte) (values[i + 0] << 1);
@@ -555,7 +557,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits16(long[] values, int i, byte[] buf, int off) {
+  static void packBits16(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 8);
     buf[off++] = (byte) (values[i + 0]);
 
@@ -581,7 +583,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits17(long[] values, int i, byte[] buf, int off) {
+  static void packBits17(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 9);
 
     buf[off++] = (byte) (values[i + 0] >>> 1);
@@ -624,7 +626,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits18(long[] values, int i, byte[] buf, int off) {
+  static void packBits18(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 10);
 
     buf[off++] = (byte) (values[i + 0] >>> 2);
@@ -668,7 +670,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits19(long[] values, int i, byte[] buf, int off) {
+  static void packBits19(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 11);
 
     buf[off++] = (byte) (values[i + 0] >>> 3);
@@ -715,7 +717,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits20(long[] values, int i, byte[] buf, int off) {
+  static void packBits20(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 12);
 
     buf[off++] = (byte) (values[i + 0] >>> 4);
@@ -761,7 +763,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits21(long[] values, int i, byte[] buf, int off) {
+  static void packBits21(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 13);
 
     buf[off++] = (byte) (values[i + 0] >>> 5);
@@ -812,7 +814,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits22(long[] values, int i, byte[] buf, int off) {
+  static void packBits22(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 14);
 
     buf[off++] = (byte) (values[i + 0] >>> 6);
@@ -864,7 +866,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits23(long[] values, int i, byte[] buf, int off) {
+  static void packBits23(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 15);
 
     buf[off++] = (byte) (values[i + 0] >>> 7);
@@ -919,7 +921,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits24(long[] values, int i, byte[] buf, int off) {
+  static void packBits24(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 16);
     buf[off++] = (byte) (values[i + 0] >>> 8);
     buf[off++] = (byte) (values[i + 0]);
@@ -953,7 +955,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits25(long[] values, int i, byte[] buf, int off) {
+  static void packBits25(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 17);
 
     buf[off++] = (byte) (values[i + 0] >>> 9);
@@ -1012,7 +1014,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits26(long[] values, int i, byte[] buf, int off) {
+  static void packBits26(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 18);
 
     buf[off++] = (byte) (values[i + 0] >>> 10);
@@ -1072,7 +1074,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits27(long[] values, int i, byte[] buf, int off) {
+  static void packBits27(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 19);
 
     buf[off++] = (byte) (values[i + 0] >>> 11);
@@ -1135,7 +1137,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits28(long[] values, int i, byte[] buf, int off) {
+  static void packBits28(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 20);
     buf[off++] = (byte) (values[i + 0] >>> 12);
     buf[off++] = (byte) (values[i + 0] >>> 4);
@@ -1170,7 +1172,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits29(long[] values, int i, byte[] buf, int off) {
+  static void packBits29(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 21);
 
     buf[off++] = (byte) (values[i + 0] >>> 13);
@@ -1237,7 +1239,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits30(long[] values, int i, byte[] buf, int off) {
+  static void packBits30(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 22);
     buf[off++] = (byte) (values[i + 0] >>> 14);
     buf[off++] = (byte) (values[i + 0] >>> 6);
@@ -1283,7 +1285,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits31(long[] values, int i, byte[] buf, int off) {
+  static void packBits31(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 23);
     buf[off++] = (byte) (values[i + 0] >>> 15);
     buf[off++] = (byte) (values[i + 0] >>> 7);
@@ -1331,7 +1333,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits32(long[] values, int i, byte[] buf, int off) {
+  static void packBits32(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 24);
     buf[off++] = (byte) (values[i + 0] >>> 16);
     buf[off++] = (byte) (values[i + 0] >>> 8);
@@ -1373,7 +1375,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits33(long[] values, int i, byte[] buf, int off) {
+  static void packBits33(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 25);
     buf[off++] = (byte) (values[i + 0] >>> 17);
     buf[off++] = (byte) (values[i + 0] >>> 9);
@@ -1423,7 +1425,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits34(long[] values, int i, byte[] buf, int off) {
+  static void packBits34(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 26);
     buf[off++] = (byte) (values[i + 0] >>> 18);
     buf[off++] = (byte) (values[i + 0] >>> 10);
@@ -1473,7 +1475,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits35(long[] values, int i, byte[] buf, int off) {
+  static void packBits35(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 27);
     buf[off++] = (byte) (values[i + 0] >>> 19);
     buf[off++] = (byte) (values[i + 0] >>> 11);
@@ -1525,7 +1527,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits36(long[] values, int i, byte[] buf, int off) {
+  static void packBits36(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 28);
     buf[off++] = (byte) (values[i + 0] >>> 20);
     buf[off++] = (byte) (values[i + 0] >>> 12);
@@ -1575,7 +1577,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits37(long[] values, int i, byte[] buf, int off) {
+  static void packBits37(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 29);
     buf[off++] = (byte) (values[i + 0] >>> 21);
     buf[off++] = (byte) (values[i + 0] >>> 13);
@@ -1629,7 +1631,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits38(long[] values, int i, byte[] buf, int off) {
+  static void packBits38(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 30);
     buf[off++] = (byte) (values[i + 0] >>> 22);
     buf[off++] = (byte) (values[i + 0] >>> 14);
@@ -1683,7 +1685,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits39(long[] values, int i, byte[] buf, int off) {
+  static void packBits39(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 31);
     buf[off++] = (byte) (values[i + 0] >>> 23);
     buf[off++] = (byte) (values[i + 0] >>> 15);
@@ -1739,7 +1741,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits40(long[] values, int i, byte[] buf, int off) {
+  static void packBits40(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 32);
     buf[off++] = (byte) (values[i + 0] >>> 24);
     buf[off++] = (byte) (values[i + 0] >>> 16);
@@ -1789,7 +1791,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits41(long[] values, int i, byte[] buf, int off) {
+  static void packBits41(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 33);
     buf[off++] = (byte) (values[i + 0] >>> 25);
     buf[off++] = (byte) (values[i + 0] >>> 17);
@@ -1847,7 +1849,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits42(long[] values, int i, byte[] buf, int off) {
+  static void packBits42(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 34);
     buf[off++] = (byte) (values[i + 0] >>> 26);
     buf[off++] = (byte) (values[i + 0] >>> 18);
@@ -1905,7 +1907,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits43(long[] values, int i, byte[] buf, int off) {
+  static void packBits43(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 35);
     buf[off++] = (byte) (values[i + 0] >>> 27);
     buf[off++] = (byte) (values[i + 0] >>> 19);
@@ -1965,7 +1967,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits44(long[] values, int i, byte[] buf, int off) {
+  static void packBits44(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 36);
     buf[off++] = (byte) (values[i + 0] >>> 28);
     buf[off++] = (byte) (values[i + 0] >>> 20);
@@ -2023,7 +2025,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits45(long[] values, int i, byte[] buf, int off) {
+  static void packBits45(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 37);
     buf[off++] = (byte) (values[i + 0] >>> 29);
     buf[off++] = (byte) (values[i + 0] >>> 21);
@@ -2085,7 +2087,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits46(long[] values, int i, byte[] buf, int off) {
+  static void packBits46(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 38);
     buf[off++] = (byte) (values[i + 0] >>> 30);
     buf[off++] = (byte) (values[i + 0] >>> 22);
@@ -2147,7 +2149,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits47(long[] values, int i, byte[] buf, int off) {
+  static void packBits47(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 39);
     buf[off++] = (byte) (values[i + 0] >>> 31);
     buf[off++] = (byte) (values[i + 0] >>> 23);
@@ -2211,7 +2213,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits48(long[] values, int i, byte[] buf, int off) {
+  static void packBits48(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 40);
     buf[off++] = (byte) (values[i + 0] >>> 32);
     buf[off++] = (byte) (values[i + 0] >>> 24);
@@ -2269,7 +2271,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits49(long[] values, int i, byte[] buf, int off) {
+  static void packBits49(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 41);
     buf[off++] = (byte) (values[i + 0] >>> 33);
     buf[off++] = (byte) (values[i + 0] >>> 25);
@@ -2335,7 +2337,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits50(long[] values, int i, byte[] buf, int off) {
+  static void packBits50(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 42);
     buf[off++] = (byte) (values[i + 0] >>> 34);
     buf[off++] = (byte) (values[i + 0] >>> 26);
@@ -2401,7 +2403,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits51(long[] values, int i, byte[] buf, int off) {
+  static void packBits51(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 43);
     buf[off++] = (byte) (values[i + 0] >>> 35);
     buf[off++] = (byte) (values[i + 0] >>> 27);
@@ -2469,7 +2471,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits52(long[] values, int i, byte[] buf, int off) {
+  static void packBits52(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 44);
     buf[off++] = (byte) (values[i + 0] >>> 36);
     buf[off++] = (byte) (values[i + 0] >>> 28);
@@ -2535,7 +2537,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits53(long[] values, int i, byte[] buf, int off) {
+  static void packBits53(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 45);
     buf[off++] = (byte) (values[i + 0] >>> 37);
     buf[off++] = (byte) (values[i + 0] >>> 29);
@@ -2605,7 +2607,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits54(long[] values, int i, byte[] buf, int off) {
+  static void packBits54(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 46);
     buf[off++] = (byte) (values[i + 0] >>> 38);
     buf[off++] = (byte) (values[i + 0] >>> 30);
@@ -2675,7 +2677,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits55(long[] values, int i, byte[] buf, int off) {
+  static void packBits55(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 47);
     buf[off++] = (byte) (values[i + 0] >>> 39);
     buf[off++] = (byte) (values[i + 0] >>> 31);
@@ -2747,7 +2749,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits56(long[] values, int i, byte[] buf, int off) {
+  static void packBits56(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 48);
     buf[off++] = (byte) (values[i + 0] >>> 40);
     buf[off++] = (byte) (values[i + 0] >>> 32);
@@ -2813,7 +2815,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits57(long[] values, int i, byte[] buf, int off) {
+  static void packBits57(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 49);
     buf[off++] = (byte) (values[i + 0] >>> 41);
     buf[off++] = (byte) (values[i + 0] >>> 33);
@@ -2887,7 +2889,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits58(long[] values, int i, byte[] buf, int off) {
+  static void packBits58(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 50);
     buf[off++] = (byte) (values[i + 0] >>> 42);
     buf[off++] = (byte) (values[i + 0] >>> 34);
@@ -2961,7 +2963,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits59(long[] values, int i, byte[] buf, int off) {
+  static void packBits59(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 51);
     buf[off++] = (byte) (values[i + 0] >>> 43);
     buf[off++] = (byte) (values[i + 0] >>> 35);
@@ -3037,7 +3039,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits60(long[] values, int i, byte[] buf, int off) {
+  static void packBits60(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 52);
     buf[off++] = (byte) (values[i + 0] >>> 44);
     buf[off++] = (byte) (values[i + 0] >>> 36);
@@ -3111,7 +3113,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits61(long[] values, int i, byte[] buf, int off) {
+  static void packBits61(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 53);
     buf[off++] = (byte) (values[i + 0] >>> 45);
     buf[off++] = (byte) (values[i + 0] >>> 37);
@@ -3189,7 +3191,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits62(long[] values, int i, byte[] buf, int off) {
+  static void packBits62(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 54);
     buf[off++] = (byte) (values[i + 0] >>> 46);
     buf[off++] = (byte) (values[i + 0] >>> 38);
@@ -3267,7 +3269,7 @@ public class BitPacking {
     buf[off] = (byte) (values[i + 7]);
   }
 
-  static void packBits63(long[] values, int i, byte[] buf, int off) {
+  static void packBits63(final long[] values, final int i, final byte[] buf, int off) {
     buf[off++] = (byte) (values[i + 0] >>> 55);
     buf[off++] = (byte) (values[i + 0] >>> 47);
     buf[off++] = (byte) (values[i + 0] >>> 39);
@@ -3347,7 +3349,7 @@ public class BitPacking {
     buf[off] = (byte) values[i + 7];
   }
 
-  static void unpackBits1(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits1(final long[] values, final int i, final byte[] buf, final int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off]) >>> 7) & 1;
     values[i + 1] = (Byte.toUnsignedLong(buf[off]) >>> 6) & 1;
     values[i + 2] = (Byte.toUnsignedLong(buf[off]) >>> 5) & 1;
@@ -3358,7 +3360,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 1;
   }
 
-  static void unpackBits2(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits2(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off]) >>> 6) & 3;
     values[i + 1] = (Byte.toUnsignedLong(buf[off]) >>> 4) & 3;
     values[i + 2] = (Byte.toUnsignedLong(buf[off]) >>> 2) & 3;
@@ -3369,7 +3371,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 3;
   }
 
-  static void unpackBits3(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits3(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off]) >>> 5;
     values[i + 1] = (Byte.toUnsignedLong(buf[off]) >>> 2) & 7;
     values[i + 2] = (Byte.toUnsignedLong(buf[off++]) & 3) << 1;
@@ -3382,7 +3384,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 7;
   }
 
-  static void unpackBits4(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits4(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off]) >>> 4;
     values[i + 1] = Byte.toUnsignedLong(buf[off++]) & 0xf;
     values[i + 2] = Byte.toUnsignedLong(buf[off]) >>> 4;
@@ -3393,7 +3395,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 0xf;
   }
 
-  static void unpackBits5(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits5(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off]) >>> 3;
 
     values[i + 1] = (Byte.toUnsignedLong(buf[off++]) & 7) << 2;
@@ -3415,7 +3417,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 0x1f;
   }
 
-  static void unpackBits6(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits6(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off]) >>> 2;
 
     values[i + 1] = (Byte.toUnsignedLong(buf[off++]) & 3) << 4;
@@ -3437,7 +3439,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 0x3f;
   }
 
-  static void unpackBits7(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits7(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off]) >>> 1;
 
     values[i + 1] = (Byte.toUnsignedLong(buf[off++]) & 1) << 6;
@@ -3461,7 +3463,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]) & 0x7f;
   }
 
-  static void unpackBits8(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits8(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]);
     values[i + 1] = Byte.toUnsignedLong(buf[off++]);
     values[i + 2] = Byte.toUnsignedLong(buf[off++]);
@@ -3472,7 +3474,7 @@ public class BitPacking {
     values[i + 7] = Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits9(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits9(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 1;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 7;
 
@@ -3498,7 +3500,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits10(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits10(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 2;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 6;
 
@@ -3524,7 +3526,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits11(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits11(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 3;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 5;
 
@@ -3552,7 +3554,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits12(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits12(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 4;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 4;
 
@@ -3578,7 +3580,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits13(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits13(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 5;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 3;
 
@@ -3608,7 +3610,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits14(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits14(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 6;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 2;
 
@@ -3638,7 +3640,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits15(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits15(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 7;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 1;
 
@@ -3670,7 +3672,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits16(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits16(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 8;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]);
     values[i + 1] = Byte.toUnsignedLong(buf[off++]) << 8;
@@ -3689,7 +3691,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits17(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits17(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 9;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 1;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 7;
@@ -3723,7 +3725,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits18(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits18(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 10;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 2;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 6;
@@ -3757,7 +3759,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits19(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits19(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 11;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 3;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 5;
@@ -3793,7 +3795,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits20(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits20(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 12;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 4;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 4;
@@ -3827,7 +3829,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits21(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits21(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 13;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 5;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 3;
@@ -3865,7 +3867,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits22(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits22(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 14;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 6;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 2;
@@ -3903,7 +3905,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits23(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits23(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 15;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 7;
     values[i + 0] |= Byte.toUnsignedLong(buf[off]) >>> 1;
@@ -3943,7 +3945,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits24(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits24(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 16;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 8;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]);
@@ -3970,7 +3972,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits25(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits25(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 17;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 9;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 1;
@@ -4012,7 +4014,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits26(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits26(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 18;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 10;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 2;
@@ -4054,7 +4056,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits27(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits27(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 19;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 11;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 3;
@@ -4098,7 +4100,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits28(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits28(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 20;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 12;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 4;
@@ -4140,7 +4142,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits29(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits29(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 21;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 13;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 5;
@@ -4186,7 +4188,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits30(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits30(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 22;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 14;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 6;
@@ -4232,7 +4234,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits31(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits31(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = Byte.toUnsignedLong(buf[off++]) << 23;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 15;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 7;
@@ -4280,7 +4282,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits32(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits32(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 24;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 16;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 8;
@@ -4315,7 +4317,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits33(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits33(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 25;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 17;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 9;
@@ -4365,7 +4367,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits34(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits34(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 26;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 18;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 10;
@@ -4415,7 +4417,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off++]);
   }
 
-  static void unpackBits35(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits35(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 27;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 19;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 11;
@@ -4467,7 +4469,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits36(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits36(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 28;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 20;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 12;
@@ -4517,7 +4519,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits37(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits37(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 29;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 21;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 13;
@@ -4571,7 +4573,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits38(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits38(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 30;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 22;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 14;
@@ -4625,7 +4627,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits39(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits39(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 31;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 23;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 15;
@@ -4681,7 +4683,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits40(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits40(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 32;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 24;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 16;
@@ -4724,7 +4726,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits41(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits41(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 33;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 25;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 17;
@@ -4782,7 +4784,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits42(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits42(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 34;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 26;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 18;
@@ -4840,7 +4842,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits43(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits43(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 35;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 27;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 19;
@@ -4900,7 +4902,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits44(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits44(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 36;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 28;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 20;
@@ -4958,7 +4960,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits45(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits45(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 37;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 29;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 21;
@@ -5020,7 +5022,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits46(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits46(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 38;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 30;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 22;
@@ -5082,7 +5084,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits47(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits47(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 39;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 31;
     values[i + 0] |= Byte.toUnsignedLong(buf[off++]) << 23;
@@ -5146,7 +5148,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits48(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits48(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 40;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 32;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 24;
@@ -5197,7 +5199,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits49(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits49(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 41;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 33;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 25;
@@ -5263,7 +5265,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits50(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits50(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 42;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 34;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 26;
@@ -5329,7 +5331,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits51(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits51(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 43;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 35;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 27;
@@ -5397,7 +5399,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits52(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits52(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 44;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 36;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 28;
@@ -5463,7 +5465,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits53(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits53(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 45;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 37;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 29;
@@ -5533,7 +5535,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits54(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits54(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 46;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 38;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 30;
@@ -5603,7 +5605,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off++]);
   }
 
-  static void unpackBits55(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits55(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 47;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 39;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 31;
@@ -5675,7 +5677,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits56(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits56(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 48;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 40;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 32;
@@ -5734,7 +5736,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits57(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits57(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 49;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 41;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 33;
@@ -5808,7 +5810,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits58(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits58(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 50;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 42;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 34;
@@ -5882,7 +5884,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off++]);
   }
 
-  static void unpackBits59(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits59(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 51;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 43;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 35;
@@ -5958,7 +5960,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits60(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits60(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 52;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 44;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 36;
@@ -6032,7 +6034,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits61(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits61(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 53;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 45;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 37;
@@ -6110,7 +6112,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits62(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits62(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 54;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 46;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 38;
@@ -6188,7 +6190,7 @@ public class BitPacking {
     values[i + 7] |= Byte.toUnsignedLong(buf[off]);
   }
 
-  static void unpackBits63(long[] values, int i, byte[] buf, int off) {
+  static void unpackBits63(final long[] values, final int i, final byte[] buf, int off) {
     values[i + 0] = (Byte.toUnsignedLong(buf[off++])) << 55;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 47;
     values[i + 0] |= (Byte.toUnsignedLong(buf[off++])) << 39;

--- a/src/main/java/org/apache/datasketches/theta/CompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/CompactSketch.java
@@ -261,7 +261,7 @@ public abstract class CompactSketch extends Sketch {
     // assumes ordered sketch
     long previous = 0;
     long ored = 0;
-    HashIterator it = iterator();
+    final HashIterator it = iterator();
     while (it.next()) {
       final long delta = it.get() - previous;
       ored |= delta;
@@ -270,7 +270,7 @@ public abstract class CompactSketch extends Sketch {
     return Long.numberOfLeadingZeros(ored);
   }
 
-  private static int wholeBytesToHoldBits(int bits) {
+  private static int wholeBytesToHoldBits(final int bits) {
     return (bits >>> 3) + ((bits & 7) > 0 ? 1 : 0);
   }
 
@@ -304,8 +304,8 @@ public abstract class CompactSketch extends Sketch {
       numEntries >>>= 8;
     }
     long previous = 0;
-    long[] deltas = new long[8];
-    HashIterator it = iterator();
+    final long[] deltas = new long[8];
+    final HashIterator it = iterator();
     int i;
     for (i = 0; i + 7 < getRetainedEntries(); i += 8) {
       for (int j = 0; j < 8; j++) {

--- a/src/main/java/org/apache/datasketches/theta/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/theta/PreambleUtil.java
@@ -109,7 +109,7 @@ import org.apache.datasketches.thetacommon.ThetaUtil;
  * <p>The UpdateSketch and AlphaSketch require 24 bytes of preamble followed by a non-compact
  * array of longs representing a hash table.</p>
  *
- * The following table applies to both the Theta UpdateSketch and the Alpha Sketch
+ * <p>The following table applies to both the Theta UpdateSketch and the Alpha Sketch</p>
  * <pre>
  * Long || Start Byte Adr:
  * Adr:

--- a/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
@@ -102,7 +102,6 @@ public class KllMiscDoublesTest {
     KllDoublesSketch.heapify(wmem);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkMisc() {
     KllDoublesSketch sk = KllDoublesSketch.newHeapInstance(8);

--- a/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
@@ -127,7 +127,6 @@ public class KllMiscFloatsTest {
     KllFloatsSketch.heapify(wmem);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkMisc() {
     KllFloatsSketch sk = KllFloatsSketch.newHeapInstance(8);

--- a/src/test/java/org/apache/datasketches/quantiles/DirectCompactDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectCompactDoublesSketchTest.java
@@ -104,7 +104,6 @@ public class DirectCompactDoublesSketchTest {
     assertTrue(Double.isNaN(s2.isEmpty() ? Double.NaN : s2.getMaxItem()));
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkEmpty() {
     final int k = PreambleUtil.DEFAULT_K;

--- a/src/test/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketchTest.java
@@ -42,7 +42,6 @@ public class DirectUpdateDoublesSketchTest {
     DoublesSketch.rand.setSeed(32749); // make sketches deterministic for testing
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkSmallMinMax () {
     int k = 32;

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -127,7 +127,6 @@ public class DoublesSketchTest {
     assertFalse(uds.isSameResource(mem));
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkEmptyNullReturns() {
     int k = 16;
@@ -235,7 +234,6 @@ public class DoublesSketchTest {
     assertTrue(rub -.5 <= 2 * eps);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkGetRanks() {
     final UpdateDoublesSketch sk = DoublesSketch.builder().build();

--- a/src/test/java/org/apache/datasketches/quantiles/HeapCompactDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/HeapCompactDoublesSketchTest.java
@@ -103,7 +103,6 @@ public class HeapCompactDoublesSketchTest {
     checkBaseBufferIsSorted(qs2);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void checkEmpty() {
     final int k = PreambleUtil.DEFAULT_K;

--- a/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
@@ -45,7 +45,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("deprecation")
 public class HeapUpdateDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/quantiles/ItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ItemsSketchTest.java
@@ -43,7 +43,6 @@ import org.apache.datasketches.quantilescommon.GenericSortedViewIterator;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@SuppressWarnings("deprecation")
 public class ItemsSketchTest {
 
   @BeforeMethod

--- a/src/test/java/org/apache/datasketches/req/ReqSketchOtherTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchOtherTest.java
@@ -173,7 +173,6 @@ public class ReqSketchOtherTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void checkEmpty() {
     final ReqSketchBuilder bldr = new ReqSketchBuilder();
     final ReqSketch sk = bldr.build();
@@ -187,7 +186,6 @@ public class ReqSketchOtherTest {
     assertTrue(sk.getRankUpperBound(0.5, 1) > 0);
   }
 
-  @SuppressWarnings("deprecation")
   private void checkGetRank(final boolean hra, final boolean ltEq) {
     final int k = 12;
     final boolean up = true;

--- a/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
@@ -136,7 +136,6 @@ public class ReqSketchTest {
     if (iDebug > 0) { println(""); }
   }
 
-  @SuppressWarnings("deprecation")
   private static void checkGetRanks(final ReqSketch sk, final int max, final int iDebug) {
     if (iDebug > 0) { println("GetRanks Test:"); }
     final float[] sp = QuantilesUtil.evenlySpacedFloats(0, max, 11);
@@ -165,7 +164,6 @@ public class ReqSketchTest {
     assertEquals(count, retainedCount);
   }
 
-  @SuppressWarnings("deprecation")
   private static void checkGetQuantiles(final ReqSketch sk, final int iDebug) {
     if (iDebug > 0) { println("GetQuantiles() Test"); }
     final double[] rArr = {0, .1F, .2F, .3F, .4F, .5F, .6F, .7F, .8F, .9F, 1.0F};
@@ -312,8 +310,6 @@ public class ReqSketchTest {
     } catch (final SketchesArgumentException e) {}
   }
 
-
-  @SuppressWarnings("deprecation")
   @Test
   public void tenValues() {
     final ReqSketch sketch = ReqSketch.builder().build();

--- a/src/test/java/org/apache/datasketches/theta/BitPackingTest.java
+++ b/src/test/java/org/apache/datasketches/theta/BitPackingTest.java
@@ -25,7 +25,7 @@ import org.apache.datasketches.common.Util;
 import org.testng.annotations.Test;
 
 public class BitPackingTest {
-
+  private final static boolean enablePrinting = false;
 //for every number of bits from 1 to 63
 //generate pseudo-random data, pack, unpack and compare
 
@@ -66,7 +66,7 @@ public class BitPackingTest {
   @Test
   public void packUnpackBlocks() {
     for (int bits = 1; bits <= 63; bits++) {
-      System.out.println("bits " + bits);
+      if (enablePrinting) { System.out.println("bits " + bits); }
       final long mask = (1L << bits) - 1;
       long[] input = new long[8];
       final long golden64 = Util.INVERSE_GOLDEN_U64;
@@ -77,13 +77,13 @@ public class BitPackingTest {
       }
       byte[] bytes = new byte[8 * Long.BYTES];
       BitPacking.packBitsBlock8(input, 0, bytes, 0, bits);
-      hexDump(bytes);
+      if (enablePrinting) { hexDump(bytes); }
 
       long[] output = new long[8];
       BitPacking.unpackBitsBlock8(output, 0, bytes, 0, bits);
 
       for (int i = 0; i < 8; ++i) {
-        System.out.println("checking value " + i);
+        if (enablePrinting) { System.out.println("checking value " + i); }
         assertEquals(output[i], input[i]);
       }
     }

--- a/src/test/java/org/apache/datasketches/theta/BitPackingTest.java
+++ b/src/test/java/org/apache/datasketches/theta/BitPackingTest.java
@@ -34,7 +34,7 @@ public class BitPackingTest {
     for (int bits = 1; bits <= 63; bits++) {
       final long mask = (1 << bits) - 1;
       long[] input = new long[8];
-      final long golden64 = Util.iGoldenU64;
+      final long golden64 = Util.INVERSE_GOLDEN_U64;
       long value = 0xaa55aa55aa55aa55L; // arbitrary starting value
       for (int i = 0; i < 8; ++i) {
         input[i] = value & mask;
@@ -69,7 +69,7 @@ public class BitPackingTest {
       System.out.println("bits " + bits);
       final long mask = (1L << bits) - 1;
       long[] input = new long[8];
-      final long golden64 = Util.iGoldenU64;
+      final long golden64 = Util.INVERSE_GOLDEN_U64;
       long value = 0xaa55aa55aa55aa55L; // arbitrary starting value
       for (int i = 0; i < 8; ++i) {
         input[i] = value & mask;


### PR DESCRIPTION
These are really minor updates although a number of classes were involved.

The deprecations of getQuantiles(...) and getRanks(...) were removed. These functions are too useful, especially in Java, to be removed.

A large number of these fixes are due to Checkstyle, mostly missing final method parameters. There were a few Javadoc missing paragraph tags.

Two static final constant names were renamed with all capitals.

The BitPackingTest was printing hundreds of lines to the console. It was modified to print based on a internal variable that can be set by the developer if needed.