### PR TITLE
recommended update by Matt Sicker after reviewing our quarterly report.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,5 @@
 github:
+  description: A software library of stochastic streaming algorithms, a.k.a. sketches.
   homepage: https://datasketches.apache.org
 
   master:
@@ -9,4 +10,35 @@ github:
     required_pull_request_reviews:
       dismiss_stale_reviews: true
       required_approving_review_count: 1
+  
+  dependabot_alerts:  true
+  dependabot_updates: false
+  
+  # Attempt to make the auto-generated github emails more easily readable in email clients.
+  custom_subjects:
+    new_pr: "[PR] {title} ({repository})"
+    close_pr: "Re: [PR] {title} ({repository})"
+    comment_pr: "Re: [PR] {title} ({repository})"
+    diffcomment: "Re: [PR] {title} ({repository})"
+    merge_pr: "Re: [PR] {title} ({repository})"
+    new_issue: "[I] {title} ({repository})"
+    comment_issue: "Re: [I] {title} ({repository})"
+    close_issue: "Re: [I] {title} ({repository})"
+    catchall: "[GH] {title} ({repository})"
+    new_discussion: "[D] {title} ({repository})"
+    edit_discussion: "Re: [D] {title} ({repository})"
+    close_discussion: "Re: [D] {title} ({repository})"
+    close_discussion_with_comment: "Re: [D] {title} ({repository})"
+    reopen_discussion: "Re: [D] {title} ({repository})"
+    new_comment_discussion: "Re: [D] {title} ({repository})"
+    edit_comment_discussion: "Re: [D] {title} ({repository})"
+    delete_comment_discussion: "Re: [D] {title} ({repository})"
 
+  notifications:
+    commits:              commits@dataskethces.apache.org
+    issues:               dev@dataskethces.apache.org
+    discussions:          dev@dataskethces.apache.org
+    pullrequests_status:  dev@dataskethces.apache.org
+    pullrequests_comment: dev@dataskethces.apache.org
+    # Send dependabot PRs to commits@ instead
+    pullrequests_bot_dependabot: commits@dataskethces.apache.org


### PR DESCRIPTION
Matt Sicker (ASF-secretary), made the following recommendation upon reading our last quarterly report:

> Even if the amount of messages is not quite as excessive as
>          with some other projects, you might want to consider tweaking
>          the settings for the GitHub PR emails to make them more
>          readable (threadable) ... feel free to have a look here:
>          https://github.com/apache/plc4x/blob/develop/.asf.yaml#L62
>          (I'm also happy to help, if you need help with this)

This is a really good idea.  What it does is forward nearly all GitHub actions to readable notices at dev@.
Plus a few other minor changes.  There are more ideas illustrated on the plc4x .asf.yaml that we may want to take advantage of.  

This current change is a proposal, but could also be leveraged by all of our repositories.
Comments are welcome.
