### PR TITLE
I discovered another bug in the design of the method

### DIFF
--- a/src/main/java/org/apache/datasketches/common/Family.java
+++ b/src/main/java/org/apache/datasketches/common/Family.java
@@ -140,7 +140,12 @@ public enum Family {
   /**
    * Relative Error Quantiles Sketch
    */
-  REQ(17, "REQ", 1, 2);
+  REQ(17, "REQ", 1, 2),
+
+  /**
+   * CountMin Sketch
+   */
+  COUNTMIN(18, "COUNTMIN", 2, 2);
 
   private static final Map<Integer, Family> lookupID = new HashMap<>();
   private static final Map<String, Family> lookupFamName = new HashMap<>();

--- a/src/main/java/org/apache/datasketches/common/Util.java
+++ b/src/main/java/org/apache/datasketches/common/Util.java
@@ -527,11 +527,11 @@ public final class Util {
    * <pre>{@code
    *     double maxP = 1024.0;
    *     double minP = 1.0;
-   *     int ppo = 2;
+   *     int ppb = 2;
    *     double logBase = 2.0;
    *
-   *     for (double p = minP; p <= maxP; p = pwr2LawNextDouble(ppo, p, true, logBase)) {
-   *       System.out.print(Math.round(p) + " ");
+   *     for (double p = minP; p <= maxP; p = powerSeriesNextDouble(ppb, p, true, logBase)) {
+   *       System.out.print(p + " ");
    *     }
    *     //generates the following series:
    *     //1 2 3 4 6 8 11 16 23 32 45 64 91 128 181 256 362 512 724 1024

--- a/src/main/java/org/apache/datasketches/hll/Hll8Array.java
+++ b/src/main/java/org/apache/datasketches/hll/Hll8Array.java
@@ -95,9 +95,7 @@ class Hll8Array extends HllArray {
   //Used by Union when source is not HLL8
   final void updateSlotNoKxQ(final int slotNo, final int newValue) {
     final int oldValue = getSlotValue(slotNo);
-    if (newValue > oldValue) {
-      hllByteArr[slotNo] = (byte) (newValue & VAL_MASK_6);
-    }
+    hllByteArr[slotNo] = (byte) Math.max(newValue, oldValue);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/hll/Union.java
+++ b/src/main/java/org/apache/datasketches/hll/Union.java
@@ -20,9 +20,12 @@
 package org.apache.datasketches.hll;
 
 import static org.apache.datasketches.common.Util.invPow2;
+import static org.apache.datasketches.hll.HllUtil.AUX_TOKEN;
 import static org.apache.datasketches.hll.HllUtil.EMPTY;
+import static org.apache.datasketches.hll.HllUtil.loNibbleMask;
 import static org.apache.datasketches.hll.PreambleUtil.HLL_BYTE_ARR_START;
 import static org.apache.datasketches.hll.PreambleUtil.extractTgtHllType;
+import static org.apache.datasketches.hll.TgtHllType.HLL_4;
 import static org.apache.datasketches.hll.TgtHllType.HLL_8;
 
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -481,53 +484,49 @@ public class Union extends BaseHllSketch {
       final int srcLgK, final int tgtLgK, final boolean srcIsMem, final boolean tgtIsMem) {
       final int sw = (tgtIsMem ? 1 : 0) | (srcIsMem ? 2 : 0)
           | ((srcLgK > tgtLgK) ? 4 : 0) | ((src.getTgtHllType() != HLL_8) ? 8 : 0);
+      final int srcK = 1 << srcLgK;
       switch (sw) {
         case 0: { //HLL_8, srcLgK=tgtLgK, src=heap, tgt=heap
-          final int srcK = 1 << srcLgK;
           final byte[] srcArr = ((Hll8Array) src.hllSketchImpl).hllByteArr;
           final byte[] tgtArr = ((Hll8Array) tgt.hllSketchImpl).hllByteArr;
           for (int i = 0; i < srcK; i++) {
             final byte srcV = srcArr[i];
             final byte tgtV = tgtArr[i];
-            tgtArr[i] = (srcV > tgtV) ? srcV : tgtV;
+            tgtArr[i] = (byte) Math.max(srcV, tgtV);
           }
           break;
         }
         case 1: { //HLL_8, srcLgK=tgtLgK, src=heap, tgt=mem
-          final int srcK = 1 << srcLgK;
           final byte[] srcArr = ((Hll8Array) src.hllSketchImpl).hllByteArr;
           final WritableMemory tgtMem = tgt.getWritableMemory();
           for (int i = 0; i < srcK; i++) {
             final byte srcV = srcArr[i];
             final byte tgtV = tgtMem.getByte(HLL_BYTE_ARR_START + i);
-            tgtMem.putByte(HLL_BYTE_ARR_START + i, (srcV > tgtV) ? srcV : tgtV);
+            tgtMem.putByte(HLL_BYTE_ARR_START + i, (byte) Math.max(srcV, tgtV));
           }
           break;
         }
         case 2: { //HLL_8, srcLgK=tgtLgK, src=mem,  tgt=heap
-          final int srcK = 1 << srcLgK;
           final Memory srcMem = src.getMemory();
           final byte[] tgtArr = ((Hll8Array) tgt.hllSketchImpl).hllByteArr;
           for (int i = 0; i < srcK; i++) {
             final byte srcV = srcMem.getByte(HLL_BYTE_ARR_START + i);
             final byte tgtV = tgtArr[i];
-            tgtArr[i] = (srcV > tgtV) ? srcV : tgtV;
+            tgtArr[i] = (byte) Math.max(srcV, tgtV);
           }
           break;
         }
         case 3: { //HLL_8, srcLgK=tgtLgK, src=mem,  tgt=mem
-          final int srcK = 1 << srcLgK;
           final Memory srcMem = src.getMemory();
           final WritableMemory tgtMem = tgt.getWritableMemory();
           for (int i = 0; i < srcK; i++) {
             final byte srcV = srcMem.getByte(HLL_BYTE_ARR_START + i);
             final byte tgtV = tgtMem.getByte(HLL_BYTE_ARR_START + i);
-            tgtMem.putByte(HLL_BYTE_ARR_START + i, (srcV > tgtV) ? srcV : tgtV);
+            tgtMem.putByte(HLL_BYTE_ARR_START + i, (byte) Math.max(srcV, tgtV));
           }
           break;
         }
         case 4: { //HLL_8, srcLgK>tgtLgK, src=heap, tgt=heap
-          final int srcK = 1 << srcLgK;
           final int tgtKmask = (1 << tgtLgK) - 1;
           final byte[] srcArr = ((Hll8Array) src.hllSketchImpl).hllByteArr;
           final byte[] tgtArr = ((Hll8Array) tgt.hllSketchImpl).hllByteArr;
@@ -535,12 +534,11 @@ public class Union extends BaseHllSketch {
             final byte srcV = srcArr[i];
             final int j = i & tgtKmask;
             final byte tgtV = tgtArr[j];
-            tgtArr[j] = (srcV > tgtV) ? srcV : tgtV;
+            tgtArr[j] = (byte) Math.max(srcV, tgtV);
           }
           break;
         }
         case 5: { //HLL_8, srcLgK>tgtLgK, src=heap, tgt=mem
-          final int srcK = 1 << srcLgK;
           final int tgtKmask = (1 << tgtLgK) - 1;
           final byte[] srcArr = ((Hll8Array) src.hllSketchImpl).hllByteArr;
           final WritableMemory tgtMem = tgt.getWritableMemory();
@@ -548,12 +546,11 @@ public class Union extends BaseHllSketch {
             final byte srcV = srcArr[i];
             final int j = i & tgtKmask;
             final byte tgtV = tgtMem.getByte(HLL_BYTE_ARR_START + j);
-            tgtMem.putByte(HLL_BYTE_ARR_START + j, (srcV > tgtV) ? srcV : tgtV);
+            tgtMem.putByte(HLL_BYTE_ARR_START + j, (byte) Math.max(srcV, tgtV));
           }
           break;
         }
         case 6: { //HLL_8, srcLgK>tgtLgK, src=mem,  tgt=heap
-          final int srcK = 1 << srcLgK;
           final int tgtKmask = (1 << tgtLgK) - 1;
           final Memory srcMem = src.getMemory();
           final byte[] tgtArr = ((Hll8Array) tgt.hllSketchImpl).hllByteArr;
@@ -561,12 +558,11 @@ public class Union extends BaseHllSketch {
             final byte srcV = srcMem.getByte(HLL_BYTE_ARR_START + i);
             final int j = i & tgtKmask;
             final byte tgtV = tgtArr[j];
-            tgtArr[j] = (srcV > tgtV) ? srcV : tgtV;
+            tgtArr[j] = (byte) Math.max(srcV, tgtV);
           }
           break;
         }
         case 7: { //HLL_8, srcLgK>tgtLgK, src=mem,  tgt=mem
-          final int srcK = 1 << srcLgK;
           final int tgtKmask = (1 << tgtLgK) - 1;
           final Memory srcMem = src.getMemory();
           final WritableMemory tgtMem = tgt.getWritableMemory();
@@ -574,33 +570,177 @@ public class Union extends BaseHllSketch {
             final byte srcV = srcMem.getByte(HLL_BYTE_ARR_START + i);
             final int j = i & tgtKmask;
             final byte tgtV = tgtMem.getByte(HLL_BYTE_ARR_START + j);
-            tgtMem.putByte(HLL_BYTE_ARR_START + j, (srcV > tgtV) ? srcV : tgtV);
+            tgtMem.putByte(HLL_BYTE_ARR_START + j, (byte) Math.max(srcV, tgtV));
           }
           break;
         }
-        case 8: case 9: case 10: case 11:
+        case 8: case 9:
         {
-          //!HLL_8, srcLgK=tgtLgK, src=heap/mem, tgt=heap/mem
-          final int srcK = 1 << srcLgK;
-          final AbstractHllArray srcAbsHllArr = (AbstractHllArray)(src.hllSketchImpl);
+          //!HLL_8, srcLgK=tgtLgK, src=heap, tgt=heap/mem
           final AbstractHllArray tgtAbsHllArr = (AbstractHllArray)(tgt.hllSketchImpl);
-          for (int i = 0; i < srcK; i++) {
-            final int srcV = srcAbsHllArr.getSlotValue(i);
-            tgtAbsHllArr.updateSlotNoKxQ(i, srcV);
+          if (src.getTgtHllType() == HLL_4) {
+            final Hll4Array src4 = (Hll4Array) src.hllSketchImpl;
+            final AuxHashMap auxHashMap = src4.getAuxHashMap();
+            final int curMin = src4.getCurMin();
+            int i = 0;
+            int j = 0;
+            while (j < srcK) {
+              final byte b = src4.hllByteArr[i++];
+              int value = Byte.toUnsignedInt(b) & loNibbleMask;
+              tgtAbsHllArr.updateSlotNoKxQ(j, value == AUX_TOKEN ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+              value = Byte.toUnsignedInt(b) >>> 4;
+              tgtAbsHllArr.updateSlotNoKxQ(j, value == AUX_TOKEN ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+            }
+          } else {
+            final Hll6Array src6 = (Hll6Array) src.hllSketchImpl;
+            int i = 0;
+            int j = 0;
+            while (j < srcK) {
+              final byte b1 = src6.hllByteArr[i++];
+              final byte b2 = src6.hllByteArr[i++];
+              final byte b3 = src6.hllByteArr[i++];
+              int value = Byte.toUnsignedInt(b1) & 0x3f;
+              tgtAbsHllArr.updateSlotNoKxQ(j++, value);
+              value = Byte.toUnsignedInt(b1) >>> 6;
+              value |= (Byte.toUnsignedInt(b2) & 0x0f) << 2;
+              tgtAbsHllArr.updateSlotNoKxQ(j++, value);
+              value = Byte.toUnsignedInt(b2) >>> 4;
+              value |= (Byte.toUnsignedInt(b3) & 3) << 4;
+              tgtAbsHllArr.updateSlotNoKxQ(j++, value);
+              value = Byte.toUnsignedInt(b3) >>> 2;
+              tgtAbsHllArr.updateSlotNoKxQ(j++, value);
+            }
           }
           break;
         }
-        case 12: case 13: case 14: case 15:
+        case 10: case 11:
         {
-          //!HLL_8, srcLgK>tgtLgK, src=heap/mem, tgt=heap/mem
-          final int srcK = 1 << srcLgK;
+          //!HLL_8, srcLgK=tgtLgK, src=mem, tgt=heap/mem
+          final AbstractHllArray tgtAbsHllArr = (AbstractHllArray)(tgt.hllSketchImpl);
+          if (src.getTgtHllType() == HLL_4) {
+            final DirectHll4Array src4 = (DirectHll4Array) src.hllSketchImpl;
+            final AuxHashMap auxHashMap = src4.getAuxHashMap();
+            final int curMin = src4.getCurMin();
+            int i = 0;
+            int j = 0;
+            while (j < srcK) {
+              final byte b = src4.mem.getByte(HLL_BYTE_ARR_START + i++);
+              int value = Byte.toUnsignedInt(b) & loNibbleMask;
+              tgtAbsHllArr.updateSlotNoKxQ(j, value == AUX_TOKEN ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+              value = Byte.toUnsignedInt(b) >>> 4;
+              tgtAbsHllArr.updateSlotNoKxQ(j, value == AUX_TOKEN ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+            }
+          } else {
+            final DirectHll6Array src6 = (DirectHll6Array) src.hllSketchImpl;
+            int i = 0;
+            int offset = HLL_BYTE_ARR_START;
+            while (i < srcK) {
+              final byte b1 = src6.mem.getByte(offset++);
+              final byte b2 = src6.mem.getByte(offset++);
+              final byte b3 = src6.mem.getByte(offset++);
+              int value = Byte.toUnsignedInt(b1) & 0x3f;
+              tgtAbsHllArr.updateSlotNoKxQ(i++, value);
+              value = Byte.toUnsignedInt(b1) >>> 6;
+              value |= (Byte.toUnsignedInt(b2) & 0x0f) << 2;
+              tgtAbsHllArr.updateSlotNoKxQ(i++, value);
+              value = Byte.toUnsignedInt(b2) >>> 4;
+              value |= (Byte.toUnsignedInt(b3) & 3) << 4;
+              tgtAbsHllArr.updateSlotNoKxQ(i++, value);
+              value = Byte.toUnsignedInt(b3) >>> 2;
+              tgtAbsHllArr.updateSlotNoKxQ(i++, value);
+            }
+          }
+          break;
+        }
+        case 12: case 13:
+        {
+          //!HLL_8, srcLgK>tgtLgK, src=heap, tgt=heap/mem
           final int tgtKmask = (1 << tgtLgK) - 1;
-          final AbstractHllArray srcAbsHllArr = (AbstractHllArray)(src.hllSketchImpl);
           final AbstractHllArray tgtAbsHllArr = (AbstractHllArray)(tgt.hllSketchImpl);
-          for (int i = 0; i < srcK; i++) {
-            final int srcV = srcAbsHllArr.getSlotValue(i);
-            final int j = i & tgtKmask;
-            tgtAbsHllArr.updateSlotNoKxQ(j, srcV);
+          if (src.getTgtHllType() == HLL_4) {
+            final Hll4Array src4 = (Hll4Array) src.hllSketchImpl;
+            final AuxHashMap auxHashMap = src4.getAuxHashMap();
+            final int curMin = src4.getCurMin();
+            int i = 0;
+            int j = 0;
+            while (j < srcK) {
+              final byte b = src4.hllByteArr[i++];
+              int value = Byte.toUnsignedInt(b) & loNibbleMask;
+              tgtAbsHllArr.updateSlotNoKxQ(j & tgtKmask, value == AUX_TOKEN
+                  ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+              value = Byte.toUnsignedInt(b) >>> 4;
+              tgtAbsHllArr.updateSlotNoKxQ(j & tgtKmask, value == AUX_TOKEN
+                  ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+            }
+          } else {
+            final Hll6Array src6 = (Hll6Array) src.hllSketchImpl;
+            int i = 0;
+            int j = 0;
+            while (j < srcK) {
+              final byte b1 = src6.hllByteArr[i++];
+              final byte b2 = src6.hllByteArr[i++];
+              final byte b3 = src6.hllByteArr[i++];
+              int value = Byte.toUnsignedInt(b1) & 0x3f;
+              tgtAbsHllArr.updateSlotNoKxQ(j++ & tgtKmask, value);
+              value = Byte.toUnsignedInt(b1) >>> 6;
+              value |= (Byte.toUnsignedInt(b2) & 0x0f) << 2;
+              tgtAbsHllArr.updateSlotNoKxQ(j++ & tgtKmask, value);
+              value = Byte.toUnsignedInt(b2) >>> 4;
+              value |= (Byte.toUnsignedInt(b3) & 3) << 4;
+              tgtAbsHllArr.updateSlotNoKxQ(j++ & tgtKmask, value);
+              value = Byte.toUnsignedInt(b3) >>> 2;
+              tgtAbsHllArr.updateSlotNoKxQ(j++ & tgtKmask, value);
+            }
+          }
+          break;
+        }
+        case 14: case 15:
+        {
+          //!HLL_8, srcLgK>tgtLgK, src=mem, tgt=heap/mem
+          final int tgtKmask = (1 << tgtLgK) - 1;
+          final AbstractHllArray tgtAbsHllArr = (AbstractHllArray)(tgt.hllSketchImpl);
+          if (src.getTgtHllType() == HLL_4) {
+            final DirectHll4Array src4 = (DirectHll4Array) src.hllSketchImpl;
+            final AuxHashMap auxHashMap = src4.getAuxHashMap();
+            final int curMin = src4.getCurMin();
+            int i = 0;
+            int j = 0;
+            while (j < srcK) {
+              final byte b = src4.mem.getByte(HLL_BYTE_ARR_START + i++);
+              int value = Byte.toUnsignedInt(b) & loNibbleMask;
+              tgtAbsHllArr.updateSlotNoKxQ(j & tgtKmask, value == AUX_TOKEN
+                  ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+              value = Byte.toUnsignedInt(b) >>> 4;
+              tgtAbsHllArr.updateSlotNoKxQ(j & tgtKmask, value == AUX_TOKEN
+                  ? auxHashMap.mustFindValueFor(j) : value + curMin);
+              j++;
+            }
+          } else {
+            final DirectHll6Array src6 = (DirectHll6Array) src.hllSketchImpl;
+            int i = 0;
+            int offset = HLL_BYTE_ARR_START;
+            while (i < srcK) {
+              final byte b1 = src6.mem.getByte(offset++);
+              final byte b2 = src6.mem.getByte(offset++);
+              final byte b3 = src6.mem.getByte(offset++);
+              int value = Byte.toUnsignedInt(b1) & 0x3f;
+              tgtAbsHllArr.updateSlotNoKxQ(i++ & tgtKmask, value);
+              value = Byte.toUnsignedInt(b1) >>> 6;
+              value |= (Byte.toUnsignedInt(b2) & 0x0f) << 2;
+              tgtAbsHllArr.updateSlotNoKxQ(i++ & tgtKmask, value);
+              value = Byte.toUnsignedInt(b2) >>> 4;
+              value |= (Byte.toUnsignedInt(b3) & 3) << 4;
+              tgtAbsHllArr.updateSlotNoKxQ(i++ & tgtKmask, value);
+              value = Byte.toUnsignedInt(b3) >>> 2;
+              tgtAbsHllArr.updateSlotNoKxQ(i++ & tgtKmask, value);
+            }
           }
           break;
         }
@@ -608,7 +748,7 @@ public class Union extends BaseHllSketch {
       tgt.hllSketchImpl.putRebuildCurMinNumKxQFlag(true);
   }
 
-  //Used by union operator.  Always copies or downsamples to Heap HLL_8.
+  //Used by union operator. Always copies or downsamples to Heap HLL_8.
   //Caller must ultimately manage oooFlag, as caller has more context.
   /**
    * Copies or downsamples the given candidate HLLmode sketch to tgtLgK, HLL_8, on the heap.

--- a/src/main/java/org/apache/datasketches/hll/Union.java
+++ b/src/main/java/org/apache/datasketches/hll/Union.java
@@ -25,7 +25,6 @@ import static org.apache.datasketches.hll.HllUtil.EMPTY;
 import static org.apache.datasketches.hll.HllUtil.loNibbleMask;
 import static org.apache.datasketches.hll.PreambleUtil.HLL_BYTE_ARR_START;
 import static org.apache.datasketches.hll.PreambleUtil.extractTgtHllType;
-import static org.apache.datasketches.hll.HllUtil.loNibbleMask;
 import static org.apache.datasketches.hll.TgtHllType.HLL_4;
 import static org.apache.datasketches.hll.TgtHllType.HLL_8;
 

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -26,8 +26,8 @@ import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_BE_UPDATABLE_
 import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_CALL;
 import static org.apache.datasketches.kll.KllSketch.Error.TGT_IS_READ_ONLY;
 import static org.apache.datasketches.kll.KllSketch.Error.kllSketchThrow;
-import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.equallyWeightedRanks;
 
 import java.util.Objects;
 
@@ -169,6 +169,13 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   }
 
   @Override
+  public double[] getCDF(final double[] splitPoints, final QuantileSearchCriteria searchCrit) {
+    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+    refreshSortedView();
+    return kllDoublesSV.getCDF(splitPoints, searchCrit);
+  }
+
+  @Override
   public double getMaxItem() {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
     return getMaxDoubleItem();
@@ -181,10 +188,18 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   }
 
   @Override
-  public double[] getCDF(final double[] splitPoints, final QuantileSearchCriteria searchCrit) {
+  public DoublesPartitionBoundaries getPartitionBoundaries(final int numEquallyWeighted,
+      final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    refreshSortedView();
-    return kllDoublesSV.getCDF(splitPoints, searchCrit);
+    final double[] ranks = equallyWeightedRanks(numEquallyWeighted);
+    final double[] boundaries = getQuantiles(ranks, searchCrit);
+    boundaries[0] = getMinItem();
+    boundaries[boundaries.length - 1] = getMaxItem();
+    final DoublesPartitionBoundaries dpb = new DoublesPartitionBoundaries();
+    dpb.N = this.getN();
+    dpb.ranks = ranks;
+    dpb.boundaries = boundaries;
+    return dpb;
   }
 
   @Override
@@ -211,13 +226,6 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
       quantiles[i] = kllDoublesSV.getQuantile(ranks[i], searchCrit);
     }
     return quantiles;
-  }
-
-  @Override
-  public double[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
-    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
-        searchCrit);
   }
 
   /**

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -26,6 +26,7 @@ import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_BE_UPDATABLE_
 import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_CALL;
 import static org.apache.datasketches.kll.KllSketch.Error.TGT_IS_READ_ONLY;
 import static org.apache.datasketches.kll.KllSketch.Error.kllSketchThrow;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
 
 import java.util.Objects;
@@ -215,7 +216,7 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   @Override
   public double[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, numEvenlySpaced),
+    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
         searchCrit);
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -26,6 +26,7 @@ import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_BE_UPDATABLE_
 import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_CALL;
 import static org.apache.datasketches.kll.KllSketch.Error.TGT_IS_READ_ONLY;
 import static org.apache.datasketches.kll.KllSketch.Error.kllSketchThrow;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
 
 import java.util.Objects;
@@ -215,7 +216,7 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
   @Override
   public float[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, numEvenlySpaced),
+    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
         searchCrit);
   }
 

--- a/src/main/java/org/apache/datasketches/quantiles/ClassicUtil.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ClassicUtil.java
@@ -29,8 +29,6 @@ import static java.lang.Math.pow;
 import static java.lang.Math.round;
 import static org.apache.datasketches.common.Util.ceilingIntPowerOf2;
 import static org.apache.datasketches.common.Util.isIntPowerOf2;
-import static org.apache.datasketches.quantiles.DoublesSketch.MAX_K;
-import static org.apache.datasketches.quantiles.DoublesSketch.MIN_K;
 import static org.apache.datasketches.quantiles.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.EMPTY_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.ORDERED_FLAG_MASK;
@@ -42,22 +40,19 @@ import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.Memory;
 
 /**
- * Utilities for the classic quantiles sketches.
+ * Utilities for the classic quantiles sketches and independent of the type.
  *
  * @author Lee Rhodes
  */
 public final class ClassicUtil {
+  static final int DOUBLES_SER_VER = 3;
+  static final int MAX_PRELONGS = Family.QUANTILES.getMaxPreLongs();
+  static final int MIN_K = 2;
+  static final int MAX_K = 1 << 15;
 
   private ClassicUtil() {}
 
-  /**
-   * The java line separator character as a String.
-   */
   static final String LS = System.getProperty("line.separator");
-
-  /**
-   * The tab character
-   */
   static final char TAB = '\t';
 
   /**
@@ -166,7 +161,7 @@ public final class ClassicUtil {
     final int flagsMask = ~allowedFlags;
     if ((flags & flagsMask) > 0) {
       throw new SketchesArgumentException(
-         "Possible corruption: Invalid flags field: " + Integer.toBinaryString(flags));
+        "Possible corruption: Invalid flags field: " + Integer.toBinaryString(flags));
     }
   }
 
@@ -215,7 +210,7 @@ public final class ClassicUtil {
     final int totLevels = computeNumLevelsNeeded(k, n);
     if (totLevels == 0) {
       final int bbItems = computeBaseBufferItems(k, n);
-      return Math.max(2 * DoublesSketch.MIN_K, ceilingIntPowerOf2(bbItems));
+      return Math.max(2 * MIN_K, ceilingIntPowerOf2(bbItems));
     }
     return (2 + totLevels) * k;
   }

--- a/src/main/java/org/apache/datasketches/quantiles/DirectCompactDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DirectCompactDoublesSketch.java
@@ -19,6 +19,9 @@
 
 package org.apache.datasketches.quantiles;
 
+import static org.apache.datasketches.quantiles.ClassicUtil.DOUBLES_SER_VER;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkFamilyID;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkK;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeBaseBufferItems;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeBitPattern;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeRetainedItems;
@@ -86,7 +89,7 @@ final class DirectCompactDoublesSketch extends CompactDoublesSketch {
     //initialize dstMem
     dstMem.putLong(0, 0L); //clear pre0
     insertPreLongs(dstMem, 2);
-    insertSerVer(dstMem, DoublesSketch.DOUBLES_SER_VER);
+    insertSerVer(dstMem, DOUBLES_SER_VER);
     insertFamilyID(dstMem, Family.QUANTILES.getID());
     insertK(dstMem, k);
 
@@ -149,10 +152,10 @@ final class DirectCompactDoublesSketch extends CompactDoublesSketch {
 
     //VALIDITY CHECKS
     DirectUpdateDoublesSketchR.checkPreLongs(preLongs);
-    ClassicUtil.checkFamilyID(familyID);
+    checkFamilyID(familyID);
     DoublesUtil.checkDoublesSerVer(serVer, MIN_DIRECT_DOUBLES_SER_VER);
     checkCompact(serVer, flags);
-    ClassicUtil.checkK(k);
+    checkK(k);
     checkDirectMemCapacity(k, n, memCap);
     DirectUpdateDoublesSketchR.checkEmptyAndN(empty, n);
 

--- a/src/main/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DirectUpdateDoublesSketch.java
@@ -19,6 +19,10 @@
 
 package org.apache.datasketches.quantiles;
 
+import static org.apache.datasketches.quantiles.ClassicUtil.DOUBLES_SER_VER;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkFamilyID;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkK;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeBitPattern;
 import static org.apache.datasketches.quantiles.PreambleUtil.COMBINED_BUFFER;
 import static org.apache.datasketches.quantiles.PreambleUtil.EMPTY_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.FLAGS_BYTE;
@@ -39,7 +43,6 @@ import static org.apache.datasketches.quantiles.PreambleUtil.insertMinDouble;
 import static org.apache.datasketches.quantiles.PreambleUtil.insertN;
 import static org.apache.datasketches.quantiles.PreambleUtil.insertPreLongs;
 import static org.apache.datasketches.quantiles.PreambleUtil.insertSerVer;
-import static org.apache.datasketches.quantiles.ClassicUtil.computeBitPattern;
 
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -78,7 +81,7 @@ final class DirectUpdateDoublesSketch extends DirectUpdateDoublesSketchR {
     //initialize dstMem
     dstMem.putLong(0, 0L); //clear pre0
     insertPreLongs(dstMem, 2);
-    insertSerVer(dstMem, DoublesSketch.DOUBLES_SER_VER);
+    insertSerVer(dstMem, DOUBLES_SER_VER);
     insertFamilyID(dstMem, Family.QUANTILES.getID());
     insertFlags(dstMem, EMPTY_FLAG_MASK);
     insertK(dstMem, k);
@@ -114,10 +117,10 @@ final class DirectUpdateDoublesSketch extends DirectUpdateDoublesSketchR {
 
     //VALIDITY CHECKS
     checkPreLongs(preLongs);
-    ClassicUtil.checkFamilyID(familyID);
+    checkFamilyID(familyID);
     DoublesUtil.checkDoublesSerVer(serVer, MIN_DIRECT_DOUBLES_SER_VER);
     checkDirectFlags(flags); //Cannot be compact
-    ClassicUtil.checkK(k);
+    checkK(k);
     checkCompact(serVer, flags);
     checkDirectMemCapacity(k, n, memCap);
     checkEmptyAndN(empty, n);

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesByteArrayImpl.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesByteArrayImpl.java
@@ -19,6 +19,9 @@
 
 package org.apache.datasketches.quantiles;
 
+import static org.apache.datasketches.quantiles.ClassicUtil.DOUBLES_SER_VER;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeBaseBufferItems;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeTotalLevels;
 import static org.apache.datasketches.quantiles.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.EMPTY_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.ORDERED_FLAG_MASK;
@@ -104,7 +107,7 @@ final class DoublesByteArrayImpl {
     long memOffsetBytes = prePlusExtraBytes;
 
     // might need to sort base buffer but don't want to change input sketch
-    final int bbCnt = ClassicUtil.computeBaseBufferItems(k, n);
+    final int bbCnt = computeBaseBufferItems(k, n);
     if (bbCnt > 0) { //Base buffer items only
       final double[] bbItemsArr = dsa.getArray(0, bbCnt);
       if (ordered) { Arrays.sort(bbItemsArr); }
@@ -115,7 +118,7 @@ final class DoublesByteArrayImpl {
 
     // If serializing from a compact sketch to a non-compact form, we may end up copying data for a
     // higher level one or more times into an unused level. A bit wasteful, but not incorrect.
-    final int totalLevels = ClassicUtil.computeTotalLevels(sketch.getBitPattern());
+    final int totalLevels = computeTotalLevels(sketch.getBitPattern());
     for (int lvl = 0; lvl < totalLevels; ++lvl) {
       dsa.setLevel(lvl);
       if (dsa.numItems() > 0) {
@@ -131,7 +134,7 @@ final class DoublesByteArrayImpl {
   private static void insertPre0(final WritableMemory wmem,
       final int preLongs, final int flags, final int k) {
     insertPreLongs(wmem, preLongs);
-    insertSerVer(wmem, DoublesSketch.DOUBLES_SER_VER);
+    insertSerVer(wmem, DOUBLES_SER_VER);
     insertFamilyID(wmem, Family.QUANTILES.getID());
     insertFlags(wmem, flags);
     insertK(wmem, k);

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesSketch.java
@@ -23,6 +23,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static org.apache.datasketches.common.Util.ceilingIntPowerOf2;
 import static org.apache.datasketches.quantiles.ClassicUtil.checkIsCompactMemory;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
 
 import java.util.Random;
@@ -200,7 +201,7 @@ public abstract class DoublesSketch implements QuantilesDoublesAPI {
   @Override
   public double[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, numEvenlySpaced),
+    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
         searchCrit);
   }
 

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesUtil.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesUtil.java
@@ -20,6 +20,12 @@
 package org.apache.datasketches.quantiles;
 
 import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.quantiles.ClassicUtil.DOUBLES_SER_VER;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeCombinedBufferItemCapacity;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeNumLevelsNeeded;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeTotalLevels;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeValidLevels;
+import static org.apache.datasketches.quantiles.ClassicUtil.getNormalizedRankError;
 
 import java.util.Arrays;
 
@@ -54,7 +60,7 @@ final class DoublesUtil {
     qsCopy.putBitPattern(sketch.getBitPattern());
 
     if (sketch.isCompact()) {
-      final int combBufItems = ClassicUtil.computeCombinedBufferItemCapacity(sketch.getK(), sketch.getN());
+      final int combBufItems = computeCombinedBufferItemCapacity(sketch.getK(), sketch.getN());
       final double[] combBuf = new double[combBufItems];
       qsCopy.putCombinedBuffer(combBuf);
       final DoublesSketchAccessor sketchAccessor = DoublesSketchAccessor.wrap(sketch);
@@ -85,7 +91,7 @@ final class DoublesUtil {
    * @param minSupportedSerVer the oldest serialization version supported
    */
   static void checkDoublesSerVer(final int serVer, final int minSupportedSerVer) {
-    final int max = DoublesSketch.DOUBLES_SER_VER;
+    final int max = DOUBLES_SER_VER;
     if ((serVer > max) || (serVer < minSupportedSerVer)) {
       throw new SketchesArgumentException(
           "Possible corruption: Unsupported Serialization Version: " + serVer);
@@ -120,21 +126,21 @@ final class DoublesUtil {
     final String bbCntStr = String.format("%,d", sk.getBaseBufferCount());
     final String combBufCapStr = String.format("%,d", sk.getCombinedBufferItemCapacity());
     final long bitPattern = sk.getBitPattern();
-    final int neededLevels = ClassicUtil.computeNumLevelsNeeded(k, n);
-    final int totalLevels = ClassicUtil.computeTotalLevels(bitPattern);
-    final int validLevels = ClassicUtil.computeValidLevels(bitPattern);
+    final int neededLevels = computeNumLevelsNeeded(k, n);
+    final int totalLevels = computeTotalLevels(bitPattern);
+    final int validLevels = computeValidLevels(bitPattern);
     final String retItemsStr = String.format("%,d", sk.getNumRetained());
     final String cmptBytesStr = String.format("%,d", sk.getCurrentCompactSerializedSizeBytes());
     final String updtBytesStr = String.format("%,d", sk.getCurrentUpdatableSerializedSizeBytes());
-    final double epsPmf = ClassicUtil.getNormalizedRankError(k, true);
+    final double epsPmf = getNormalizedRankError(k, true);
     final String epsPmfPctStr = String.format("%.3f%%", epsPmf * 100.0);
-    final double eps =  ClassicUtil.getNormalizedRankError(k, false);
+    final double eps =  getNormalizedRankError(k, false);
     final String epsPctStr = String.format("%.3f%%", eps * 100.0);
     final String memCap = sk.hasMemory() ? Long.toString(sk.getMemory().getCapacity()) : "";
     final double minItem = sk.isEmpty() ? Double.NaN : sk.getMinItem();
     final double maxItem = sk.isEmpty() ? Double.NaN : sk.getMaxItem();
 
-    sb.append(ClassicUtil.LS).append("### Quantiles ").append(thisSimpleName).append(" SUMMARY: ")
+    sb.append(LS).append("### Quantiles ").append(thisSimpleName).append(" SUMMARY: ")
       .append(LS);
     sb.append("   Empty                        : ").append(sk.isEmpty()).append(LS);
     sb.append("   Memory, Capacity bytes       : ").append(sk.hasMemory())

--- a/src/main/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketch.java
@@ -19,9 +19,13 @@
 
 package org.apache.datasketches.quantiles;
 
+import static org.apache.datasketches.quantiles.ClassicUtil.MIN_K;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkFamilyID;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkHeapFlags;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeBaseBufferItems;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeBitPattern;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeCombinedBufferItemCapacity;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeNumLevelsNeeded;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeRetainedItems;
 import static org.apache.datasketches.quantiles.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.EMPTY_FLAG_MASK;
@@ -106,7 +110,7 @@ final class HeapUpdateDoublesSketch extends UpdateDoublesSketch {
    */
   static HeapUpdateDoublesSketch newInstance(final int k) {
     final HeapUpdateDoublesSketch hqs = new HeapUpdateDoublesSketch(k);
-    final int baseBufAlloc = 2 * Math.min(DoublesSketch.MIN_K, k); //the min is important
+    final int baseBufAlloc = 2 * Math.min(MIN_K, k); //the min is important
     hqs.n_ = 0;
     hqs.combinedBuffer_ = new double[baseBufAlloc];
     hqs.baseBufferCount_ = 0;
@@ -140,9 +144,9 @@ final class HeapUpdateDoublesSketch extends UpdateDoublesSketch {
 
     //VALIDITY CHECKS
     DoublesUtil.checkDoublesSerVer(serVer, MIN_HEAP_DOUBLES_SER_VER);
-    ClassicUtil.checkHeapFlags(flags);
+    checkHeapFlags(flags);
     checkPreLongsFlagsSerVer(flags, serVer, preLongs);
-    ClassicUtil.checkFamilyID(familyID);
+    checkFamilyID(familyID);
 
     final HeapUpdateDoublesSketch hds = newInstance(k); //checks k
     if (empty) { return hds; }
@@ -198,7 +202,7 @@ final class HeapUpdateDoublesSketch extends UpdateDoublesSketch {
   @Override
   public void reset() {
     n_ = 0;
-    final int combinedBufferItemCapacity = 2 * Math.min(DoublesSketch.MIN_K, k_); //min is important
+    final int combinedBufferItemCapacity = 2 * Math.min(MIN_K, k_); //min is important
     combinedBuffer_ = new double[combinedBufferItemCapacity];
     baseBufferCount_ = 0;
     bitPattern_ = 0;
@@ -310,7 +314,7 @@ final class HeapUpdateDoublesSketch extends UpdateDoublesSketch {
 
       }
     } else { //srcMem not compact
-      final int levels = ClassicUtil.computeNumLevelsNeeded(k, n);
+      final int levels = computeNumLevelsNeeded(k, n);
       final int totItems = (levels == 0) ? bbCnt : (2 + levels) * k;
       srcMem.getDoubleArray(preBytes, combinedBuffer, 0, totItems);
     }
@@ -393,7 +397,7 @@ final class HeapUpdateDoublesSketch extends UpdateDoublesSketch {
     final int oldSize = combinedBuffer_.length;
     assert oldSize < (2 * k_);
     final double[] baseBuffer = combinedBuffer_;
-    final int newSize = 2 * Math.max(Math.min(k_, oldSize), DoublesSketch.MIN_K);
+    final int newSize = 2 * Math.max(Math.min(k_, oldSize), MIN_K);
     combinedBuffer_ = Arrays.copyOf(baseBuffer, newSize);
   }
 
@@ -442,7 +446,7 @@ final class HeapUpdateDoublesSketch extends UpdateDoublesSketch {
     if (compact) {
       reqBufBytes = (metaPre + retainedItems) << 3;
     } else { //not compact
-      final int totLevels = ClassicUtil.computeNumLevelsNeeded(k, n);
+      final int totLevels = computeNumLevelsNeeded(k, n);
       reqBufBytes = (totLevels == 0)
           ? (metaPre + retainedItems) << 3
           : (metaPre + ((2 + totLevels) * k)) << 3;

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
@@ -31,6 +31,7 @@ import static org.apache.datasketches.quantiles.PreambleUtil.extractN;
 import static org.apache.datasketches.quantiles.PreambleUtil.extractPreLongs;
 import static org.apache.datasketches.quantiles.PreambleUtil.extractSerVer;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
 
 import java.lang.reflect.Array;
@@ -544,7 +545,7 @@ public final class ItemsSketch<T> implements QuantilesAPI {
    */
   public T[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, numEvenlySpaced),
+    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
         searchCrit);
   }
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesAPI.java
@@ -275,6 +275,8 @@ public interface QuantilesAPI {
   /**
    * Resets this sketch to the empty state.
    * If the sketch is <i>read only</i> this does nothing.
+   *
+   * <p>The parameter <i>k</i> will not change.</p>
    */
   void reset();
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -349,7 +349,8 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries} method.
+   * {@link org.apache.datasketches.quantilescommon.QuantilesDoublesAPI#getPartitionBoundaries(int,
+   * QuantileSearchCritera) getPartitionBoundaries} method.
    */
   static class DoublesPartitionBoundaries {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -235,24 +235,25 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
   }
 
   /**
-   * This is a version of getQuantiles() where the caller only specifies the number of of desired evenly spaced,
-   * normalized ranks, and returns an array of the corresponding quantiles.
+   * This is a version of getQuantiles() where the caller only specifies the number of of desired quantile intervals 
+   * that are computed from an array of evenly spaced normalized ranks between 0 and 1.0 determined from the given
+   * <i>numEvenlySpaced</i> parameter.
    *
-   * @param numEvenlySpaced an integer that specifies the number of evenly spaced normalized ranks.
-   * This must be a positive integer greater than 0.
-   * <ul><li>Let <i>Smallest</i> and <i>Largest</i> be the smallest and largest quantiles
-   * retained by the sketch algorithm, respectively.
-   * (This should not to be confused with {@link #getMinItem} and {@link #getMaxItem},
-   * which are the smallest and largest quantiles of the stream.)</li>
-   * <li>A 1 will return the Smallest quantile.</li>
-   * <li>A 2 will return the Smallest and Largest quantiles.</li>
-   * <li>A 3 will return the Smallest, the Median, and the Largest quantiles.</li>
+   * @param numEvenlySpaced an integer that specifies the number of desired quantile intervals to be returned
+   * from the sketch. This must be a positive integer greater than 0.
+   * <ul><li>Let <i>Largest</i> be the largest quantile retained by the sketch algorithm.
+   * (This should not to be confused with {@link #getMaxItem},
+   * which is the largest quantile of the stream. They may be equal, but not necessarily.)</li>
+   * <li>A 1 will return the Largest quantile.</li>
+   * <li>A 2 will return 2 quantiles, including the Largest, dividing the quantile domain into two regions. 
+   * The first returned quantile should roughly correspond to the median quantile</li>
+   * <li>A 3 will return 3 quantiles, including the Largest, dividing the quantile domain into three regions.</li>
    * <li>Etc.</li>
    * </ul>
    *
    * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
-   * each rank.
-   * @return an array of quantiles that are evenly spaced by their ranks.
+   * any given rank. In this case the ranks are generated internally by this method.
+   * @return an array of quantiles that divide the quantile domain into numEvenlySpaced quantile intervals.
    * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced is less than 1</i>.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -93,7 +93,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
   double getMinItem();
 
   /**
-   * This method returns an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries} which provides
+   * This method returns an instance of {@link DoublesPartitionBoundaries DoublesPartitionBoundaries} which provides
    * sufficient information for the user to create the given number of equally weighted partitions.
    *
    * <p>This method is equivalent to
@@ -102,33 +102,32 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    *
    * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
    * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
-   * This must be a positive integer greater than 0.
+   * This must be a positive integer greater than zero.
    * <ul>
    * <li>A 1 will return: minItem, maxItem.</li>
    * <li>A 2 will return: minItem, median quantile, maxItem.</li>
-   * <li>Etc.<li>
+   * <li>Etc.</li>
    * </ul>
    *
-   * @return an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries}.
+   * @return an instance of {@link DoublesPartitionBoundaries DoublesPartitionBoundaries}.
    * @throws IllegalArgumentException if sketch is empty.
    * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   default DoublesPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted) {
     return getPartitionBoundaries(numEquallyWeighted, INCLUSIVE);
   }
 
   /**
-   * This method returns an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries} which provides
+   * This method returns an instance of {@link DoublesPartitionBoundaries DoublesPartitionBoundaries} which provides
    * sufficient information for the user to create the given number of equally weighted partitions.
    *
    * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
    * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
-   * This must be a positive integer greater than 0.
+   * This must be a positive integer greater than zero.
    * <ul>
    * <li>A 1 will return: minItem, maxItem.</li>
    * <li>A 2 will return: minItem, median quantile, maxItem.</li>
-   * <li>Etc.<li>
+   * <li>Etc.</li>
    * </ul>
    *
    * @param searchCrit
@@ -137,10 +136,9 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * If EXCLUSIVE, all the returned quantiles are the lower boundaries of the equally weighted partitions
    * with the exception of the highest returned quantile, which is the upper boundary of the highest ranked partition.
    *
-   * @return an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries}.
+   * @return an instance of {@link DoublesPartitionBoundaries DoublesPartitionBoundaries}.
    * @throws IllegalArgumentException if sketch is empty.
    * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   DoublesPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted, QuantileSearchCriteria searchCrit);
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -349,8 +349,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link org.apache.datasketches.quantilescommon.QuantilesDoublesAPI#getPartitionBoundaries(int,
-   * QuantileSearchCritera) getPartitionBoundaries} method.
+   * <i>getPartitionBoundaries(int, QuantileSearchCritera)</i> method.
    */
   static class DoublesPartitionBoundaries {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -349,7 +349,7 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
+   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries} method.
    */
   static class DoublesPartitionBoundaries {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesDoublesAPI.java
@@ -93,6 +93,58 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
   double getMinItem();
 
   /**
+   * This method returns an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries} which provides
+   * sufficient information for the user to create the given number of equally weighted partitions.
+   *
+   * <p>This method is equivalent to
+   * {@link #getPartitionBoundaries(int, QuantileSearchCriteria) getPartitionBoundaries(numEquallyWeighted, INCLUSIVE)}.
+   * </p>
+   *
+   * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
+   * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
+   * This must be a positive integer greater than 0.
+   * <ul>
+   * <li>A 1 will return: minItem, maxItem.</li>
+   * <li>A 2 will return: minItem, median quantile, maxItem.</li>
+   * <li>Etc.<li>
+   * </ul>
+   *
+   * @return an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries}.
+   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
+   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
+   */
+  default DoublesPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted) {
+    return getPartitionBoundaries(numEquallyWeighted, INCLUSIVE);
+  }
+
+  /**
+   * This method returns an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries} which provides
+   * sufficient information for the user to create the given number of equally weighted partitions.
+   *
+   * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
+   * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
+   * This must be a positive integer greater than 0.
+   * <ul>
+   * <li>A 1 will return: minItem, maxItem.</li>
+   * <li>A 2 will return: minItem, median quantile, maxItem.</li>
+   * <li>Etc.<li>
+   * </ul>
+   *
+   * @param searchCrit
+   * If INCLUSIVE, all the returned quantiles are the upper boundaries of the equally weighted partitions
+   * with the exception of the lowest returned quantile, which is the lowest boundary of the lowest ranked partition.
+   * If EXCLUSIVE, all the returned quantiles are the lower boundaries of the equally weighted partitions
+   * with the exception of the highest returned quantile, which is the upper boundary of the highest ranked partition.
+   *
+   * @return an instance of {@link #DoublesPartitionBoundaries DoublesPartitionBoundaries}.
+   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
+   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
+   */
+  DoublesPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted, QuantileSearchCriteria searchCrit);
+
+  /**
    * This is equivalent to {@link #getPMF(double[], QuantileSearchCriteria) getPMF(splitPoints, INCLUSIVE)}
    * @param splitPoints an array of <i>m</i> unique, monotonically increasing items.
    * @return a PMF array of m+1 probability masses as doubles on the interval [0.0, 1.0].
@@ -225,41 +277,6 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
   double[] getQuantiles(double[] ranks, QuantileSearchCriteria searchCrit);
 
   /**
-   * This is equivalent to {@link #getQuantiles(int, QuantileSearchCriteria) getQuantiles(numEvenlySpaced, INCLUSIVE)}
-   * @param numEvenlySpaced number of evenly spaced normalized ranks
-   * @return an array of quantiles that are evenly spaced by their ranks.
-   * @throws IllegalArgumentException if sketch is empty.
-   */
-  default double[] getQuantiles(int numEvenlySpaced) {
-    return getQuantiles(numEvenlySpaced, INCLUSIVE);
-  }
-
-  /**
-   * This is a version of getQuantiles() where the caller only specifies the number of of desired quantile intervals 
-   * that are computed from an array of evenly spaced normalized ranks between 0 and 1.0 determined from the given
-   * <i>numEvenlySpaced</i> parameter.
-   *
-   * @param numEvenlySpaced an integer that specifies the number of desired quantile intervals to be returned
-   * from the sketch. This must be a positive integer greater than 0.
-   * <ul><li>Let <i>Largest</i> be the largest quantile retained by the sketch algorithm.
-   * (This should not to be confused with {@link #getMaxItem},
-   * which is the largest quantile of the stream. They may be equal, but not necessarily.)</li>
-   * <li>A 1 will return the Largest quantile.</li>
-   * <li>A 2 will return 2 quantiles, including the Largest, dividing the quantile domain into two regions. 
-   * The first returned quantile should roughly correspond to the median quantile</li>
-   * <li>A 3 will return 3 quantiles, including the Largest, dividing the quantile domain into three regions.</li>
-   * <li>Etc.</li>
-   * </ul>
-   *
-   * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
-   * any given rank. In this case the ranks are generated internally by this method.
-   * @return an array of quantiles that divide the quantile domain into numEvenlySpaced quantile intervals.
-   * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced is less than 1</i>.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   */
-  double[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);
-
-  /**
    * This is equivalent to {@link #getRank(double, QuantileSearchCriteria) getRank(quantile, INCLUSIVE)}
    * @param quantile the given quantile
    * @return the normalized rank corresponding to the given quantile
@@ -331,5 +348,40 @@ public interface QuantilesDoublesAPI extends QuantilesAPI {
    * @param item from a stream of quantiles. NaNs are ignored.
    */
   void update(double item);
+
+  /**
+   * This encapsulates the essential information needed to construct actual partitions and is returned from the
+   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
+   */
+  static class DoublesPartitionBoundaries {
+
+    /**
+     * The total number of items presented to the sketch.
+     *
+     * <p>To compute the weight or density of a specific
+     * partition <i>i</i> where <i>i</i> varies from 1 to <i>m</i> partitions:
+     * <pre>{@code
+     * long N = getN();
+     * double[] ranks = getRanks();
+     * long weight = Math.round((ranks[i] - ranks[i - 1]) * N);
+     * }</pre>
+     */
+    public long N;
+
+    /**
+     * The normalized ranks that correspond to the returned boundaries.
+     * The returned array is of size <i>(m + 1)</i>, where <i>m</i> is the requested number of partitions.
+     * Index 0 of the returned array is always 0.0, and index <i>m</i> is always 1.0.
+     */
+    public double[] ranks;
+
+    /**
+     * The partition boundaries as quantiles.
+     * The returned array is of size <i>(m + 1)</i>, where <i>m</i> is the requested number of partitions.
+     * Index 0 of the returned array is always {@link #getMinItem() getMinItem()}, and index <i>m</i> is always
+     * {@link #getMaxItem() getMaxItem()}.
+     */
+    public double[] boundaries;
+  }
 }
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -348,8 +348,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link org.apache.datasketches.quantilescommon.QuantilesFloatsAPI#getPartitionBoundaries(int,
-   * QuantileSearchCritera) getPartitionBoundaries} method.
+   * <i>getPartitionBoundaries(int, QuantileSearchCritera)</i> method.
    */
 
   static class FloatsPartitionBoundaries {

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -348,8 +348,10 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries} method.
+   * {@link org.apache.datasketches.quantilescommon.QuantilesFloatsAPI#getPartitionBoundaries(int,
+   * QuantileSearchCritera) getPartitionBoundaries} method.
    */
+
   static class FloatsPartitionBoundaries {
 
     /**

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -348,7 +348,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
+   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries} method.
    */
   static class FloatsPartitionBoundaries {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -92,7 +92,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
   float getMinItem();
 
   /**
-   * This method returns an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries} which provides
+   * This method returns an instance of {@link FloatsPartitionBoundaries FloatsPartitionBoundaries} which provides
    * sufficient information for the user to create the given number of equally weighted partitions.
    *
    * <p>This method is equivalent to
@@ -101,33 +101,32 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    *
    * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
    * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
-   * This must be a positive integer greater than 0.
+   * This must be a positive integer greater than zero.
    * <ul>
    * <li>A 1 will return: minItem, maxItem.</li>
    * <li>A 2 will return: minItem, median quantile, maxItem.</li>
-   * <li>Etc.<li>
+   * <li>Etc.</li>
    * </ul>
    *
-   * @return an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries}.
+   * @return an instance of {@link FloatsPartitionBoundaries FloatsPartitionBoundaries}.
    * @throws IllegalArgumentException if sketch is empty.
    * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   default FloatsPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted) {
     return getPartitionBoundaries(numEquallyWeighted, INCLUSIVE);
   }
 
   /**
-   * This method returns an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries} which provides
+   * This method returns an instance of {@link FloatsPartitionBoundaries FloatsPartitionBoundaries} which provides
    * sufficient information for the user to create the given number of equally weighted partitions.
    *
    * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
    * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
-   * This must be a positive integer greater than 0.
+   * This must be a positive integer greater than zero.
    * <ul>
    * <li>A 1 will return: minItem, maxItem.</li>
    * <li>A 2 will return: minItem, median quantile, maxItem.</li>
-   * <li>Etc.<li>
+   * <li>Etc.</li>
    * </ul>
    *
    * @param searchCrit
@@ -136,10 +135,9 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * If EXCLUSIVE, all the returned quantiles are the lower boundaries of the equally weighted partitions
    * with the exception of the highest returned quantile, which is the upper boundary of the highest ranked partition.
    *
-   * @return an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries}.
+   * @return an instance of {@link FloatsPartitionBoundaries FloatsPartitionBoundaries}.
    * @throws IllegalArgumentException if sketch is empty.
    * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   FloatsPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted, QuantileSearchCriteria searchCrit);
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -234,24 +234,25 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
   }
 
   /**
-   * This is a version of getQuantiles() where the caller only specifies the number of of desired evenly spaced,
-   * normalized ranks, and returns an array of the corresponding quantiles.
+   * This is a version of getQuantiles() where the caller only specifies the number of of desired quantile intervals 
+   * that are computed from an array of evenly spaced normalized ranks between 0 and 1.0 determined from the given
+   * <i>numEvenlySpaced</i> parameter.
    *
-   * @param numEvenlySpaced an integer that specifies the number of evenly spaced normalized ranks.
-   * This must be a positive integer greater than 0.
-   * <ul><li>Let <i>Smallest</i> and <i>Largest</i> be the smallest and largest quantiles
-   * retained by the sketch algorithm, respectively.
-   * (This should not to be confused with {@link #getMinItem} and {@link #getMaxItem},
-   * which are the smallest and largest quantiles of the stream.)</li>
-   * <li>A 1 will return the Smallest quantile.</li>
-   * <li>A 2 will return the Smallest and Largest quantiles.</li>
-   * <li>A 3 will return the Smallest, the Median, and the Largest quantiles.</li>
+   * @param numEvenlySpaced an integer that specifies the number of desired quantile intervals to be returned
+   * from the sketch. This must be a positive integer greater than 0.
+   * <ul><li>Let <i>Largest</i> be the largest quantile retained by the sketch algorithm.
+   * (This should not to be confused with {@link #getMaxItem},
+   * which is the largest quantile of the stream. They may be equal, but not necessarily.)</li>
+   * <li>A 1 will return the Largest quantile.</li>
+   * <li>A 2 will return 2 quantiles, including the Largest, dividing the quantile domain into two regions. 
+   * The first returned quantile should roughly correspond to the median quantile</li>
+   * <li>A 3 will return 3 quantiles, including the Largest, dividing the quantile domain into three regions.</li>
    * <li>Etc.</li>
    * </ul>
    *
    * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
-   * each rank.
-   * @return an array of quantiles that are evenly spaced by their ranks.
+   * any given rank. In this case the ranks are generated internally by this method.
+   * @return an array of quantiles that divide the quantile domain into numEvenlySpaced quantile intervals.
    * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced is less than 1</i>.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -92,6 +92,58 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
   float getMinItem();
 
   /**
+   * This method returns an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries} which provides
+   * sufficient information for the user to create the given number of equally weighted partitions.
+   *
+   * <p>This method is equivalent to
+   * {@link #getPartitionBoundaries(int, QuantileSearchCriteria) getPartitionBoundaries(numEquallyWeighted, INCLUSIVE)}.
+   * </p>
+   *
+   * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
+   * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
+   * This must be a positive integer greater than 0.
+   * <ul>
+   * <li>A 1 will return: minItem, maxItem.</li>
+   * <li>A 2 will return: minItem, median quantile, maxItem.</li>
+   * <li>Etc.<li>
+   * </ul>
+   *
+   * @return an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries}.
+   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
+   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
+   */
+  default FloatsPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted) {
+    return getPartitionBoundaries(numEquallyWeighted, INCLUSIVE);
+  }
+
+  /**
+   * This method returns an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries} which provides
+   * sufficient information for the user to create the given number of equally weighted partitions.
+   *
+   * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
+   * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
+   * This must be a positive integer greater than 0.
+   * <ul>
+   * <li>A 1 will return: minItem, maxItem.</li>
+   * <li>A 2 will return: minItem, median quantile, maxItem.</li>
+   * <li>Etc.<li>
+   * </ul>
+   *
+   * @param searchCrit
+   * If INCLUSIVE, all the returned quantiles are the upper boundaries of the equally weighted partitions
+   * with the exception of the lowest returned quantile, which is the lowest boundary of the lowest ranked partition.
+   * If EXCLUSIVE, all the returned quantiles are the lower boundaries of the equally weighted partitions
+   * with the exception of the highest returned quantile, which is the upper boundary of the highest ranked partition.
+   *
+   * @return an instance of {@link #FloatsPartitionBoundaries FloatsPartitionBoundaries}.
+   * @throws IllegalArgumentException if sketch is empty.
+   * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
+   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
+   */
+  FloatsPartitionBoundaries getPartitionBoundaries(int numEquallyWeighted, QuantileSearchCriteria searchCrit);
+
+  /**
    * This is equivalent to {@link #getPMF(float[], QuantileSearchCriteria) getPMF(splitPoints, INCLUSIVE)}
    * @param splitPoints an array of <i>m</i> unique, monotonically increasing items.
    * @return a PMF array of m+1 probability masses as doubles on the interval [0.0, 1.0].
@@ -224,41 +276,6 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
   float[] getQuantiles(double[] ranks, QuantileSearchCriteria searchCrit);
 
   /**
-   * This is equivalent to {@link #getQuantiles(int, QuantileSearchCriteria) getQuantiles(numEvenlySpaced, INCLUSIVE)}
-   * @param numEvenlySpaced number of evenly spaced normalized ranks
-   * @return an array of quantiles that are evenly spaced by their ranks.
-   * @throws IllegalArgumentException if sketch is empty.
-   */
-  default float[] getQuantiles(int numEvenlySpaced) {
-    return getQuantiles(numEvenlySpaced, INCLUSIVE);
-  }
-
-  /**
-   * This is a version of getQuantiles() where the caller only specifies the number of of desired quantile intervals 
-   * that are computed from an array of evenly spaced normalized ranks between 0 and 1.0 determined from the given
-   * <i>numEvenlySpaced</i> parameter.
-   *
-   * @param numEvenlySpaced an integer that specifies the number of desired quantile intervals to be returned
-   * from the sketch. This must be a positive integer greater than 0.
-   * <ul><li>Let <i>Largest</i> be the largest quantile retained by the sketch algorithm.
-   * (This should not to be confused with {@link #getMaxItem},
-   * which is the largest quantile of the stream. They may be equal, but not necessarily.)</li>
-   * <li>A 1 will return the Largest quantile.</li>
-   * <li>A 2 will return 2 quantiles, including the Largest, dividing the quantile domain into two regions. 
-   * The first returned quantile should roughly correspond to the median quantile</li>
-   * <li>A 3 will return 3 quantiles, including the Largest, dividing the quantile domain into three regions.</li>
-   * <li>Etc.</li>
-   * </ul>
-   *
-   * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
-   * any given rank. In this case the ranks are generated internally by this method.
-   * @return an array of quantiles that divide the quantile domain into numEvenlySpaced quantile intervals.
-   * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced is less than 1</i>.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
-   */
-  float[] getQuantiles(int numEvenlySpaced, QuantileSearchCriteria searchCrit);
-
-  /**
    * This is equivalent to {@link #getRank(float, QuantileSearchCriteria) getRank(quantile, INCLUSIVE)}
    * @param quantile the given quantile
    * @return the normalized rank corresponding to the given quantile.
@@ -330,5 +347,40 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * @param item from a stream of quantiles. NaNs are ignored.
    */
   void update(float item);
+
+  /**
+   * This encapsulates the essential information needed to construct actual partitions and is returned from the
+   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
+   */
+  static class FloatsPartitionBoundaries {
+
+    /**
+     * The total number of items presented to the sketch.
+     *
+     * <p>To compute the weight or density of a specific
+     * partition <i>i</i> where <i>i</i> varies from 1 to <i>m</i> partitions:
+     * <pre>{@code
+     * long N = getN();
+     * double[] ranks = getRanks();
+     * long weight = Math.round((ranks[i] - ranks[i - 1]) * N);
+     * }</pre>
+     */
+    public long N;
+
+    /**
+     * The normalized ranks that correspond to the returned boundaries.
+     * The returned array is of size <i>(m + 1)</i>, where <i>m</i> is the requested number of partitions.
+     * Index 0 of the returned array is always 0.0, and index <i>m</i> is always 1.0.
+     */
+    public double[] ranks;
+
+    /**
+     * The partition boundaries as quantiles.
+     * The returned array is of size <i>(m + 1)</i>, where <i>m</i> is the requested number of partitions.
+     * Index 0 of the returned array is always {@link #getMinItem() getMinItem()}, and index <i>m</i> is always
+     * {@link #getMaxItem() getMaxItem()}.
+     */
+    public float[] boundaries;
+  }
 }
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -235,24 +235,25 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
   }
 
   /**
-   * This is a version of getQuantiles() where the caller only specifies the number of of desired evenly spaced,
-   * normalized ranks, and returns an array of the corresponding quantiles.
+   * This is a version of getQuantiles() where the caller only specifies the number of of desired quantile intervals 
+   * that are computed from an array of evenly spaced normalized ranks between 0 and 1.0 determined from the given
+   * <i>numEvenlySpaced</i> parameter.
    *
-   * @param numEvenlySpaced an integer that specifies the number of evenly spaced normalized ranks.
-   * This must be a positive integer greater than 0.
-   * <ul><li>Let <i>Smallest</i> and <i>Largest</i> be the smallest and largest quantiles
-   * retained by the sketch algorithm, respectively.
-   * (This should not to be confused with {@link #getMinItem} and {@link #getMaxItem},
-   * which are the smallest and largest quantiles of the stream.)</li>
-   * <li>A 1 will return the Smallest quantile.</li>
-   * <li>A 2 will return the Smallest and Largest quantiles.</li>
-   * <li>A 3 will return the Smallest, the Median, and the Largest quantiles.</li>
+   * @param numEvenlySpaced an integer that specifies the number of desired quantile intervals to be returned
+   * from the sketch. This must be a positive integer greater than 0.
+   * <ul><li>Let <i>Largest</i> be the largest quantile retained by the sketch algorithm.
+   * (This should not to be confused with {@link #getMaxItem},
+   * which is the largest quantile of the stream. They may be equal, but not necessarily.)</li>
+   * <li>A 1 will return the Largest quantile.</li>
+   * <li>A 2 will return 2 quantiles, including the Largest, dividing the quantile domain into two regions. 
+   * The first returned quantile should roughly correspond to the median quantile</li>
+   * <li>A 3 will return 3 quantiles, including the Largest, dividing the quantile domain into three regions.</li>
    * <li>Etc.</li>
    * </ul>
    *
    * @param searchCrit if INCLUSIVE, the given ranks include all quantiles &le; the quantile directly corresponding to
-   * each rank.
-   * @return an array of quantiles that are evenly spaced by their ranks.
+   * any given rank. In this case the ranks are generated internally by this method.
+   * @return an array of quantiles that divide the quantile domain into numEvenlySpaced quantile intervals.
    * @throws IllegalArgumentException if sketch is empty or if <i>numEvenlySpaced is less than 1</i>.
    * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -93,7 +93,8 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
   T getMinItem();
 
   /**
-   * This method returns an instance of {@link #GenericPartitionBoundaries GenericPartitionBoundaries} which provides
+   * This method returns an instance of
+   * {@link GenericPartitionBoundaries GenericPartitionBoundaries} which provides
    * sufficient information for the user to create the given number of equally weighted partitions.
    *
    * <p>This method is equivalent to
@@ -102,33 +103,33 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    *
    * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
    * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
-   * This must be a positive integer greater than 0.
+   * This must be a positive integer greater than zero.
    * <ul>
    * <li>A 1 will return: minItem, maxItem.</li>
    * <li>A 2 will return: minItem, median quantile, maxItem.</li>
-   * <li>Etc.<li>
+   * <li>Etc.</li>
    * </ul>
    *
-   * @return an instance of {@link #GenericPartitionBoundaries GenericPartitionBoundaries}.
+   * @return an instance of {@link GenericPartitionBoundaries GenericPartitionBoundaries}.
    * @throws IllegalArgumentException if sketch is empty.
    * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   default GenericPartitionBoundaries<T> getPartitionBoundaries(int numEquallyWeighted) {
     return getPartitionBoundaries(numEquallyWeighted, INCLUSIVE);
   }
 
   /**
-   * This method returns an instance of {@link #GenericPartitionBoundaries GenericPartitionBoundaries} which provides
+   * This method returns an instance of
+   * {@link GenericPartitionBoundaries GenericPartitionBoundaries} which provides
    * sufficient information for the user to create the given number of equally weighted partitions.
    *
    * @param numEquallyWeighted an integer that specifies the number of equally weighted partitions between
    * {@link #getMinItem() getMinItem()} and {@link #getMaxItem() getMaxItem()}.
-   * This must be a positive integer greater than 0.
+   * This must be a positive integer greater than zero.
    * <ul>
    * <li>A 1 will return: minItem, maxItem.</li>
    * <li>A 2 will return: minItem, median quantile, maxItem.</li>
-   * <li>Etc.<li>
+   * <li>Etc.</li>
    * </ul>
    *
    * @param searchCrit
@@ -137,10 +138,9 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
    * If EXCLUSIVE, all the returned quantiles are the lower boundaries of the equally weighted partitions
    * with the exception of the highest returned quantile, which is the upper boundary of the highest ranked partition.
    *
-   * @return an instance of {@link #GenericPartitionBoundaries GenericPartitionBoundaries}.
+   * @return an instance of {@link GenericPartitionBoundaries GenericPartitionBoundaries}.
    * @throws IllegalArgumentException if sketch is empty.
    * @throws IllegalArgumentException if <i>numEquallyWeighted</i> is less than 1.
-   * @see org.apache.datasketches.quantilescommon.QuantileSearchCriteria
    */
   GenericPartitionBoundaries<T> getPartitionBoundaries(int numEquallyWeighted, QuantileSearchCriteria searchCrit);
 
@@ -339,7 +339,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
+   * {@link QuantilesGenericAPI#getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
    */
   static class GenericPartitionBoundaries<T> {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -339,7 +339,8 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries} method.
+   * {@link org.apache.datasketches.quantilescommon.QuantilesGenericAPI#getPartitionBoundaries(int,
+   * QuantileSearchCritera) getPartitionBoundaries} method.
    */
   static class GenericPartitionBoundaries<T> {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -339,8 +339,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link org.apache.datasketches.quantilescommon.QuantilesGenericAPI#getPartitionBoundaries(int,
-   * QuantileSearchCritera) getPartitionBoundaries} method.
+   * <i>getPartitionBoundaries(int, QuantileSearchCritera)</i> method.
    */
   static class GenericPartitionBoundaries<T> {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesGenericAPI.java
@@ -339,7 +339,7 @@ public interface QuantilesGenericAPI<T> extends QuantilesAPI {
 
   /**
    * This encapsulates the essential information needed to construct actual partitions and is returned from the
-   * {@link QuantilesGenericAPI#getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries(...)} method.
+   * {@link #getPartitionBoundaries(int, QuantileSearchCritera) getPartitionBoundaries} method.
    */
   static class GenericPartitionBoundaries<T> {
 

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesUtil.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesUtil.java
@@ -80,28 +80,20 @@ public final class QuantilesUtil {
   }
 
   /**
-   * Returns a double array of evenly spaced values between value1 and value2 inclusive.
-   * If value2 &gt; value1, the resulting sequence will be increasing.
-   * If value2 &lt; value1, the resulting sequence will be decreasing.
-   * If num == 1, value1 will be in index 0 of the returned array.
-   * @param value1 will be in index 0 of the returned array
-   * @param value2 will be in the highest index of the returned array
-   * @param num the total number of values including value1 and value2. Must be 1 or greater.
-   * @return a double array of evenly spaced values between value1 and value2 inclusive.
+   * Returns a double array of evenly spaced values between 0.0, exclusive, and 1.0, inclusive.
+   * If num == 1, 1.0 will be in index 0 of the returned array.
+   * @param num the total number of values excluding 0 and including 1.0. Must be 1 or greater.
+   * @return a double array of evenly spaced values between 0.0, exclusive, and 1.0, inclusive.
    * @throws IllegalArgumentException if <i>num</i> is less than 1.
    */
-  public static double[] evenlySpaced(final double value1, final double value2, final int num) {
-    if (num < 1) {
-      throw new IllegalArgumentException("num must be >= 1");
-    }
+  public static double[] evenlySpacedRanks(final int num) {
+    if (num < 1) { throw new IllegalArgumentException("num must be >= 1"); }
     final double[] out = new double[num];
-    out[0] = value1;
-    if (num == 1) { return out; }
-    out[num - 1] = value2;
-    if (num == 2) { return out; }
+    if (num == 1) { return new double[] { 1.0 }; }
+    out[num - 1] = 1.0;
 
-    final double delta = (value2 - value1) / (num - 1);
-    for (int i = 1; i < num - 1; i++) { out[i] = i * delta + value1; }
+    final double delta = 1.0 / num;
+    for (int i = 0; i < num - 1; i++) { out[i] = (i + 1) * delta; }
     return out;
   }
 
@@ -130,6 +122,30 @@ public final class QuantilesUtil {
   }
 
   /**
+   * Returns a double array of evenly spaced values between value1, inclusive, and value2 inclusive.
+   * If value2 &gt; value1, the resulting sequence will be increasing.
+   * If value2 &lt; value1, the resulting sequence will be decreasing.
+   * @param value1 will be in index 0 of the returned array
+   * @param value2 will be in the highest index of the returned array
+   * @param num the total number of values including value1 and value2. Must be 2 or greater.
+   * @return a float array of evenly spaced values between value1 and value2 inclusive.
+   */
+  public static double[] evenlySpacedDoubles(final double value1, final double value2, final int num) {
+    if (num < 2) {
+      throw new SketchesArgumentException("num must be >= 2");
+    }
+    final double[] out = new double[num];
+    out[0] = value1;
+    out[num - 1] = value2;
+    if (num == 2) { return out; }
+
+    final double delta = (value2 - value1) / (num - 1);
+
+    for (int i = 1; i < num - 1; i++) { out[i] = i * delta + value1; }
+    return out;
+  }
+  
+  /**
    * Returns a double array of values between min and max inclusive where the log of the
    * returned values are evenly spaced.
    * If value2 &gt; value1, the resulting sequence will be increasing.
@@ -147,7 +163,7 @@ public final class QuantilesUtil {
       throw new SketchesArgumentException("value1 and value2 must be > 0.");
     }
 
-    final double[] arr = evenlySpaced(log(value1) / Util.LOG2, log(value2) / Util.LOG2, num);
+    final double[] arr = evenlySpacedDoubles(log(value1) / Util.LOG2, log(value2) / Util.LOG2, num);
     for (int i = 0; i < arr.length; i++) { arr[i] = pow(2.0,arr[i]); }
     return arr;
   }

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesUtil.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesUtil.java
@@ -45,7 +45,7 @@ public final class QuantilesUtil {
   public static final void checkNormalizedRankBounds(final double nRank) {
     if ((nRank < 0.0) || (nRank > 1.0)) {
       throw new SketchesArgumentException(
-        "A normalized rank must be >= 0 and <= 1.0: " + nRank);
+          "A normalized rank must be >= 0 and <= 1.0: " + nRank);
     }
   }
 
@@ -80,31 +80,35 @@ public final class QuantilesUtil {
   }
 
   /**
-   * Returns a double array of evenly spaced values between 0.0, exclusive, and 1.0, inclusive.
-   * If num == 1, 1.0 will be in index 0 of the returned array.
-   * @param num the total number of values excluding 0 and including 1.0. Must be 1 or greater.
-   * @return a double array of evenly spaced values between 0.0, exclusive, and 1.0, inclusive.
+   * Returns a double array of ranks that defines equally weighted regions between 0.0, inclusive and 1.0, inclusive.
+   * The 0.0 and 1.0 end points are part of the returned array and are the getMinItem() and getMaxItem() values of the
+   * sketch.
+   * For example, if num == 2, three values will be returned: 0.0, .5, and 1, where the two equally weighted regions are
+   * 0.0 to 0.5, and 0.5 to 1.0.
+   * @param num the total number of equally weighted regions between 0.0 and 1.0 defined by the ranks in the returned
+   * array.  <i>num</i> must be 1 or greater.
+   * @return a double array of <i>num + 1</i> ranks that define the boundaries of <i>num</i> equally weighted
+   * regions between 0.0, inclusive and 1.0, inclusive.
    * @throws IllegalArgumentException if <i>num</i> is less than 1.
    */
-  public static double[] evenlySpacedRanks(final int num) {
+  public static double[] equallyWeightedRanks(final int num) {
     if (num < 1) { throw new IllegalArgumentException("num must be >= 1"); }
-    final double[] out = new double[num];
-    if (num == 1) { return new double[] { 1.0 }; }
-    out[num - 1] = 1.0;
-
+    final double[] out = new double[num + 1];
+    out[0] = 0.0;
+    out[num] = 1.0;
     final double delta = 1.0 / num;
-    for (int i = 0; i < num - 1; i++) { out[i] = (i + 1) * delta; }
+    for (int i = 1; i < num; i++) { out[i] = i * delta; }
     return out;
   }
 
   /**
-   * Returns a float array of evenly spaced values between value1 and value2 inclusive.
+   * Returns a float array of evenly spaced values between value1, inclusive, and value2 inclusive.
    * If value2 &gt; value1, the resulting sequence will be increasing.
    * If value2 &lt; value1, the resulting sequence will be decreasing.
    * @param value1 will be in index 0 of the returned array
    * @param value2 will be in the highest index of the returned array
    * @param num the total number of values including value1 and value2. Must be 2 or greater.
-   * @return a float array of evenly spaced values between value1 and value2 inclusive.
+   * @return a float array of evenly spaced values between value1, inclusive, and value2 inclusive.
    */
   public static float[] evenlySpacedFloats(final float value1, final float value2, final int num) {
     if (num < 2) {
@@ -128,7 +132,7 @@ public final class QuantilesUtil {
    * @param value1 will be in index 0 of the returned array
    * @param value2 will be in the highest index of the returned array
    * @param num the total number of values including value1 and value2. Must be 2 or greater.
-   * @return a float array of evenly spaced values between value1 and value2 inclusive.
+   * @return a float array of evenly spaced values between value1, inclusive, and value2 inclusive.
    */
   public static double[] evenlySpacedDoubles(final double value1, final double value2, final int num) {
     if (num < 2) {
@@ -144,7 +148,7 @@ public final class QuantilesUtil {
     for (int i = 1; i < num - 1; i++) { out[i] = i * delta + value1; }
     return out;
   }
-  
+
   /**
    * Returns a double array of values between min and max inclusive where the log of the
    * returned values are evenly spaced.

--- a/src/main/java/org/apache/datasketches/req/BaseReqSketch.java
+++ b/src/main/java/org/apache/datasketches/req/BaseReqSketch.java
@@ -20,7 +20,7 @@
 package org.apache.datasketches.req;
 
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
-import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.equallyWeightedRanks;
 
 import org.apache.datasketches.quantilescommon.FloatsSortedView;
 import org.apache.datasketches.quantilescommon.QuantileSearchCriteria;
@@ -62,6 +62,21 @@ abstract class BaseReqSketch implements QuantilesFloatsAPI {
   @Override
   public abstract float getMinItem();
 
+  @Override
+  public FloatsPartitionBoundaries getPartitionBoundaries(final int numEquallyWeighted,
+      final QuantileSearchCriteria searchCrit) {
+    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
+    final double[] ranks = equallyWeightedRanks(numEquallyWeighted);
+    final float[] boundaries = getQuantiles(ranks, searchCrit);
+    boundaries[0] = getMinItem();
+    boundaries[boundaries.length - 1] = getMaxItem();
+    final FloatsPartitionBoundaries fpb = new FloatsPartitionBoundaries();
+    fpb.N = this.getN();
+    fpb.ranks = ranks;
+    fpb.boundaries = boundaries;
+    return fpb;
+  }
+
   /**
    * Returns an a priori estimate of relative standard error (RSE, expressed as a number in [0,1]).
    * Derived from Lemma 12 in https://arxiv.org/abs/2004.01668v2, but the constant factors were
@@ -88,13 +103,6 @@ abstract class BaseReqSketch implements QuantilesFloatsAPI {
 
   @Override
   public abstract float[] getQuantiles(double[] normRanks, QuantileSearchCriteria searchCrit);
-
-  @Override
-  public float[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
-    if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
-        searchCrit);
-  }
 
   @Override
   public abstract float getQuantileLowerBound(double rank);

--- a/src/main/java/org/apache/datasketches/req/BaseReqSketch.java
+++ b/src/main/java/org/apache/datasketches/req/BaseReqSketch.java
@@ -20,6 +20,7 @@
 package org.apache.datasketches.req;
 
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.THROWS_EMPTY;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 
 import org.apache.datasketches.quantilescommon.FloatsSortedView;
 import org.apache.datasketches.quantilescommon.QuantileSearchCriteria;
@@ -91,7 +92,7 @@ abstract class BaseReqSketch implements QuantilesFloatsAPI {
   @Override
   public float[] getQuantiles(final int numEvenlySpaced, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new IllegalArgumentException(THROWS_EMPTY); }
-    return getQuantiles(org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, numEvenlySpaced),
+    return getQuantiles(evenlySpacedRanks(numEvenlySpaced),
         searchCrit);
   }
 

--- a/src/test/java/org/apache/datasketches/kll/KllDirectDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDirectDoublesSketchTest.java
@@ -429,12 +429,11 @@ public class KllDirectDoublesSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final double[] quantiles1 = sketch.getQuantiles(new double[] {0, 0.5, 1}, EXCLUSIVE);
-    final double[] quantiles2 = sketch.getQuantiles(3, EXCLUSIVE);
+    final double[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
+    final double[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 1.0);
-    assertEquals(quantiles1[1], 2.0);
-    assertEquals(quantiles1[2], 3.0);
+    assertEquals(quantiles1[0], 2.0);
+    assertEquals(quantiles1[1], 3.0);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllDirectDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDirectDoublesSketchTest.java
@@ -20,6 +20,7 @@
 package org.apache.datasketches.kll;
 
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE;
+import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -429,11 +430,13 @@ public class KllDirectDoublesSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final double[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
-    final double[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
+    sketch.update(4);
+    double[] quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, EXCLUSIVE);
+    double[] quantiles2 = sketch.getPartitionBoundaries(2, EXCLUSIVE).boundaries;
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 2.0);
-    assertEquals(quantiles1[1], 3.0);
+    quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, INCLUSIVE);
+    quantiles2 = sketch.getPartitionBoundaries(2, INCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllDirectFloatsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDirectFloatsSketchTest.java
@@ -430,12 +430,11 @@ public class KllDirectFloatsSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final float[] quantiles1 = sketch.getQuantiles(new double[] {0, 0.5, 1}, EXCLUSIVE);
-    final float[] quantiles2 = sketch.getQuantiles(3, EXCLUSIVE);
+    final float[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
+    final float[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 1f);
-    assertEquals(quantiles1[1], 2f);
-    assertEquals(quantiles1[2], 3f);
+    assertEquals(quantiles1[0], 2f);
+    assertEquals(quantiles1[1], 3f);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllDirectFloatsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDirectFloatsSketchTest.java
@@ -20,6 +20,7 @@
 package org.apache.datasketches.kll;
 
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE;
+import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -430,11 +431,13 @@ public class KllDirectFloatsSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final float[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
-    final float[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
+    sketch.update(4);
+    float[] quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, EXCLUSIVE);
+    float[] quantiles2 = sketch.getPartitionBoundaries(2, EXCLUSIVE).boundaries;
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 2f);
-    assertEquals(quantiles1[1], 3f);
+    quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, INCLUSIVE);
+    quantiles2 = sketch.getPartitionBoundaries(2, INCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDoublesSketchTest.java
@@ -474,12 +474,11 @@ public class KllDoublesSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final double[] quantiles1 = sketch.getQuantiles(new double[] {0, 0.5, 1}, EXCLUSIVE);
-    final double[] quantiles2 = sketch.getQuantiles(3, EXCLUSIVE);
+    final double[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
+    final double[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 1.0);
-    assertEquals(quantiles1[1], 2.0);
-    assertEquals(quantiles1[2], 3.0);
+    assertEquals(quantiles1[0], 2.0);
+    assertEquals(quantiles1[1], 3.0);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDoublesSketchTest.java
@@ -474,11 +474,13 @@ public class KllDoublesSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final double[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
-    final double[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
+    sketch.update(4);
+    double[] quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, EXCLUSIVE);
+    double[] quantiles2 = sketch.getPartitionBoundaries(2, EXCLUSIVE).boundaries;
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 2.0);
-    assertEquals(quantiles1[1], 3.0);
+    quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, INCLUSIVE);
+    quantiles2 = sketch.getPartitionBoundaries(2, INCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllFloatsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllFloatsSketchTest.java
@@ -475,11 +475,13 @@ public class KllFloatsSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final float[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
-    final float[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
+    sketch.update(4);
+    float[] quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, EXCLUSIVE);
+    float[] quantiles2 = sketch.getPartitionBoundaries(2, EXCLUSIVE).boundaries;
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 2f);
-    assertEquals(quantiles1[1], 3f);
+    quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, INCLUSIVE);
+    quantiles2 = sketch.getPartitionBoundaries(2, INCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllFloatsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllFloatsSketchTest.java
@@ -475,12 +475,11 @@ public class KllFloatsSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final float[] quantiles1 = sketch.getQuantiles(new double[] {0, 0.5, 1}, EXCLUSIVE);
-    final float[] quantiles2 = sketch.getQuantiles(3, EXCLUSIVE);
+    final float[] quantiles1 = sketch.getQuantiles(new double[] {0.5, 1}, EXCLUSIVE);
+    final float[] quantiles2 = sketch.getQuantiles(2, EXCLUSIVE);
     assertEquals(quantiles1, quantiles2);
-    assertEquals(quantiles1[0], 1f);
-    assertEquals(quantiles1[1], 2f);
-    assertEquals(quantiles1[2], 3f);
+    assertEquals(quantiles1[0], 2f);
+    assertEquals(quantiles1[1], 3f);
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/kll/KllMiscDirectDoublesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscDirectDoublesTest.java
@@ -58,11 +58,11 @@ public class KllMiscDirectDoublesTest {
   @Test
   public void checkMisc() {
     final KllDoublesSketch sk = getDDSketch(8, 0);
-    try { sk.getQuantiles(10); fail(); } catch (IllegalArgumentException e) {}
-    //sk.toString(true, true);
+    try { sk.getMaxItem(); fail(); } catch (IllegalArgumentException e) {}
+    println(sk.toString(true, true));
     for (int i = 0; i < 20; i++) { sk.update(i); }
-    //sk.toString(true, true);
-    //sk.toByteArray();
+    println(sk.toString(true, true));
+    sk.toByteArray();
     final double[] values = sk.getDoubleItemsArray();
     assertEquals(values.length, 16);
     final int[] levels = sk.getLevelsArray();
@@ -432,14 +432,26 @@ public class KllMiscDirectDoublesTest {
 
   @Test
   public void printlnTest() {
-    println("PRINTING: " + this.getClass().getName());
+    String s = "PRINTING:  printf in " + this.getClass().getName();
+    println(s);
+    printf("%s\n", s);
+  }
+
+  private final static boolean enablePrinting = false;
+
+  /**
+   * @param format the format
+   * @param args the args
+   */
+  private static final void printf(final String format, final Object ...args) {
+    if (enablePrinting) { System.out.printf(format, args); }
   }
 
   /**
-   * @param s value to print
+   * @param o the Object to println
    */
-  static void println(final String s) {
-    //System.out.println(s); //disable here
+  private static final void println(final Object o) {
+    if (enablePrinting) { System.out.println(o.toString()); }
   }
 
 }

--- a/src/test/java/org/apache/datasketches/kll/KllMiscDirectFloatsTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscDirectFloatsTest.java
@@ -58,7 +58,7 @@ public class KllMiscDirectFloatsTest {
   @Test
   public void checkMisc() {
     final KllFloatsSketch sk = getDFSketch(8, 0);
-    try { sk.getQuantiles(10); fail(); } catch (IllegalArgumentException e) {}
+    try { sk.getPartitionBoundaries(10); fail(); } catch (IllegalArgumentException e) {}
 
     //sk.toString(true, true);
     for (int i = 0; i < 20; i++) { sk.update(i); }

--- a/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
@@ -29,6 +29,8 @@ import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
+import org.apache.datasketches.quantilescommon.DoublesSortedView;
+import org.apache.datasketches.quantilescommon.DoublesSortedViewIterator;
 import org.testng.annotations.Test;
 
 /**
@@ -105,10 +107,10 @@ public class KllMiscDoublesTest {
   @Test
   public void checkMisc() {
     KllDoublesSketch sk = KllDoublesSketch.newHeapInstance(8);
-    try { sk.getQuantiles(10); fail(); } catch (IllegalArgumentException e) {}
-    sk.toString(true, true);
+    try { sk.getMaxItem(); fail(); } catch (IllegalArgumentException e) {}
+    println(sk.toString(true, true));
     for (int i = 0; i < 20; i++) { sk.update(i); }
-    sk.toString(true, true);
+    println(sk.toString(true, true));
     sk.toByteArray();
     final double[] values = sk.getDoubleItemsArray();
     assertEquals(values.length, 16);
@@ -150,6 +152,21 @@ public class KllMiscDoublesTest {
     show(sk, 97); //compaction 6
     show(sk, 108);
   }
+
+  @Test
+  public void viewCompactionAndSortedView() {
+    KllDoublesSketch sk = KllDoublesSketch.newHeapInstance(20);
+    show(sk, 20);
+    DoublesSortedView sv = sk.getSortedView();
+    DoublesSortedViewIterator itr = sv.iterator();
+    printf("%12s%12s\n", "Value", "CumWeight");
+    while (itr.next()) {
+      double v = itr.getQuantile();
+      long wt = itr.getWeight();
+      printf("%12.1f%12d\n", v, wt);
+    }
+  }
+
 
   private static void show(final KllDoublesSketch sk, int limit) {
     int i = (int) sk.getN();
@@ -538,14 +555,26 @@ public class KllMiscDoublesTest {
 
   @Test
   public void printlnTest() {
-    println("PRINTING: " + this.getClass().getName());
+    String s = "PRINTING:  printf in " + this.getClass().getName();
+    println(s);
+    printf("%s\n", s);
+  }
+
+  private final static boolean enablePrinting = false;
+
+  /**
+   * @param format the format
+   * @param args the args
+   */
+  private static final void printf(final String format, final Object ...args) {
+    if (enablePrinting) { System.out.printf(format, args); }
   }
 
   /**
-   * @param o value to print
+   * @param o the Object to println
    */
-  static void println(final Object o) {
-    //System.out.println(o.toString()); //disable here
+  private static final void println(final Object o) {
+    if (enablePrinting) { System.out.println(o.toString()); }
   }
 
 }

--- a/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
@@ -130,10 +130,10 @@ public class KllMiscFloatsTest {
   @Test
   public void checkMisc() {
     KllFloatsSketch sk = KllFloatsSketch.newHeapInstance(8);
-    try { sk.getQuantiles(10); fail(); } catch (IllegalArgumentException e) {}
-    sk.toString(true, true);
+    try { sk.getMaxItem(); fail(); } catch (IllegalArgumentException e) {} //empty
+    println(sk.toString(true, true));
     for (int i = 0; i < 20; i++) { sk.update(i); }
-    sk.toString(true, true);
+    println(sk.toString(true, true));
     sk.toByteArray();
     final float[] items = sk.getFloatItemsArray();
     assertEquals(items.length, 16);
@@ -576,8 +576,8 @@ public class KllMiscFloatsTest {
 
   @Test
   public void printlnTest() {
-    println("PRINTING: println in " + this.getClass().getName());
     String s = "PRINTING:  printf in " + this.getClass().getName();
+    println(s);
     printf("%s\n", s);
   }
 

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -128,13 +128,13 @@ public class DoublesSketchTest {
   }
 
   @Test
-  public void checkEmptyNullReturns() {
+  public void checkEmptyExceptions() {
     int k = 16;
     UpdateDoublesSketch uds = DoublesSketch.builder().setK(k).build();
     try { uds.getMaxItem(); fail(); } catch (IllegalArgumentException e) {}
     try { uds.getMinItem(); fail(); } catch (IllegalArgumentException e) {}
     try { uds.getRank(1.0); fail(); } catch (IllegalArgumentException e) {}
-    try { uds.getQuantiles(5); fail(); } catch (IllegalArgumentException e) {}
+    try { uds.getPartitionBoundaries(5); fail(); } catch (IllegalArgumentException e) {}
     try { uds.getPMF(new double[] { 0, 0.5, 1.0 }); fail(); } catch (IllegalArgumentException e) {}
     try { uds.getCDF(new double[] { 0, 0.5, 1.0 }); fail(); } catch (IllegalArgumentException e) {}
   }

--- a/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
@@ -29,6 +29,7 @@ import static org.apache.datasketches.quantiles.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.EMPTY_FLAG_MASK;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -800,12 +801,12 @@ public class HeapUpdateDoublesSketchTest {
 
   @Test
   public void checkEvenlySpaced() {
-    int n = 11;
-    double[] es = org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced(0.0, 1.0, n);
+    int n = 10;
+    double[] es = evenlySpacedRanks(n);
     int len = es.length;
     for (int j=0; j<len; j++) {
       double f = es[j];
-      assertEquals(f, j/10.0, (j/10.0) * 0.001);
+      assertEquals(f, (j+1)/10.0, ((j+1)/10.0) * 0.001);
       print(es[j]+", ");
     }
     println("");

--- a/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/HeapUpdateDoublesSketchTest.java
@@ -29,7 +29,7 @@ import static org.apache.datasketches.quantiles.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.quantiles.PreambleUtil.EMPTY_FLAG_MASK;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
-import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedRanks;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.equallyWeightedRanks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -785,28 +785,36 @@ public class HeapUpdateDoublesSketchTest {
   @Test
   public void checkEvenlySpacedQuantiles() {
     DoublesSketch qsk = buildAndLoadQS(32, 1001);
-    double[] values = qsk.getQuantiles(11);
+    double[] values = qsk.getPartitionBoundaries(10).boundaries;
     for (int i = 0; i<values.length; i++) {
       println(""+values[i]);
     }
     assertEquals(values.length, 11);
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void checkEvenlySpacedQuantilesException() {
-    DoublesSketch qsk = buildAndLoadQS(32, 1001);
-    qsk.getQuantiles(1);
-    qsk.getQuantiles(0);
+  @Test
+  public void getQuantiles() {
+    final DoublesSketch sketch = buildAndLoadQS(32,0);
+    sketch.update(1);
+    sketch.update(2);
+    sketch.update(3);
+    sketch.update(4);
+    double[] quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, EXCLUSIVE);
+    double[] quantiles2 = sketch.getPartitionBoundaries(2, EXCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
+    quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, INCLUSIVE);
+    quantiles2 = sketch.getPartitionBoundaries(2, INCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
   }
 
   @Test
-  public void checkEvenlySpaced() {
+  public void checkEquallySpacedRanks() {
     int n = 10;
-    double[] es = evenlySpacedRanks(n);
+    double[] es = equallyWeightedRanks(n);
     int len = es.length;
     for (int j=0; j<len; j++) {
       double f = es[j];
-      assertEquals(f, (j+1)/10.0, ((j+1)/10.0) * 0.001);
+      assertEquals(f, j/10.0, (j/10.0) * 0.001);
       print(es[j]+", ");
     }
     println("");

--- a/src/test/java/org/apache/datasketches/quantiles/ItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ItemsSketchTest.java
@@ -212,9 +212,9 @@ public class ItemsSketchTest {
 
 
 
-    quantiles = sketch.getQuantiles(3);
+    quantiles = sketch.getQuantiles(2);
 
-    assertEquals(quantiles[1], Integer.valueOf(500), 17); // median
+    assertEquals(quantiles[0], Integer.valueOf(500), 17); // median
 
 
     final double normErr = sketch.getNormalizedRankError(true);

--- a/src/test/java/org/apache/datasketches/quantiles/UtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/UtilTest.java
@@ -19,6 +19,12 @@
 
 package org.apache.datasketches.quantiles;
 
+import static org.apache.datasketches.quantiles.ClassicUtil.MIN_K;
+import static org.apache.datasketches.quantiles.ClassicUtil.checkPreLongsFlagsCap;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeCombinedBufferItemCapacity;
+import static org.apache.datasketches.quantiles.ClassicUtil.computeValidLevels;
+import static org.apache.datasketches.quantiles.ClassicUtil.hiBitPos;
+import static org.apache.datasketches.quantiles.ClassicUtil.lowestZeroBitStartingAt;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -32,25 +38,25 @@ public class UtilTest {
   @Test
   public void checkCombBufItemCapacity() {
     int k = 227;
-    int capEl = ClassicUtil.computeCombinedBufferItemCapacity(k, 0);
-    assertEquals(capEl, 2 * DoublesSketch.MIN_K);
+    int capEl = computeCombinedBufferItemCapacity(k, 0);
+    assertEquals(capEl, 2 * MIN_K);
   }
 
   @Test(expectedExceptions = SketchesArgumentException.class)
-  public void checkPreLongsFlagsCap() {
-    ClassicUtil.checkPreLongsFlagsCap(2, 0, 15);
+  public void checkThePreLongsFlagsCap() {
+    checkPreLongsFlagsCap(2, 0, 15L);
   }
 
   @Test
   public void checkHiBitPos() {
-    int bitPos = ClassicUtil.hiBitPos(4096);
+    int bitPos = hiBitPos(4096);
     assertEquals(bitPos, 12);
   }
 
   @Test
   public void checkNumValidLevels() {
     long v = (1L << 32)-1L;
-    int ones = ClassicUtil.computeValidLevels(v);
+    int ones = computeValidLevels(v);
     assertEquals(ones, 32);
   }
 
@@ -60,7 +66,7 @@ public class UtilTest {
     long v = 109L;
     //println("IN: " + Long.toBinaryString(v));
     for (int i = 0, j = 9; i < 10; i++, j--) {
-      int result = ClassicUtil.lowestZeroBitStartingAt(v, i);
+      int result = lowestZeroBitStartingAt(v, i);
       //System.out.printf ("%d %d %d%n", i, result, answers[j]);
       assertTrue (answers[j] == result);
     }
@@ -70,7 +76,7 @@ public class UtilTest {
   public void testPositionOfLowestZeroBitStartingAt2() {
     long bits = -1L;
     int startingBit = 70; //only low 6 bits are used
-    int result = ClassicUtil.lowestZeroBitStartingAt(bits, startingBit);
+    int result = lowestZeroBitStartingAt(bits, startingBit);
     assertEquals(result, 64);
   }
 

--- a/src/test/java/org/apache/datasketches/quantilescommon/QuantilesUtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantilescommon/QuantilesUtilTest.java
@@ -29,14 +29,14 @@ public class QuantilesUtilTest {
 
   @Test
   public void checkEvenlySpacedRanks() {
-    double[] arr = QuantilesUtil.evenlySpacedRanks(2);
-    assertEquals(arr[0], 0.5);
-    assertEquals(arr[1], 1.0);
-    arr = QuantilesUtil.evenlySpacedRanks(4);
-    assertEquals(arr[0], 0.25);
+    double[] arr = QuantilesUtil.equallyWeightedRanks(2);
     assertEquals(arr[1], 0.5);
-    assertEquals(arr[2], 0.75);
-    assertEquals(arr[3], 1.0);
+    arr = QuantilesUtil.equallyWeightedRanks(4);
+    assertEquals(arr[0], 0.0);
+    assertEquals(arr[1], 0.25);
+    assertEquals(arr[2], 0.5);
+    assertEquals(arr[3], 0.75);
+    assertEquals(arr[4], 1.0);
   }
 
   @Test
@@ -70,7 +70,7 @@ public class QuantilesUtilTest {
     assertEquals(arr[1], 1.0);
     try { QuantilesUtil.evenlySpacedDoubles(0, 1.0, 1); fail(); } catch (SketchesArgumentException e) {}
   }
-  
+
   @Test
   public void checkEvenlyLogSpaced() {
     final double[] arr = QuantilesUtil.evenlyLogSpaced(1, 8, 4);

--- a/src/test/java/org/apache/datasketches/quantilescommon/QuantilesUtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantilescommon/QuantilesUtilTest.java
@@ -28,15 +28,15 @@ import org.testng.annotations.Test;
 public class QuantilesUtilTest {
 
   @Test
-  public void checkEvenlySpaced() {
-    double[] arr = QuantilesUtil.evenlySpaced(0, 1, 3);
-    assertEquals(arr[0], 0.0);
+  public void checkEvenlySpacedRanks() {
+    double[] arr = QuantilesUtil.evenlySpacedRanks(2);
+    assertEquals(arr[0], 0.5);
+    assertEquals(arr[1], 1.0);
+    arr = QuantilesUtil.evenlySpacedRanks(4);
+    assertEquals(arr[0], 0.25);
     assertEquals(arr[1], 0.5);
-    assertEquals(arr[2], 1.0);
-    arr = QuantilesUtil.evenlySpaced(3, 7, 3);
-    assertEquals(arr[0], 3.0);
-    assertEquals(arr[1], 5.0);
-    assertEquals(arr[2], 7.0);
+    assertEquals(arr[2], 0.75);
+    assertEquals(arr[3], 1.0);
   }
 
   @Test
@@ -55,6 +55,22 @@ public class QuantilesUtilTest {
     try { QuantilesUtil.evenlySpacedFloats(0f, 1f, 1); fail(); } catch (SketchesArgumentException e) {}
   }
 
+  @Test
+  public void checkEvenlySpacedDoubles() {
+    double[] arr = QuantilesUtil.evenlySpacedDoubles(0, 1, 3);
+    assertEquals(arr[0], 0.0);
+    assertEquals(arr[1], 0.5);
+    assertEquals(arr[2], 1.0);
+    arr = QuantilesUtil.evenlySpacedDoubles(3, 7, 3);
+    assertEquals(arr[0], 3.0);
+    assertEquals(arr[1], 5.0);
+    assertEquals(arr[2], 7.0);
+    arr = QuantilesUtil.evenlySpacedDoubles(0, 1.0, 2);
+    assertEquals(arr[0], 0);
+    assertEquals(arr[1], 1.0);
+    try { QuantilesUtil.evenlySpacedDoubles(0, 1.0, 1); fail(); } catch (SketchesArgumentException e) {}
+  }
+  
   @Test
   public void checkEvenlyLogSpaced() {
     final double[] arr = QuantilesUtil.evenlyLogSpaced(1, 8, 4);

--- a/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.req;
 
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
+import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpacedDoubles;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
@@ -119,7 +120,7 @@ public class ReqSketchTest {
   private static void checkGetRank(final ReqSketch sk, final int min, final int max, final int iDebug) {
     if (iDebug > 0) { println("GetRank Test: INCLUSIVE"); }
     final float[] spArr = QuantilesUtil.evenlySpacedFloats(0, max, 11);
-    final double[] trueRanks = QuantilesUtil.evenlySpaced(0, 1.0, 11);
+    final double[] trueRanks = evenlySpacedDoubles(0, 1.0, 11);
     final String dfmt = "%10.2f%10.6f" + LS;
     final String sfmt = "%10s%10s" + LS;
     if (iDebug > 0) { printf(sfmt, "Value", "Rank"); }

--- a/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchTest.java
@@ -232,6 +232,23 @@ public class ReqSketchTest {
     assertEquals(sk.getN(), 200);
   }
 
+  //specific tests
+
+  @Test
+  public void getQuantiles() {
+    final ReqSketch sketch = ReqSketch.builder().setK(12).build();
+    sketch.update(1);
+    sketch.update(2);
+    sketch.update(3);
+    sketch.update(4);
+    float[] quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, EXCLUSIVE);
+    float[] quantiles2 = sketch.getPartitionBoundaries(2, EXCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
+    quantiles1 = sketch.getQuantiles(new double[] {0.0, 0.5, 1.0}, INCLUSIVE);
+    quantiles2 = sketch.getPartitionBoundaries(2, INCLUSIVE).boundaries;
+    assertEquals(quantiles1, quantiles2);
+  }
+
   @Test
   public void merge() {
     final ReqSketch s1 = ReqSketch.builder().setK(12).build();


### PR DESCRIPTION
getQuantiles(evenlySpaced).

The general method in QuantilesUtil.evenlySpacedFloats which is used in several places in the library was also being used in the getQuantiles(evenlySpaced) method.  It turns out that for the getQuantiles, the evenlySpaced algo must omit 0.0, which the general method does not.  It really needs its own generator for the evenly spaced ranks.

Given that I fixed this issue, the documentation was also not correct, so the javadocs had to be revised, again.