### PR TITLE
This commit fixes all the SpotBugs 4.7.3 issues.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,2 @@
 github:
   homepage: https://datasketches.apache.org
-  collaborators:

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ target/
 out/
 build/
 jarsIn/
-*.jar
 build.xml
 *.properties
 *.releaseBackup

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you are interested in making contributions to this site please see our [Commu
 ## Maven Build Instructions
 __NOTE:__ This component accesses resource files for testing. As a result, the directory elements of the full absolute path of the target installation directory must qualify as Java identifiers. In other words, the directory elements must not have any space characters (or non-Java identifier characters) in any of the path elements. This is required by the Oracle Java Specification in order to ensure location-independent access to resources: [See Oracle Location-Independent Access to Resources](https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html)
 
-### A JDK8 with Hotspot through JDK13 with Hotspot is required to compile
+### A JDK8 with Hotspot or JDK11 with Hotspot is required to compile
 This component depends on the [datasketches-memory](https://github.com/apache/datasketches-memory) component, 
 and, as a result, must be compiled with one of the above JDKs. 
 If your application only relies on the APIs of this component no special JVM arguments are required.

--- a/src/main/java/org/apache/datasketches/common/Family.java
+++ b/src/main/java/org/apache/datasketches/common/Family.java
@@ -20,6 +20,7 @@
 package org.apache.datasketches.common;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -157,13 +158,13 @@ public enum Family {
   static {
     for (final Family f : values()) {
       lookupID.put(f.getID(), f);
-      lookupFamName.put(f.getFamilyName().toUpperCase(), f);
+      lookupFamName.put(f.getFamilyName().toUpperCase(Locale.US), f);
     }
   }
 
   private Family(final int id, final String famName, final int minPreLongs, final int maxPreLongs) {
     id_ = id;
-    famName_ = famName.toUpperCase();
+    famName_ = famName.toUpperCase(Locale.US);
     minPreLongs_ = minPreLongs;
     maxPreLongs_ = maxPreLongs;
   }
@@ -172,6 +173,7 @@ public enum Family {
    * Returns the byte ID for this family
    * @return the byte ID for this family
    */
+  @SuppressFBWarnings(value = "NM_CONFUSING", justification = "Harmless, will not fix")
   public int getID() {
     return id_;
   }
@@ -236,7 +238,7 @@ public enum Family {
    * @return the Family given the family name
    */
   public static Family stringToFamily(final String famName) {
-    final Family f = lookupFamName.get(famName.toUpperCase());
+    final Family f = lookupFamName.get(famName.toUpperCase(Locale.US));
     if (f == null) {
       throw new SketchesArgumentException("Possible Corruption: Illegal Family Name: " + famName);
     }

--- a/src/main/java/org/apache/datasketches/common/SuppressFBWarnings.java
+++ b/src/main/java/org/apache/datasketches/common/SuppressFBWarnings.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.common;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Used to suppress SpotBug warnings.
+ *
+ * @author Lee Rhodes
+ */
+@Retention(RetentionPolicy.CLASS)
+public @interface SuppressFBWarnings {
+
+  /**
+   * A list of comma-separated, quoted SpotBugs warnings that are to be suppressed in the associated
+   * annotated element. The value can be a bug category, kind or pattern.
+   * @return list of relevant bug descriptors
+   */
+  String[] value() default {};
+
+  /**
+   * Optional explanation for the suppression.
+   * @return explanation
+   */
+  String justification() default "";
+}
+

--- a/src/main/java/org/apache/datasketches/cpc/CompressionCharacterization.java
+++ b/src/main/java/org/apache/datasketches/cpc/CompressionCharacterization.java
@@ -19,8 +19,8 @@
 
 package org.apache.datasketches.cpc;
 
-import static org.apache.datasketches.common.Util.ceilingIntPowerOf2;
 import static org.apache.datasketches.common.Util.INVERSE_GOLDEN_U64;
+import static org.apache.datasketches.common.Util.ceilingIntPowerOf2;
 import static org.apache.datasketches.common.Util.log2;
 import static org.apache.datasketches.common.Util.powerSeriesNextDouble;
 import static org.apache.datasketches.cpc.CompressedState.importFromMemory;
@@ -29,6 +29,7 @@ import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssert;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
@@ -66,6 +67,7 @@ public class CompressionCharacterization {
   private CompressedState[] compressedStates2;
   private CpcSketch[] unCompressedSketches;
 
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "This is OK here")
   public CompressionCharacterization(
       final int lgMinK,
       final int lgMaxK,

--- a/src/main/java/org/apache/datasketches/cpc/CpcWrapper.java
+++ b/src/main/java/org/apache/datasketches/cpc/CpcWrapper.java
@@ -32,6 +32,7 @@ import static org.apache.datasketches.cpc.PreambleUtil.isCompressed;
 import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssert;
 
 import org.apache.datasketches.common.Family;
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.Memory;
 
 /**
@@ -47,6 +48,7 @@ public final class CpcWrapper {
    * Construct a read-only view of the given Memory that contains a CpcSketch
    * @param mem the given Memory
    */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "This is OK here")
   public CpcWrapper(final Memory mem) {
     this.mem = mem;
     checkLoPreamble(mem);

--- a/src/main/java/org/apache/datasketches/cpc/MergingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/MergingValidation.java
@@ -28,6 +28,8 @@ import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssertEquals;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
+
 /**
  * This code is used both by unit tests, for short running tests,
  * and by the characterization repository for longer running, more exhaustive testing. To be
@@ -62,6 +64,7 @@ public class MergingValidation {
    * @param pS pS
    * @param pW pW
    */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "This is OK here")
   public MergingValidation(final int lgMinK, final int lgMaxK, final int lgMulK, final int uPPO,
       final int incLgK, final PrintStream pS, final PrintWriter pW) {
     this.lgMinK = lgMinK;

--- a/src/main/java/org/apache/datasketches/cpc/QuickMergingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/QuickMergingValidation.java
@@ -25,6 +25,8 @@ import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssert;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
+
 /**
  * This code is used both by unit tests, for short running tests,
  * and by the characterization repository for longer running, more exhaustive testing. To be
@@ -58,6 +60,7 @@ public class QuickMergingValidation {
    * @param ps ps
    * @param pw pw
    */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "This is OK here")
   public QuickMergingValidation(final int lgMinK, final int lgMaxK, final int incLgK,
       final PrintStream ps, final PrintWriter pw) {
     this.lgMinK = lgMinK;

--- a/src/main/java/org/apache/datasketches/cpc/StreamingValidation.java
+++ b/src/main/java/org/apache/datasketches/cpc/StreamingValidation.java
@@ -26,6 +26,8 @@ import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssertEquals;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
+
 /**
  * This code is used both by unit tests, for short running tests,
  * and by the characterization repository for longer running, more exhaustive testing. To be
@@ -62,6 +64,7 @@ public class StreamingValidation {
    * @param pS pS
    * @param pW pW
    */
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "This is OK here")
   public StreamingValidation(final int lgMinK, final int lgMaxK, final int trials, final int ppoN,
       final PrintStream pS, final PrintWriter pW) {
     this.lgMinK = lgMinK;

--- a/src/main/java/org/apache/datasketches/frequencies/LongsSketch.java
+++ b/src/main/java/org/apache/datasketches/frequencies/LongsSketch.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesStateException;
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 
@@ -142,6 +143,7 @@ import org.apache.datasketches.memory.WritableMemory;
  * @author Justin Thaler
  * @author Lee Rhodes
  */
+@SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC_ANON", justification = "Harmless, fix later")
 public class LongsSketch {
 
   private static final int STR_PREAMBLE_TOKENS = 6;

--- a/src/main/java/org/apache/datasketches/hll/HllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/HllArray.java
@@ -48,7 +48,6 @@ abstract class HllArray extends AbstractHllArray {
   double kxq0;
   double kxq1;
   byte[] hllByteArr = null; //init by sub-classes
-  final int configKmask;
 
   /**
    * Standard constructor for new instance
@@ -62,7 +61,6 @@ abstract class HllArray extends AbstractHllArray {
     hipAccum = 0;
     kxq0 = 1 << lgConfigK;
     kxq1 = 0;
-    configKmask = (1 << lgConfigK) - 1;
   }
 
   /**
@@ -85,7 +83,6 @@ abstract class HllArray extends AbstractHllArray {
     } else {
       putAuxHashMap(null, false);
     }
-    configKmask = (1 << lgConfigK) - 1;
   }
 
   static final HllArray newHeapHll(final int lgConfigK, final TgtHllType tgtHllType) {

--- a/src/main/java/org/apache/datasketches/hll/RelativeErrorTables.java
+++ b/src/main/java/org/apache/datasketches/hll/RelativeErrorTables.java
@@ -55,6 +55,7 @@ final class RelativeErrorTables {
         f = NON_HIP_UB[idx];
         break;
       }
+      default: f = 0;//can't happen
     }
     return f;
   }

--- a/src/main/java/org/apache/datasketches/hll/ToByteArrayImpl.java
+++ b/src/main/java/org/apache/datasketches/hll/ToByteArrayImpl.java
@@ -170,6 +170,8 @@ class ToByteArrayImpl {
         }
         break;
       }
+
+      case 6:   //Src Heap,   Src Updatable, Dst Compact
       case 2: { //Src Memory, Src Updatable, Dst Compact
         final int dataStart = impl.getMemDataStart();
         final int bytesOut = dataStart + (srcCouponCount << 2);
@@ -195,26 +197,6 @@ class ToByteArrayImpl {
         final int bytesOut = impl.getMemDataStart() + (srcCouponArrInts << 2);
         byteArrOut = new byte[bytesOut];
         srcMem.getByteArray(0, byteArrOut, 0, bytesOut);
-        break;
-      }
-      case 6: { //Src Heap, Src Updatable, Dst Compact
-        final int dataStart = impl.getMemDataStart();
-        final int bytesOut = dataStart + (srcCouponCount << 2);
-        byteArrOut = new byte[bytesOut];
-        final WritableMemory memOut = WritableMemory.writableWrap(byteArrOut);
-        copyCommonListAndSet(impl, memOut);
-        insertCompactFlag(memOut, dstCompact);
-
-        final PairIterator itr = impl.iterator();
-        int cnt = 0;
-        while (itr.nextValid()) {
-          insertInt(memOut, dataStart + (cnt++ << 2), itr.getPair());
-        }
-        if (list) {
-          insertListCount(memOut, srcCouponCount);
-        } else {
-          insertHashSetCount(memOut, srcCouponCount);
-        }
         break;
       }
       case 7: { //Src Heap, Src Updatable, Dst Updatable

--- a/src/main/java/org/apache/datasketches/hll/Union.java
+++ b/src/main/java/org/apache/datasketches/hll/Union.java
@@ -372,6 +372,7 @@ public class Union extends BaseHllSketch {
     final int bit4 = (srcLgK > lgMaxK) ? 16 : 0;
     final int sw = bit4 | bit3 | bits1_2 | bit0;
     HllSketchImpl hllSketchImpl = null; //never returned as null
+
     switch (sw) {
       case 0: //src <= max, src >= gdt, gdtLIST, gdtHeap
       case 8: //src <= max, src <  gdt, gdtLIST, gdtHeap
@@ -465,7 +466,7 @@ public class Union extends BaseHllSketch {
         hllSketchImpl = useGadgetMemory(gadget, srcHll8Heap, false).hllSketchImpl;
         break;
       }
-      //default: return gadget.hllSketchImpl; //not possible
+      default: return gadget.hllSketchImpl; //not possible
     }
     return hllSketchImpl;
   }
@@ -485,6 +486,7 @@ public class Union extends BaseHllSketch {
       final int sw = (tgtIsMem ? 1 : 0) | (srcIsMem ? 2 : 0)
           | ((srcLgK > tgtLgK) ? 4 : 0) | ((src.getTgtHllType() != HLL_8) ? 8 : 0);
       final int srcK = 1 << srcLgK;
+
       switch (sw) {
         case 0: { //HLL_8, srcLgK=tgtLgK, src=heap, tgt=heap
           final byte[] srcArr = ((Hll8Array) src.hllSketchImpl).hllByteArr;
@@ -744,6 +746,7 @@ public class Union extends BaseHllSketch {
           }
           break;
         }
+        default: break; //not possible
       }
       tgt.hllSketchImpl.putRebuildCurMinNumKxQFlag(true);
   }

--- a/src/main/java/org/apache/datasketches/hllmap/CouponTraverseMap.java
+++ b/src/main/java/org/apache/datasketches/hllmap/CouponTraverseMap.java
@@ -38,6 +38,7 @@ import org.apache.datasketches.hash.MurmurHash3;
  */
 final class CouponTraverseMap extends Map {
   private static final double RSE = 0.408 / Math.sqrt(1024);
+  //private static int
   private final int maxCouponsPerKey_;
 
   private int tableEntries_;
@@ -73,7 +74,7 @@ final class CouponTraverseMap extends Map {
 
     map.keysArr_ = new byte[COUPON_MAP_MIN_NUM_ENTRIES * keySizeBytes];
     map.couponsArr_ = new short[COUPON_MAP_MIN_NUM_ENTRIES * maxCouponsPerKey];
-    map.stateArr_ = new byte[(int) Math.ceil(COUPON_MAP_MIN_NUM_ENTRIES / 8.0)];
+    map.stateArr_ = new byte[COUPON_MAP_MIN_NUM_ENTRIES_ARR_SIZE];
     return map;
   }
 

--- a/src/main/java/org/apache/datasketches/hllmap/Map.java
+++ b/src/main/java/org/apache/datasketches/hllmap/Map.java
@@ -44,6 +44,7 @@ abstract class Map {
   static final double COUPON_MAP_SHRINK_TRIGGER_FACTOR = 0.5;
   static final double COUPON_MAP_GROW_TRIGGER_FACTOR = 15.0 / 16.0;
   static final double COUPON_MAP_TARGET_FILL_FACTOR = 2.0 / 3.0;
+  static final int COUPON_MAP_MIN_NUM_ENTRIES_ARR_SIZE = (int)Math.ceil(COUPON_MAP_MIN_NUM_ENTRIES / 8.0);
 
   final int keySizeBytes_;
 

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -31,6 +31,7 @@ import static org.apache.datasketches.quantilescommon.QuantilesUtil.equallyWeigh
 
 import java.util.Objects;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
@@ -305,6 +306,7 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   }
 
   @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "OK in this case.")
   public DoublesSortedView getSortedView() {
     refreshSortedView();
     return kllDoublesSV;

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -31,6 +31,7 @@ import static org.apache.datasketches.quantilescommon.QuantilesUtil.equallyWeigh
 
 import java.util.Objects;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
@@ -305,6 +306,7 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
   }
 
   @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "OK in this case.")
   public FloatsSortedView getSortedView() {
     refreshSortedView();
     return kllFloatsSV;

--- a/src/main/java/org/apache/datasketches/kll/KllHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHelper.java
@@ -89,7 +89,7 @@ final class KllHelper {
 
   static class LevelStats {
     long n;
-    int numLevels;
+    public int numLevels;
     int numItems;
 
     LevelStats(final long n, final int numLevels, final int numItems) {

--- a/src/main/java/org/apache/datasketches/kll/KllMemoryValidate.java
+++ b/src/main/java/org/apache/datasketches/kll/KllMemoryValidate.java
@@ -118,6 +118,7 @@ final class KllMemoryValidate {
   void compactMemoryValidate(final Memory srcMem) { //FOR HEAPIFY
     if (empty && singleItem) { memoryValidateThrow(EMPTYBIT_AND_SINGLEBIT, flags); }
     final int sw = (empty ? 1 : 0) | (singleItem ? 4 : 0);
+
     switch (sw) {
       case 0: { //FULL_COMPACT
         if (preInts != PREAMBLE_INTS_FULL) { memoryValidateThrow(INVALID_PREINTS, preInts); }
@@ -156,7 +157,7 @@ final class KllMemoryValidate {
         sketchBytes = DATA_START_ADR_SINGLE_ITEM + typeBytes;
         break;
       }
-      default: //can not happen
+      default: break; //can not happen
     }
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllPreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/kll/KllPreambleUtil.java
@@ -214,7 +214,7 @@ final class KllPreambleUtil {
     final long n = memVal.n;
     final int minK = memVal.minK;
     final int numLevels = memVal.numLevels;
-    if (updatableMemFormat || (!updatableMemFormat && !empty && !singleItem)) {
+    if (updatableMemFormat || (!empty && !singleItem)) {
         sb.append("Bytes  8-15: N                   : ").append(n).append(LS);
         sb.append("Bytes 16-17: MinK                : ").append(minK).append(LS);
         sb.append("Byte  18   : NumLevels           : ").append(numLevels).append(LS);

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesUnionImpl.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesUnionImpl.java
@@ -161,6 +161,7 @@ final class DoublesUnionImpl extends DoublesUnionImplR {
     int sw1 = ((myQS  == null) ? 0 :  myQS.isEmpty() ? 4 : 8);
     sw1 |=    ((other == null) ? 0 : other.isEmpty() ? 1 : 2);
     int outCase = 0; //0=null, 1=NOOP, 2=copy, 3=merge
+
     switch (sw1) {
       case 0:  outCase = 0; break; //myQS = null,  other = null ; return null
       case 1:  outCase = 4; break; //myQS = null,  other = empty; create empty-heap(myMaxK)
@@ -171,9 +172,10 @@ final class DoublesUnionImpl extends DoublesUnionImplR {
       case 8:  outCase = 1; break; //myQS = valid, other = null ; no-op
       case 9:  outCase = 1; break; //myQS = valid, other = empty: no-op
       case 10: outCase = 3; break; //myQS = valid, other = valid; merge
-      //default: //This cannot happen and cannot be tested
+      default: break; //This cannot happen
     }
     UpdateDoublesSketch ret = null;
+
     switch (outCase) {
       case 0: ret = null; break; //return null
       case 1: ret = myQS; break; //no-op
@@ -239,7 +241,7 @@ final class DoublesUnionImpl extends DoublesUnionImplR {
         ret = HeapUpdateDoublesSketch.newInstance(myMaxK);
         break;
       }
-      //default: //This cannot happen and cannot be tested
+      default: break; //This cannot happen
     }
     return ret;
   }

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsUnion.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsUnion.java
@@ -37,10 +37,10 @@ import org.apache.datasketches.memory.Memory;
  */
 public final class ItemsUnion<T> {
 
-  protected final int maxK_;
-  protected final Comparator<? super T> comparator_;
-  protected ItemsSketch<T> gadget_;
-  protected Class<T> clazz_;
+  final int maxK_;
+  final Comparator<? super T> comparator_;
+  ItemsSketch<T> gadget_;
+  Class<T> clazz_;
 
   private ItemsUnion(final int maxK, final Comparator<? super T> comparator, final ItemsSketch<T> gadget) {
     Objects.requireNonNull(gadget, "Gadjet sketch must not be null.");
@@ -272,6 +272,7 @@ public final class ItemsUnion<T> {
     int sw1 = ((myQS   == null) ? 0 :   myQS.isEmpty() ? 4 : 8);
     sw1 |=    ((other  == null) ? 0 :  other.isEmpty() ? 1 : 2);
     int outCase = 0; //0=null, 1=NOOP, 2=copy, 3=merge
+
     switch (sw1) {
       case 0:  outCase = 0; break; //myQS = null,  other = null ; return null
       case 1:  outCase = 4; break; //myQS = null,  other = empty; create empty-heap(myMaxK)
@@ -282,9 +283,10 @@ public final class ItemsUnion<T> {
       case 8:  outCase = 1; break; //myQS = valid, other = null ; no-op
       case 9:  outCase = 1; break; //myQS = valid, other = empty: no-op
       case 10: outCase = 3; break; //myQS = valid, other = valid; merge
-      //default: //This cannot happen and cannot be tested
+      default: break; //This cannot happen
     }
     ItemsSketch<T> ret = null;
+
     switch (outCase) {
       case 0: ret = null; break;
       case 1: ret = myQS; break;
@@ -334,7 +336,7 @@ public final class ItemsUnion<T> {
         ret = ItemsSketch.getInstance(other.getSketchType(), Math.min(myMaxK, other.getK()), comparator);
         break;
       }
-      //default: //This cannot happen and cannot be tested
+      default: break; //This cannot happen
     }
     return ret;
   }

--- a/src/main/java/org/apache/datasketches/sampling/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/sampling/PreambleUtil.java
@@ -23,6 +23,7 @@ import static org.apache.datasketches.common.Util.LS;
 import static org.apache.datasketches.common.Util.zeroPad;
 
 import java.nio.ByteOrder;
+import java.util.Locale;
 
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.ResizeFactor;
@@ -239,7 +240,7 @@ final class PreambleUtil {
     final StringBuilder sb = new StringBuilder();
     sb.append(LS)
       .append("### END ")
-      .append(family.getFamilyName().toUpperCase())
+      .append(family.getFamilyName().toUpperCase(Locale.US))
       .append(" PREAMBLE SUMMARY").append(LS)
       .append("Byte  0: Preamble Longs       : ").append(preLongs).append(LS)
       .append("Byte  0: ResizeFactor         : ").append(rf.toString()).append(LS)
@@ -272,7 +273,7 @@ final class PreambleUtil {
       .append("  Preamble Bytes              : ").append(preLongs << 3).append(LS)
       .append("  Data Bytes                  : ").append(dataBytes).append(LS)
       .append("### END ")
-      .append(family.getFamilyName().toUpperCase())
+      .append(family.getFamilyName().toUpperCase(Locale.US))
       .append(" PREAMBLE SUMMARY").append(LS);
     return sb.toString();
   }
@@ -302,7 +303,7 @@ final class PreambleUtil {
     final long dataBytes = mem.getCapacity() - (preLongs << 3);
 
     return LS
-            + "### END " + family.getFamilyName().toUpperCase() + " PREAMBLE SUMMARY" + LS
+            + "### END " + family.getFamilyName().toUpperCase(Locale.US) + " PREAMBLE SUMMARY" + LS
             + "Byte  0: Preamble Longs           : " + preLongs + LS
             + "Byte  0: ResizeFactor             : " + rf.toString() + LS
             + "Byte  1: Serialization Version    : " + serVer + LS
@@ -316,7 +317,7 @@ final class PreambleUtil {
             + "TOTAL Sketch Bytes                : " + mem.getCapacity() + LS
             + "  Preamble Bytes                  : " + (preLongs << 3) + LS
             + "  Sketch Bytes                    : " + dataBytes + LS
-            + "### END " + family.getFamilyName().toUpperCase() + " PREAMBLE SUMMARY" + LS;
+            + "### END " + family.getFamilyName().toUpperCase(Locale.US) + " PREAMBLE SUMMARY" + LS;
   }
 
   // Extraction methods

--- a/src/main/java/org/apache/datasketches/sampling/VarOptItemsSamples.java
+++ b/src/main/java/org/apache/datasketches/sampling/VarOptItemsSamples.java
@@ -22,6 +22,7 @@ package org.apache.datasketches.sampling;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * This class provides access to the samples contained in a VarOptItemsSketch. It provides two
@@ -184,6 +185,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
   }
 
   VarOptItemsSamples(final VarOptItemsSketch<T> sketch) {
+    Objects.requireNonNull(sketch, "sketch must not be null");
     sketch_ = sketch;
     n_ = sketch.getN();
     h_ = sketch.getHRegionCount();
@@ -224,7 +226,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
    */
   public int getNumSamples() {
     loadArrays();
-    return (sampleLists == null ? 0 : sampleLists.weights.length);
+    return (sampleLists == null || sampleLists.weights == null ? 0 : sampleLists.weights.length);
   }
 
   /**
@@ -245,7 +247,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
    */
   public T items(final int i) {
     loadArrays();
-    return (sampleLists == null ? null : sampleLists.items[i]);
+    return (sampleLists == null || sampleLists.items == null ? null : sampleLists.items[i]);
   }
 
   /**
@@ -266,7 +268,7 @@ public class VarOptItemsSamples<T> implements Iterable<VarOptItemsSamples<T>.Wei
    */
   public double weights(final int i) {
     loadArrays();
-    return (sampleLists == null ? Double.NaN : sampleLists.weights[i]);
+    return (sampleLists == null || sampleLists.weights == null ? Double.NaN : sampleLists.weights[i]);
   }
 
   private void loadArrays() {

--- a/src/main/java/org/apache/datasketches/theta/ConcurrentHeapQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/ConcurrentHeapQuickSelectSketch.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.datasketches.common.ResizeFactor;
+import org.apache.datasketches.common.SuppressFBWarnings;
 
 /**
  * A concurrent shared sketch that is based on HeapQuickSelectSketch.
@@ -35,7 +36,7 @@ import org.apache.datasketches.common.ResizeFactor;
  * @author eshcar
  * @author Lee Rhodes
  */
-class ConcurrentHeapQuickSelectSketch extends HeapQuickSelectSketch
+final class ConcurrentHeapQuickSelectSketch extends HeapQuickSelectSketch
     implements ConcurrentSharedThetaSketch {
 
   // The propagation thread
@@ -246,13 +247,14 @@ class ConcurrentHeapQuickSelectSketch extends HeapQuickSelectSketch
   /**
    * Advances the epoch while there is no background propagation
    * This ensures a propagation invoked before the reset cannot affect the sketch after the reset
-   * is completed. Ignore VO_VOLATILE_INCREMENT findbugs warning, it is False Positive.
+   * is completed.
    */
+  @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "Likely False Positive, Fix Later")
   private void advanceEpoch() {
     awaitBgPropagationTermination();
     startEagerPropagation();
     ConcurrentPropagationService.resetExecutorService(Thread.currentThread().getId());
-    //noinspection NonAtomicOperationOnVolatileField
+    //no inspection NonAtomicOperationOnVolatileField
     // this increment of a volatile field is done within the scope of the propagation
     // synchronization and hence is done by a single thread
     // Ignore a FindBugs warning

--- a/src/main/java/org/apache/datasketches/theta/ConcurrentPropagationService.java
+++ b/src/main/java/org/apache/datasketches/theta/ConcurrentPropagationService.java
@@ -22,6 +22,8 @@ package org.apache.datasketches.theta;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.datasketches.common.SuppressFBWarnings;
+
 /**
  * Pool of threads to serve <i>all</i> propagation tasks in the system.
  *
@@ -33,11 +35,13 @@ final class ConcurrentPropagationService {
   private static volatile ConcurrentPropagationService instance = null; // Singleton
   private static ExecutorService[] propagationExecutorService = null;
 
+  @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Fix later")
   private ConcurrentPropagationService() {
     propagationExecutorService = new ExecutorService[NUM_POOL_THREADS];
   }
 
   //Factory: Get the singleton
+  @SuppressFBWarnings(value = "SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA", justification = "Fix later")
   private static ConcurrentPropagationService getInstance() {
     if (instance == null) {
       synchronized (ConcurrentPropagationService.class) {

--- a/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketchR.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketchR.java
@@ -40,6 +40,7 @@ import static org.apache.datasketches.theta.PreambleUtil.insertThetaLong;
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesReadOnlyException;
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
@@ -182,7 +183,7 @@ class DirectQuickSelectSketchR extends UpdateSketch {
   //UpdateSketch
 
   @Override
-  public int getLgNomLongs() {
+  public final int getLgNomLongs() {
     return PreambleUtil.extractLgNomLongs(wmem_);
   }
 
@@ -274,8 +275,9 @@ class DirectQuickSelectSketchR extends UpdateSketch {
    * @param lgArrLongs <a href="{@docRoot}/resources/dictionary.html#lgArrLongs">See lgArrLongs</a>.
    * @return the hash table threshold
    */
+  @SuppressFBWarnings(value = "DB_DUPLICATE_BRANCHES", justification = "False Positive, see the code comments")
   static final int setHashTableThreshold(final int lgNomLongs, final int lgArrLongs) {
-    //FindBugs may complain (DB_DUPLICATE_BRANCHES) if DQS_RESIZE_THRESHOLD == REBUILD_THRESHOLD,
+    //SpotBugs may complain (DB_DUPLICATE_BRANCHES) if DQS_RESIZE_THRESHOLD == REBUILD_THRESHOLD,
     //but this allows us to tune these constants for different sketches.
     final double fraction = (lgArrLongs <= lgNomLongs) ? DQS_RESIZE_THRESHOLD : ThetaUtil.REBUILD_THRESHOLD;
     return (int) Math.floor(fraction * (1 << lgArrLongs));

--- a/src/main/java/org/apache/datasketches/theta/HeapUpdateSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapUpdateSketch.java
@@ -79,7 +79,7 @@ abstract class HeapUpdateSketch extends UpdateSketch {
   //UpdateSketch
 
   @Override
-  public int getLgNomLongs() {
+  public final int getLgNomLongs() {
     return lgNomLongs_;
   }
 

--- a/src/main/java/org/apache/datasketches/theta/UnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/UnionImpl.java
@@ -316,7 +316,7 @@ final class UnionImpl extends Union {
     unionEmpty_ = false;
     final int curCountIn = sketchIn.getRetainedEntries(true);
     if (curCountIn > 0) {
-      if (sketchIn.isOrdered()) { //Only true if Compact. Use early stop
+      if (sketchIn.isOrdered() && (sketchIn instanceof CompactSketch)) { //Use early stop
         //Ordered, thus compact
         if (sketchIn.hasMemory()) {
           final Memory skMem = ((CompactSketch) sketchIn).getMemory();

--- a/src/main/java/org/apache/datasketches/theta/UpdateSketchBuilder.java
+++ b/src/main/java/org/apache/datasketches/theta/UpdateSketchBuilder.java
@@ -27,6 +27,7 @@ import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesStateException;
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
@@ -423,6 +424,8 @@ public class UpdateSketchBuilder {
    * @return a concurrent UpdateSketch with the current configuration of the Builder
    * and the given destination WritableMemory.
    */
+  @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+      justification = "Harmless in Builder, fix later")
   public UpdateSketch buildShared(final WritableMemory dstMem) {
     ConcurrentPropagationService.NUM_POOL_THREADS = bNumPoolThreads;
     if (dstMem == null) {
@@ -456,6 +459,8 @@ public class UpdateSketchBuilder {
    * @return a concurrent UpdateSketch with the current configuration of the Builder
    * and the given destination WritableMemory.
    */
+  @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+      justification = "Harmless in Builder, fix later")
   public UpdateSketch buildSharedFromSketch(final UpdateSketch sketch, final WritableMemory dstMem) {
     ConcurrentPropagationService.NUM_POOL_THREADS = bNumPoolThreads;
     if (dstMem == null) {

--- a/src/main/java/org/apache/datasketches/tuple/AnotB.java
+++ b/src/main/java/org/apache/datasketches/tuple/AnotB.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesStateException;
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.thetacommon.SetOperationCornerCases;
 import org.apache.datasketches.thetacommon.SetOperationCornerCases.AnotbAction;
 import org.apache.datasketches.thetacommon.SetOperationCornerCases.CornerCase;
@@ -66,6 +67,7 @@ import org.apache.datasketches.thetacommon.ThetaUtil;
  *
  * @author Lee Rhodes
  */
+@SuppressFBWarnings(value = "DP_DO_INSIDE_DO_PRIVILEGED", justification = "Defer fix")
 public final class AnotB<S extends Summary> {
   private boolean empty_ = true;
   private long thetaLong_ = Long.MAX_VALUE;
@@ -308,6 +310,8 @@ public final class AnotB<S extends Summary> {
    * @param <S> Type of Summary
    * @return the result as an unordered {@link CompactSketch}
    */
+  @SuppressFBWarnings(value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+      justification = "hashArr and summaryArr are guaranteed to be valid due to the switch on CornerCase")
   public static <S extends Summary> CompactSketch<S> aNotB(
       final Sketch<S> skA,
       final Sketch<S> skB) {
@@ -399,6 +403,8 @@ public final class AnotB<S extends Summary> {
    * @param <S> Type of Summary
    * @return the result as an unordered {@link CompactSketch}
    */
+  @SuppressFBWarnings(value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+      justification = "hashArr and summaryArr are guaranteed to be valid due to the switch on CornerCase")
   public static <S extends Summary> CompactSketch<S> aNotB(
       final Sketch<S> skA,
       final org.apache.datasketches.theta.Sketch skB) {
@@ -449,9 +455,11 @@ public final class AnotB<S extends Summary> {
         result = new CompactSketch<>(daA.hashArr, daA.summaryArr, thetaLongA, skA.empty_);
         break;
       }
-      case FULL_ANOTB: { //both A and B should have valid entries.
+      case FULL_ANOTB: { //both A and B have valid entries.
         final DataArrays<S> daA = getCopyOfDataArraysTuple(skA);
         final long minThetaLong = min(thetaLongA, thetaLongB);
+        @SuppressFBWarnings(value = "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
+            justification = "hashArr and summaryArr are guaranteed to be valid due to the switch on CornerCase")
         final DataArrays<S> daR =
             getCopyOfResultArraysTheta(minThetaLong, daA.hashArr.length, daA.hashArr, daA.summaryArr, skB);
         final int countR = (daR.hashArr == null) ? 0 : daR.hashArr.length;

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesAnotBImpl.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesAnotBImpl.java
@@ -29,6 +29,7 @@ import static org.apache.datasketches.thetacommon.HashOperations.hashSearch;
 import java.util.Arrays;
 
 import org.apache.datasketches.common.SketchesArgumentException;
+import org.apache.datasketches.common.SuppressFBWarnings;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.SetOperationCornerCases;
 import org.apache.datasketches.thetacommon.SetOperationCornerCases.AnotbAction;
@@ -63,6 +64,7 @@ public class ArrayOfDoublesAnotBImpl extends ArrayOfDoublesAnotB {
   }
 
   @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "This is OK here")
   public void update(final ArrayOfDoublesSketch skA, final ArrayOfDoublesSketch skB) {
     if (skA == null || skB == null) {
       throw new SketchesArgumentException("Neither argument may be null.");

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketch.java
@@ -156,7 +156,7 @@ abstract class ArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesUpdatableSk
     incrementCount();
   }
 
-  void setRebuildThreshold() {
+  final void setRebuildThreshold() {
     if (getCurrentCapacity() > getNominalEntries()) {
       rebuildThreshold_ = (int) (getCurrentCapacity() * ThetaUtil.REBUILD_THRESHOLD);
     } else {

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketch.java
@@ -277,7 +277,7 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
   }
 
   @Override
-  protected int getCurrentCapacity() {
+  protected final int getCurrentCapacity() {
     return 1 << mem_.getByte(LG_CUR_CAPACITY_BYTE);
   }
 

--- a/tools/FindBugsExcludeFilter.xml
+++ b/tools/FindBugsExcludeFilter.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -23,143 +24,24 @@ under the License.
     <Class name="~.*\.*Test" />
   </Match>
 
-  <!-- False positive.  FindBugs complains if DQS_RESIZE_THRESHOLD == REBUILD_THRESHOLD, 
-       but this allows us to tune these constants for different sketches. -->
+  <!-- Harmless, Too many False Positives May 2, 2023-->
   <Match>
-    <Bug pattern="DB_DUPLICATE_BRANCHES" />
-    <Class name="org.apache.datasketches.theta.DirectQuickSelectSketchR" />
-    <Method name="setHashTableThreshold" />
+    <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
   </Match>
 
-  <Match>   <!-- Too many False Positives. -->
+  <!-- Harmless, Too many False Positives May 2, 2023-->
+  <Match>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+  </Match>
+
+  <!-- Harmless, Too many False Positives May 2, 2023-->
+  <Match>
+    <Bug pattern="BIT_SIGNED_CHECK" />
+  </Match>
+
+  <!-- Harmless, Too many False Positives May 2, 2023 -->
+  <Match>   
     <Bug pattern="DLS_DEAD_LOCAL_STORE" />
   </Match>
 
-  <Match> <!-- Too many False Positives -->
-    <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE" />
-  </Match>
-  
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP" />
-    <Or>
-      <Class name= "org.apache.datasketches.kll.KllDoublesSketch" />
-      <Class name= "org.apache.datasketches.kll.KllFloatsSketch" />
-    </Or>
-    <Method name= "getSortedView" />
-  </Match>
-  
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2" /> <!-- False positive -->
-    <Or>
-      <Class name="org.apache.datasketches.cpc.CpcWrapper" />
-      <Class name="org.apache.datasketches.cpc.CompressionCharacterization" />
-      <Class name="org.apache.datasketches.cpc.MergingValidation" />
-      <Class name="org.apache.datasketches.cpc.QuickMergingValidation" />
-      <Class name="org.apache.datasketches.cpc.StreamingValidation" />
-      <Class name="org.apache.datasketches.req.ReqDebugImpl" />
-      <Class name="org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesAnotBImpl" />
-    </Or>
-  </Match>
-  
-  <Match>
-    <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS" />
-    <Class name="~.*\.Group" />
-  </Match>
-  
-  <!-- False positive.  In this case we want to ignore the exceptions -->
-  <Match>
-    <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
-    <Class name="org.apache.datasketches.thetacommon.BinomialBoundsN" />
-  </Match>
-  
-  <!-- False positive.  In this case we want to ignore the exceptions -->
-  <Match>
-    <Bug pattern="FL_FLOATS_AS_LOOP_COUNTERS" />
-    <Class name="org.apache.datasketches.sampling.SamplingUtil" />
-    <Method name="nextDoubleExcludeZero" />
-  </Match>
-  
-  <!-- This is in the /test/ tree but doesn't end in "Test" -->
-  <Match>
-    <Bug pattern="REFLF_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_FIELD" />
-    <Class name="org.apache.datasketches.quantilescommon.ReflectUtility" />
-  </Match>
-  
-  <!-- Too many false positives to be useful.  I could not make it happy :( -->
-  <Match>
-    <Bug pattern="SF_SWITCH_NO_DEFAULT" />
-  </Match>
-  
-  <!-- False positive.  In this case we want to ignore the exceptions -->
-  <Match>
-    <Bug pattern="SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA" />
-    <Class name="org.apache.datasketches.theta.ConcurrentPropagationService" />
-    <Method name="getInstance" />
-  </Match>
-
-  <Match>   <!-- Harmless in the Builder -->
-    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
-    <Class name="org.apache.datasketches.theta.UpdateSketchBuilder" />
-  </Match>
-  
-  <Match>
-    <Bug pattern="VO_VOLATILE_INCREMENT" />
-    <Class name="~.*\.Concurrent.+QuickSelectSketch" />
-  </Match>
-  
 </FindBugsFilter>
-
-<!--  Examples: -->
-
-<!-- Exclude java.* classes -->
-  <!--
-  <Match>
-    <Package name="java\.*" />
-  </Match>
--->
-
-  <!-- Exclude test classes -->
-<!-- 
-  <Match>
-    <Class name="~.*\.*Test" />
-  </Match>
--->
-
-<!--
-     <Match>
-       <Class name="com.foobar.ClassNotToBeAnalyzed" />
-     </Match>
--->
-<!--
-     <Match>
-       <Class name="com.foobar.ClassWithSomeBugsMatched" />
-       <Bug code="DE,UrF,SIC" />
-     </Match>
--->
-     <!-- Match all XYZ violations. -->
-<!--
-     <Match>
-       <Bug code="XYZ" />
-     </Match>
--->
-     <!-- Match all doublecheck violations in these methods of "AnotherClass". -->
-<!--
-     <Match>
-       <Class name="com.foobar.AnotherClass" />
-       <Or>
-         <Method name="nonOverloadedMethod" />
-         <Method name="frob" params="int,java.lang.String" returns="void" />
-         <Method name="blat" params="" returns="boolean" />
-       </Or>
-       <Bug code="DC" />
-     </Match>
--->
-     <!-- A method with a dead local store false positive (medium priority). -->
-<!--
-     <Match>
-       <Class name="com.foobar.MyClass" />
-       <Method name="someMethod" />
-       <Bug pattern="DLS_DEAD_LOCAL_STORE" />
-       <Priority value="2" />
-     </Match>
--->


### PR DESCRIPTION
I also cleaned up the tools/FindBugsExcludeFilter.xml.

Jon & I fixed some actual bugs that were uncovered by SB, and came up with superior solutions.  These were mostly in quantiles, sampling and VarOpt where we were not checking the possibility of improper method call sequences corrupting the sketch.  (long story).

In addition, Will & I came up with an elegant solution to being able to use SpotBugs and SpotBugs @SuppressFBWarnings WITHOUT having to make SpotBugs a dependency. It works GREAT!