### PR TITLE
Adds branch protection to master.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,2 +1,12 @@
 github:
   homepage: https://datasketches.apache.org
+
+  master:
+    required_status_checks:
+      # strict means "Require branches to be up to date before merging."
+      strict: true
+
+    required_pull_request_reviews:
+      dismiss_stale_reviews: true
+      required_approving_review_count: 1
+


### PR DESCRIPTION
This modification to .asf.yaml enables branch protection to the "master" branch in the following ways:

- The target and source branches must be up-to-date before merging
- Stale reviews will be dismissed
- The required approving review count is 1

This is just an initial configuration as the capabilities of .asf.yaml are huge. If you are interested, I suggest you check out [Apache .asf.yaml features](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features), which are the GitHub features that ASF has enabled for customization of ASF repositories via this file. I think one has to be a committer to view this site.

I have a few more things to do before I release this draft.