### PR TITLE
Remove unused travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
     under the License.
 -->
 
-[![Build Status](https://travis-ci.org/apache/datasketches-java.svg?branch=master)](https://travis-ci.org/apache/datasketches-java)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.datasketches/datasketches-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.datasketches/datasketches-java)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/apache/datasketches-java.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/apache/datasketches-java/context:java)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/apache/datasketches-java.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/apache/datasketches-java/alerts/)


### PR DESCRIPTION
Removes an unused Travis-ci badge from the very top of the README.md file.