### PR TITLE
Found a minor Javadoc vs implementation discrepancy. 

### DIFF
--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -253,7 +253,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
    * each rank.
    * @return an array of quantiles that are evenly spaced by their ranks.
-   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced < 1</i>.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   double[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -252,7 +252,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
    * each rank.
    * @return an array of quantiles that are evenly spaced by their ranks.
-   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced < 1</i>.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   float[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -253,7 +253,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
    * each rank.
    * @return an array of quantiles that are evenly spaced by their ranks.
-   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced < 1</i>.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   T[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesUtil.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesUtil.java
@@ -83,22 +83,24 @@ public final class QuantilesUtil {
    * Returns a double array of evenly spaced values between value1 and value2 inclusive.
    * If value2 &gt; value1, the resulting sequence will be increasing.
    * If value2 &lt; value1, the resulting sequence will be decreasing.
+   * If num == 1, value1 will be in index 0 of the returned array.
    * @param value1 will be in index 0 of the returned array
    * @param value2 will be in the highest index of the returned array
-   * @param num the total number of values including value1 and value2. Must be 2 or greater.
+   * @param num the total number of values including value1 and value2. Must be 1 or greater.
    * @return a double array of evenly spaced values between value1 and value2 inclusive.
+   * @throws IllegalArgumentException if <i>num</i> < 1.
    */
   public static double[] evenlySpaced(final double value1, final double value2, final int num) {
-    if (num < 2) {
-      throw new SketchesArgumentException("num must be >= 2");
+    if (num < 1) {
+      throw new IllegalArgumentException("num must be >= 1");
     }
     final double[] out = new double[num];
     out[0] = value1;
+    if (num == 1) { return out; }
     out[num - 1] = value2;
     if (num == 2) { return out; }
 
     final double delta = (value2 - value1) / (num - 1);
-
     for (int i = 1; i < num - 1; i++) { out[i] = i * delta + value1; }
     return out;
   }


### PR DESCRIPTION
This is WRT getQuantiles(int numEvenlySpaced) methods and the implementation of the QuantilesUtil.evenlySpaced(...) method.

The javadocs of the getQuantiles methods (for all quantiles sketches) claimed that a "numEvenlySpaced == 1" was valid, yet the implementation would throw an exception if "numEvenlySpaced < 2".

So I updated the implementation so that the implementation matched the javadocs.

I also updated the relevant quantiles javadocs to reflect that this exception could be thrown.

The only place this QuantilesUtil.evenlySpaced(...) method was used was for these quantiles methods, so no place else in the library used this common method.