### PR TITLE
Preparatory work for generic items.

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllDirectDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectDoublesSketch.java
@@ -22,7 +22,6 @@ package org.apache.datasketches.kll;
 import static org.apache.datasketches.kll.KllPreambleUtil.DATA_START_ADR;
 import static org.apache.datasketches.kll.KllPreambleUtil.PREAMBLE_INTS_FULL;
 import static org.apache.datasketches.kll.KllPreambleUtil.SERIAL_VERSION_UPDATABLE;
-import static org.apache.datasketches.kll.KllPreambleUtil.UPDATABLE_BIT_MASK;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryK;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryLevelZeroSortedFlag;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryM;
@@ -30,7 +29,6 @@ import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryMinK;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryN;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryNumLevels;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryFamilyID;
-import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryFlags;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryK;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryLevelZeroSortedFlag;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryM;
@@ -59,13 +57,12 @@ import org.apache.datasketches.memory.WritableMemory;
 class KllDirectDoublesSketch extends KllDoublesSketch {
 
   /**
-   * The constructor with Memory that can be off-heap.
+   * The constructor with WritableMemory that can be off-heap.
    * @param wmem the current WritableMemory
    * @param memReqSvr the given MemoryRequestServer to request a larger WritableMemory
    * @param memVal the MemoryValadate object
    */
-  KllDirectDoublesSketch(final WritableMemory wmem, final MemoryRequestServer memReqSvr,
-      final KllMemoryValidate memVal) {
+  KllDirectDoublesSketch(final WritableMemory wmem, final MemoryRequestServer memReqSvr, final KllMemoryValidate memVal) {
     super(wmem, memReqSvr);
     levelsArr = memVal.levelsArr;
   }
@@ -83,7 +80,6 @@ class KllDirectDoublesSketch extends KllDoublesSketch {
     setMemoryPreInts(dstMem, PREAMBLE_INTS_FULL);
     setMemorySerVer(dstMem, SERIAL_VERSION_UPDATABLE);
     setMemoryFamilyID(dstMem, Family.KLL.getID());
-    setMemoryFlags(dstMem, UPDATABLE_BIT_MASK);
     setMemoryK(dstMem, k);
     setMemoryM(dstMem, m);
     setMemoryN(dstMem, 0);

--- a/src/main/java/org/apache/datasketches/kll/KllDirectFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectFloatsSketch.java
@@ -22,7 +22,6 @@ package org.apache.datasketches.kll;
 import static org.apache.datasketches.kll.KllPreambleUtil.DATA_START_ADR;
 import static org.apache.datasketches.kll.KllPreambleUtil.PREAMBLE_INTS_FULL;
 import static org.apache.datasketches.kll.KllPreambleUtil.SERIAL_VERSION_UPDATABLE;
-import static org.apache.datasketches.kll.KllPreambleUtil.UPDATABLE_BIT_MASK;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryK;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryLevelZeroSortedFlag;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryM;
@@ -30,7 +29,6 @@ import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryMinK;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryN;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryNumLevels;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryFamilyID;
-import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryFlags;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryK;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryLevelZeroSortedFlag;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryM;
@@ -59,13 +57,12 @@ import org.apache.datasketches.memory.WritableMemory;
 class KllDirectFloatsSketch extends KllFloatsSketch {
 
   /**
-   * The constructor with Memory that can be off-heap.
+   * The constructor with WritableMemory that can be off-heap.
    * @param wmem the current WritableMemory
    * @param memReqSvr the given MemoryRequestServer to request a larger WritableMemory
    * @param memVal the MemoryValadate object
    */
-  KllDirectFloatsSketch(final WritableMemory wmem, final MemoryRequestServer memReqSvr,
-      final KllMemoryValidate memVal) {
+  KllDirectFloatsSketch(final WritableMemory wmem, final MemoryRequestServer memReqSvr, final KllMemoryValidate memVal) {
     super(wmem, memReqSvr);
     levelsArr = memVal.levelsArr;
   }
@@ -83,7 +80,6 @@ class KllDirectFloatsSketch extends KllFloatsSketch {
     setMemoryPreInts(dstMem, PREAMBLE_INTS_FULL);
     setMemorySerVer(dstMem, SERIAL_VERSION_UPDATABLE);
     setMemoryFamilyID(dstMem, Family.KLL.getID());
-    setMemoryFlags(dstMem, UPDATABLE_BIT_MASK);
     setMemoryK(dstMem, k);
     setMemoryM(dstMem, m);
     setMemoryN(dstMem, 0);

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesHelper.java
@@ -49,14 +49,13 @@ final class KllDoublesHelper {
     final int myMinK = mySketch.getMinK();
 
     //update this sketch with level0 items from the other sketch
-
     if (otherDblSk.isCompactSingleItem()) {
       updateDouble(mySketch, otherDblSk.getDoubleSingleItem());
       otherDoubleItemsArr = new double[0];
     } else {
       otherDoubleItemsArr = otherDblSk.getDoubleItemsArray();
       for (int i = otherLevelsArr[0]; i < otherLevelsArr[1]; i++) {
-        KllDoublesHelper.updateDouble(mySketch, otherDoubleItemsArr[i]);
+        updateDouble(mySketch, otherDoubleItemsArr[i]);
       }
     }
     // after the level 0 update, we capture the state of levels and items arrays
@@ -68,7 +67,7 @@ final class KllDoublesHelper {
     int[] myNewLevelsArr = myCurLevelsArr;
     double[] myNewDoubleItemsArr = myCurDoubleItemsArr;
 
-    if (otherNumLevels > 1 && !otherDblSk.isCompactSingleItem()) { //now merge other levels if they exist
+    if (otherNumLevels > 1 && !otherDblSk.isCompactSingleItem()) { //now merge higher levels if they exist
       final int tmpSpaceNeeded = mySketch.getNumRetained()
           + KllHelper.getNumRetainedAboveLevelZero(otherNumLevels, otherLevelsArr);
       final double[] workbuf = new double[tmpSpaceNeeded];
@@ -115,7 +114,7 @@ final class KllDoublesHelper {
       }
 
       //MEMORY SPACE MANAGEMENT
-      if (mySketch.updatableMemFormat) {
+      if (mySketch.serialVersionUpdatable) {
         mySketch.wmem = KllHelper.memorySpaceMgmt(mySketch, myNewLevelsArr.length, myNewDoubleItemsArr.length);
       }
     }
@@ -358,7 +357,7 @@ final class KllDoublesHelper {
     worklevels[0] = 0;
 
     // Note: the level zero data from "other" was already inserted into "self"
-    final int selfPopZero = KllHelper.currentLevelSize(0, myCurNumLevels,myCurLevelsArr);
+    final int selfPopZero = KllHelper.currentLevelSize(0, myCurNumLevels, myCurLevelsArr);
     System.arraycopy(myCurDoubleItemsArr, myCurLevelsArr[0], workbuf, worklevels[0], selfPopZero);
     worklevels[1] = worklevels[0] + selfPopZero;
 

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsHelper.java
@@ -114,7 +114,7 @@ final class KllFloatsHelper {
       }
 
       //MEMORY SPACE MANAGEMENT
-      if (mySketch.updatableMemFormat) {
+      if (mySketch.serialVersionUpdatable) {
         mySketch.wmem = KllHelper.memorySpaceMgmt(mySketch, myNewLevelsArr.length, myNewFloatItemsArr.length);
       }
     }

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -21,8 +21,8 @@ package org.apache.datasketches.kll;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryUpdatableFormatFlag;
-import static org.apache.datasketches.kll.KllSketch.Error.MUST_NOT_BE_UPDATABLE_FORMAT;
+import static org.apache.datasketches.kll.KllPreambleUtil.SERIAL_VERSION_UPDATABLE;
+import static org.apache.datasketches.kll.KllPreambleUtil.getMemorySerVer;
 import static org.apache.datasketches.kll.KllSketch.Error.TGT_IS_READ_ONLY;
 import static org.apache.datasketches.kll.KllSketch.Error.kllSketchThrow;
 import static org.apache.datasketches.kll.KllSketch.SketchType.FLOATS_SKETCH;
@@ -61,10 +61,23 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
    */
   public static KllFloatsSketch heapify(final Memory srcMem) {
     Objects.requireNonNull(srcMem, "Parameter 'srcMem' must not be null");
-    if (getMemoryUpdatableFormatFlag(srcMem)) { Error.kllSketchThrow(MUST_NOT_BE_UPDATABLE_FORMAT); }
     return KllHeapFloatsSketch.heapifyImpl(srcMem);
   }
 
+  /**
+   * Create a new direct instance of this sketch with the default <em>k</em>.
+   * The default <em>k</em> = 200 results in a normalized rank error of about
+   * 1.65%. Larger <em>k</em> will have smaller error but the sketch will be larger (and slower).
+   * @param dstMem the given destination WritableMemory object for use by the sketch
+   * @param memReqSvr the given MemoryRequestServer to request a larger WritableMemory
+   * @return a new direct instance of this sketch
+   */
+  public static KllFloatsSketch newDirectInstance(
+      final WritableMemory dstMem,
+      final MemoryRequestServer memReqSvr) {
+    return newDirectInstance(DEFAULT_K, dstMem, memReqSvr);
+  }
+  
   /**
    * Create a new direct instance of this sketch with a given <em>k</em>.
    * @param k parameter that controls size of the sketch and accuracy of estimates.
@@ -82,39 +95,22 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
   }
 
   /**
-   * Create a new direct instance of this sketch with the default <em>k</em>.
-   * The default <em>k</em> = 200 results in a normalized rank error of about
-   * 1.65%. Larger <em>k</em> will have smaller error but the sketch will be larger (and slower).
-   * @param dstMem the given destination WritableMemory object for use by the sketch
-   * @param memReqSvr the given MemoryRequestServer to request a larger WritableMemory
-   * @return a new direct instance of this sketch
-   */
-  public static KllFloatsSketch newDirectInstance(
-      final WritableMemory dstMem,
-      final MemoryRequestServer memReqSvr) {
-    Objects.requireNonNull(dstMem, "Parameter 'dstMem' must not be null");
-    Objects.requireNonNull(memReqSvr, "Parameter 'memReqSvr' must not be null");
-    return KllDirectFloatsSketch.newDirectInstance(DEFAULT_K, DEFAULT_M, dstMem, memReqSvr);
-  }
-
-  /**
    * Create a new heap instance of this sketch with the default <em>k = 200</em>.
    * The default <em>k</em> = 200 results in a normalized rank error of about
    * 1.65%. Larger K will have smaller error but the sketch will be larger (and slower).
-   * This will have a rank error of about 1.65%.
-   * @return new KllFloatsSketch on the heap.
+   * @return new KllFloatsSketch on the Java heap.
    */
   public static KllFloatsSketch newHeapInstance() {
-    return new KllHeapFloatsSketch(DEFAULT_K, DEFAULT_M);
+    return newHeapInstance(DEFAULT_K);
   }
 
   /**
    * Create a new heap instance of this sketch with a given parameter <em>k</em>.
-   * <em>k</em> can be between DEFAULT_M and 65535, inclusive.
+   * <em>k</em> can be between 8, inclusive, and 65535, inclusive.
    * The default <em>k</em> = 200 results in a normalized rank error of about
    * 1.65%. Larger K will have smaller error but the sketch will be larger (and slower).
    * @param k parameter that controls size of the sketch and accuracy of estimates.
-   * @return new KllFloatsSketch on the heap.
+   * @return new KllFloatsSketch on the Java heap.
    */
   public static KllFloatsSketch newHeapInstance(final int k) {
     return new KllHeapFloatsSketch(k, DEFAULT_M);
@@ -129,7 +125,7 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
   public static KllFloatsSketch wrap(final Memory srcMem) {
     Objects.requireNonNull(srcMem, "Parameter 'srcMem' must not be null");
     final KllMemoryValidate memVal = new KllMemoryValidate(srcMem, FLOATS_SKETCH);
-    if (memVal.updatableMemFormat) {
+    if (getMemorySerVer(srcMem) == SERIAL_VERSION_UPDATABLE) {
       return new KllDirectFloatsSketch((WritableMemory) srcMem, null, memVal);
     } else {
       return new KllDirectCompactFloatsSketch(srcMem, memVal);
@@ -148,10 +144,8 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
       final MemoryRequestServer memReqSvr) {
     Objects.requireNonNull(srcMem, "Parameter 'srcMem' must not be null");
     final KllMemoryValidate memVal = new KllMemoryValidate(srcMem, FLOATS_SKETCH);
-    if (memVal.updatableMemFormat) {
-      if (!memVal.readOnly) {
+    if (getMemorySerVer(srcMem) == SERIAL_VERSION_UPDATABLE && !srcMem.isReadOnly()) {
         Objects.requireNonNull(memReqSvr, "Parameter 'memReqSvr' must not be null");
-      }
       return new KllDirectFloatsSketch(srcMem, memReqSvr, memVal);
     } else {
       return new KllDirectCompactFloatsSketch(srcMem, memVal);

--- a/src/main/java/org/apache/datasketches/kll/KllHeapFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHeapFloatsSketch.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.kll;
 
 import static org.apache.datasketches.kll.KllPreambleUtil.DATA_START_ADR;
 import static org.apache.datasketches.kll.KllPreambleUtil.DATA_START_ADR_SINGLE_ITEM;
+import static org.apache.datasketches.kll.KllPreambleUtil.SERIAL_VERSION_UPDATABLE;
+import static org.apache.datasketches.kll.KllPreambleUtil.getMemorySerVer;
 import static org.apache.datasketches.kll.KllSketch.Error.NOT_SINGLE_ITEM;
 import static org.apache.datasketches.kll.KllSketch.Error.kllSketchThrow;
 import static org.apache.datasketches.kll.KllSketch.SketchType.FLOATS_SKETCH;
@@ -73,6 +75,12 @@ final class KllHeapFloatsSketch extends KllFloatsSketch {
     floatItems_ = new float[k];
   }
 
+  static KllHeapFloatsSketch heapifyImpl(final Memory srcMem) {
+    Objects.requireNonNull(srcMem, "Parameter 'srcMem' must not be null");
+    final KllMemoryValidate memVal = new KllMemoryValidate(srcMem, FLOATS_SKETCH);
+    return new KllHeapFloatsSketch(srcMem, memVal);
+  }
+
   /**
    * Heapify constructor.
    * @param srcMem Memory object that contains data serialized by this sketch.
@@ -86,14 +94,14 @@ final class KllHeapFloatsSketch extends KllFloatsSketch {
     minK_ = memValidate.minK;
     levelsArr = memValidate.levelsArr;
     isLevelZeroSorted_ = memValidate.level0Sorted;
-    final boolean updatableMemFormat = memValidate.updatableMemFormat;
+    final boolean serialVersionUpdatable = getMemorySerVer(srcMem) == SERIAL_VERSION_UPDATABLE;
 
-    if (memValidate.empty && !updatableMemFormat) {
+    if (memValidate.empty && !serialVersionUpdatable) {
       minFloatItem_ = Float.NaN;
       maxFloatItem_ = Float.NaN;
       floatItems_ = new float[k_];
     }
-    else if (memValidate.singleItem && !updatableMemFormat) {
+    else if (memValidate.singleItem && !serialVersionUpdatable) {
       final float item = srcMem.getFloat(DATA_START_ADR_SINGLE_ITEM);
       minFloatItem_ = maxFloatItem_ = item;
       floatItems_ = new float[k_];
@@ -101,7 +109,7 @@ final class KllHeapFloatsSketch extends KllFloatsSketch {
     }
     else { //Full or updatableMemFormat
       int offsetBytes = DATA_START_ADR;
-      offsetBytes += (updatableMemFormat ? levelsArr.length * Integer.BYTES : (levelsArr.length - 1) * Integer.BYTES);
+      offsetBytes += (serialVersionUpdatable ? levelsArr.length * Integer.BYTES : (levelsArr.length - 1) * Integer.BYTES);
       minFloatItem_ = srcMem.getFloat(offsetBytes);
       offsetBytes += Float.BYTES;
       maxFloatItem_ = srcMem.getFloat(offsetBytes);
@@ -110,19 +118,13 @@ final class KllHeapFloatsSketch extends KllFloatsSketch {
       final int retainedItems = capacityItems - levelsArr[0];
       floatItems_ = new float[capacityItems];
       final int shift = levelsArr[0];
-      if (updatableMemFormat) {
+      if (serialVersionUpdatable) {
         offsetBytes += shift * Float.BYTES;
         srcMem.getFloatArray(offsetBytes, floatItems_, shift, retainedItems);
       } else {
         srcMem.getFloatArray(offsetBytes, floatItems_, shift, retainedItems);
       }
     }
-  }
-
-  static KllHeapFloatsSketch heapifyImpl(final Memory srcMem) {
-    Objects.requireNonNull(srcMem, "Parameter 'srcMem' must not be null");
-    final KllMemoryValidate memVal = new KllMemoryValidate(srcMem, FLOATS_SKETCH);
-    return new KllHeapFloatsSketch(srcMem, memVal);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/kll/KllMemoryValidate.java
+++ b/src/main/java/org/apache/datasketches/kll/KllMemoryValidate.java
@@ -19,7 +19,6 @@
 
 package org.apache.datasketches.kll;
 
-import static org.apache.datasketches.common.Family.idToFamily;
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.EMPTYBIT_AND_PREINTS;
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.EMPTYBIT_AND_SER_VER;
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.EMPTYBIT_AND_SINGLEBIT;
@@ -27,7 +26,6 @@ import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.INV
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.SINGLEBIT_AND_PREINTS;
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.SINGLEBIT_AND_SER_VER;
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.SRC_NOT_KLL;
-import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.UPDATABLEBIT_AND_SER_VER;
 import static org.apache.datasketches.kll.KllMemoryValidate.MemoryInputError.memoryValidateThrow;
 import static org.apache.datasketches.kll.KllPreambleUtil.DATA_START_ADR;
 import static org.apache.datasketches.kll.KllPreambleUtil.DATA_START_ADR_SINGLE_ITEM;
@@ -48,7 +46,6 @@ import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryNumLevels;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryPreInts;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemorySerVer;
 import static org.apache.datasketches.kll.KllPreambleUtil.getMemorySingleItemFlag;
-import static org.apache.datasketches.kll.KllPreambleUtil.getMemoryUpdatableFormatFlag;
 import static org.apache.datasketches.kll.KllSketch.SketchType.DOUBLES_SKETCH;
 
 import org.apache.datasketches.common.Family;
@@ -65,59 +62,57 @@ import org.apache.datasketches.memory.WritableMemory;
  *
  */
 final class KllMemoryValidate {
-  // first 8 bytes
-  final int preInts; // = extractPreInts(srcMem);
+  // first 8 bytes of preamble
+  final int preInts;
   final int serVer;
   final int familyID;
-  final String famName;
   final int flags;
-  boolean empty;
-  boolean singleItem;
-  final boolean level0Sorted;
-  final SketchType sketchType;
-  boolean updatableMemFormat = false;
-  final boolean readOnly;
   final int k;
   final int m;
-  final int typeBytes;
-
-  // depending on the layout, the next 8-16 bytes of the preamble, may be filled with assumed items.
-  // For example, if the layout is compact & empty, n = 0, if compact and single, n = 1, etc.
-  long n;
-  // next 4 bytes
-  int minK;
-  int numLevels;
-  // derived
+  //last byte is unused
+  
+  //Flag bits:
+  final boolean empty;
+  final boolean level0Sorted;
+  final boolean singleItem;
+  //From SerVer
+  private boolean serialVersionUpdatable;
+  
+  // depending on the layout, the next 8-16 bytes of the preamble, may be derived by assumption.
+  // For example, if the layout is compact & empty, n = 0, if compact and single, n = 1. 
+  long n;        //8 bytes (if present)
+  int minK;      //2 bytes (if present)
+  int numLevels; //1 byte  (if present)
+  //unused byte
+  int[] levelsArr; //starts at byte 20, adjusted to include top index here
+  
+  // derived, other
   int sketchBytes;
-  int[] levelsArr; //adjusted to include top index
-
+  private int typeBytes;
+  
   KllMemoryValidate(final Memory srcMem, final SketchType sketchType) {
-    
-    readOnly = srcMem.isReadOnly();
     preInts = getMemoryPreInts(srcMem);
     serVer = getMemorySerVer(srcMem);
-
     familyID = getMemoryFamilyID(srcMem);
     if (familyID != Family.KLL.getID()) { memoryValidateThrow(SRC_NOT_KLL, familyID); }
-    famName = idToFamily(familyID).toString();
     flags = getMemoryFlags(srcMem);
-    updatableMemFormat = getMemoryUpdatableFormatFlag(srcMem);
-    empty = getMemoryEmptyFlag(srcMem);
-    singleItem = getMemorySingleItemFlag(srcMem);
-    level0Sorted  = getMemoryLevelZeroSortedFlag(srcMem);
-    this.sketchType = sketchType;
     k = getMemoryK(srcMem);
     m = getMemoryM(srcMem);
     KllHelper.checkM(m);
     KllHelper.checkK(k, m);
-    if ((serVer == SERIAL_VERSION_UPDATABLE) ^ updatableMemFormat) { memoryValidateThrow(UPDATABLEBIT_AND_SER_VER, 1); }
+    
+    empty = getMemoryEmptyFlag(srcMem);
+    level0Sorted  = getMemoryLevelZeroSortedFlag(srcMem);
+    singleItem = getMemorySingleItemFlag(srcMem);
+    
+    serialVersionUpdatable = serVer == SERIAL_VERSION_UPDATABLE;
     typeBytes = (sketchType == DOUBLES_SKETCH) ? Double.BYTES : Float.BYTES;
 
-    if (updatableMemFormat) { updatableMemFormatValidate((WritableMemory) srcMem); }
+    if (serialVersionUpdatable) { updatableMemFormatValidate((WritableMemory) srcMem); }
     else { compactMemoryValidate(srcMem); }
   }
 
-  void compactMemoryValidate(final Memory srcMem) { //FOR HEAPIFY
+  private void compactMemoryValidate(final Memory srcMem) { //FOR HEAPIFY.  NOT UPDATABLE
     if (empty && singleItem) { memoryValidateThrow(EMPTYBIT_AND_SINGLEBIT, flags); }
     final int sw = (empty ? 1 : 0) | (singleItem ? 4 : 0);
 
@@ -129,7 +124,7 @@ final class KllMemoryValidate {
         minK = getMemoryMinK(srcMem);
         numLevels = getMemoryNumLevels(srcMem);
 
-        // Create Levels Arr
+        // Get Levels Arr and add the last element
         levelsArr = new int[numLevels + 1];
         srcMem.getIntArray(DATA_START_ADR, levelsArr, 0, numLevels); //copies all except the last one
         final int capacityItems = KllHelper.computeTotalItemCapacity(k, m, numLevels);
@@ -163,11 +158,9 @@ final class KllMemoryValidate {
     }
   }
 
-  void updatableMemFormatValidate(final WritableMemory wSrcMem) {
+  private void updatableMemFormatValidate(final WritableMemory wSrcMem) {
     if (preInts != PREAMBLE_INTS_FULL) { memoryValidateThrow(INVALID_PREINTS, preInts); }
     n = getMemoryN(wSrcMem);
-    empty = n == 0;       //empty & singleItem are set for convenience
-    singleItem = n == 1;  // there is no error checking on these bits
     minK = getMemoryMinK(wSrcMem);
     numLevels = getMemoryNumLevels(wSrcMem);
 
@@ -187,7 +180,6 @@ final class KllMemoryValidate {
     SINGLEBIT_AND_SER_VER("Single Item Bit: 1 -> SerVer: " + SERIAL_VERSION_SINGLE + ", NOT: "),
     SINGLEBIT_AND_PREINTS("Single Item Bit: 1 -> PreInts: " + PREAMBLE_INTS_EMPTY_SINGLE + ", NOT: "),
     INVALID_PREINTS("PreInts Must Be: " + PREAMBLE_INTS_FULL + ", NOT: "),
-    UPDATABLEBIT_AND_SER_VER("((SerVer == 3) ^ (Updatable Bit)) must = 0, NOT: "),
     EMPTYBIT_AND_SINGLEBIT("Empty flag bit and SingleItem flag bit cannot both be set. Flags: ");
 
     private String msg;

--- a/src/test/java/org/apache/datasketches/kll/KllMemoryValidateTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMemoryValidateTest.java
@@ -23,8 +23,8 @@ import static org.apache.datasketches.kll.KllPreambleUtil.EMPTY_BIT_MASK;
 import static org.apache.datasketches.kll.KllPreambleUtil.PREAMBLE_INTS_EMPTY_SINGLE;
 import static org.apache.datasketches.kll.KllPreambleUtil.PREAMBLE_INTS_FULL;
 import static org.apache.datasketches.kll.KllPreambleUtil.SERIAL_VERSION_EMPTY_FULL;
+import static org.apache.datasketches.kll.KllPreambleUtil.SERIAL_VERSION_SINGLE;
 import static org.apache.datasketches.kll.KllPreambleUtil.SINGLE_ITEM_BIT_MASK;
-import static org.apache.datasketches.kll.KllPreambleUtil.UPDATABLE_BIT_MASK;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryFamilyID;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryFlags;
 import static org.apache.datasketches.kll.KllPreambleUtil.setMemoryPreInts;
@@ -72,8 +72,7 @@ public class KllMemoryValidateTest {
     KllFloatsSketch sk = KllFloatsSketch.newHeapInstance();
     byte[] byteArr = sk.toByteArray();
     WritableMemory wmem = WritableMemory.writableWrap(byteArr);
-    setMemoryFlags(wmem, UPDATABLE_BIT_MASK);
-    setMemorySerVer(wmem, SERIAL_VERSION_EMPTY_FULL);
+    setMemorySerVer(wmem, SERIAL_VERSION_SINGLE);
     KllMemoryValidate memVal = new KllMemoryValidate(wmem, FLOATS_SKETCH);
   }
 

--- a/tools/SketchesCheckstyle.xml
+++ b/tools/SketchesCheckstyle.xml
@@ -64,7 +64,7 @@ under the License.
   <!-- Size Violations -->
   <module name="LineLength">
     <property name="severity" value="warning"/>
-    <property name="max" value="120"/>
+    <property name="max" value="140"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     <!-- <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/> -->
   </module>


### PR DESCRIPTION
1. The UpdatableBitMask as part of the Flags field has been eliminated. This should make the Flags field identical to the one used in C++.

2. The documentation of the serialization formats has been significantly improved.  See the docs for the KllPreambleUtil class.

3. I have reduced the dependence on the KllMemoryValidate class to those that are actually required for validation.

4. More cleanup of fields and variables not really being used.