### PR TITLE
Reserving count min family id

### DIFF
--- a/src/main/java/org/apache/datasketches/common/Family.java
+++ b/src/main/java/org/apache/datasketches/common/Family.java
@@ -140,7 +140,12 @@ public enum Family {
   /**
    * Relative Error Quantiles Sketch
    */
-  REQ(17, "REQ", 1, 2);
+  REQ(17, "REQ", 1, 2),
+
+  /**
+   * CountMin Sketch
+   */
+  COUNTMIN(18, "COUNTMIN", 2, 2);
 
   private static final Map<Integer, Family> lookupID = new HashMap<>();
   private static final Map<String, Family> lookupFamName = new HashMap<>();


### PR DESCRIPTION
The count min sketch family id has been [changed in cpp](https://github.com/apache/datasketches-cpp/pull/360).
I have reserved the family id value 18 for count min to ensure consistency.