### PR TITLE
Substitute compile-time constants for the TestNG groups name.

### DIFF
--- a/src/test/java/org/apache/datasketches/common/TestUtil.java
+++ b/src/test/java/org/apache/datasketches/common/TestUtil.java
@@ -32,6 +32,13 @@ public final class TestUtil  {
   private static String userDir = System.getProperty("user.dir");
 
   /**
+   * TestNG group constants
+   */
+  public static final String GENERATE_JAVA_FILES = "generate_java_files";
+  public static final String CHECK_CPP_FILES = "check_cpp_files";
+  public static final String CHECK_CPP_HISTORICAL_FILES = "check_cpp_historical_files";
+
+  /**
    * The full target Path for Java serialized sketches to be tested by other languages.
    */
   public static Path javaPath = createPath("target/java_generated_files");

--- a/src/test/java/org/apache/datasketches/cpc/CpcCBinariesTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcCBinariesTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.datasketches.cpc;
 
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_FILES;
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.cppPath;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 import static org.testng.Assert.assertEquals;
@@ -40,7 +42,7 @@ public class CpcCBinariesTest {
   static PrintStream ps = System.out;
   static final String LS = System.getProperty("line.separator");
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkEmptyBin() {
     final File file = cppPath.resolve("cpc-empty.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -53,7 +55,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkSparseBin() {
     final File file = cppPath.resolve("cpc-sparse.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -78,7 +80,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkHybridBin() {
     final File file = cppPath.resolve("cpc-hybrid.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -103,7 +105,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkPinnedBin() {
     final File file = cppPath.resolve("cpc-pinned.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -128,7 +130,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkSlidingBin() {
     final File file = cppPath.resolve("cpc-sliding.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -155,7 +157,7 @@ public class CpcCBinariesTest {
 
   //Image checks
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkEmptyImages() {
     final File file = cppPath.resolve("cpc-empty.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -174,7 +176,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkSparseImages() {
     final File file = cppPath.resolve("cpc-sparse.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -194,7 +196,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkHybridImages() {
     final File file = cppPath.resolve("cpc-hybrid.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -214,7 +216,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkPinnedImages() {
     final File file = cppPath.resolve("cpc-pinned.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -234,7 +236,7 @@ public class CpcCBinariesTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkSlidingImages() {
     final File file = cppPath.resolve("cpc-sliding.sk").toFile();
     try (MapHandle mh = Memory.map(file)) {
@@ -275,7 +277,7 @@ public class CpcCBinariesTest {
     println(sk2.toString(true));
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 100, 200, 2000, 20_000};
     final Flavor[] flavorArr = {Flavor.EMPTY, Flavor.SPARSE, Flavor.HYBRID, Flavor.PINNED, Flavor.SLIDING};

--- a/src/test/java/org/apache/datasketches/frequencies/SerDeCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies/SerDeCompatibilityTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.frequencies;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -83,7 +84,7 @@ public class SerDeCompatibilityTest {
     Assert.assertEquals(sketch2.getEstimate(4L), 1);
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingLongsSketch() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -96,7 +97,7 @@ public class SerDeCompatibilityTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingStringsSketch() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (final int n: nArr) {
@@ -110,7 +111,7 @@ public class SerDeCompatibilityTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingStringsSketchAscii() throws IOException {
     final ItemsSketch<String> sk = new ItemsSketch<>(64);
     sk.update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1);
@@ -121,7 +122,7 @@ public class SerDeCompatibilityTest {
       .write(sk.toByteArray(new ArrayOfStringsSerDe()));
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingStringsSketchUtf8() throws IOException {
     final ItemsSketch<String> sk = new ItemsSketch<>(64);
     sk.update("абвгд", 1);

--- a/src/test/java/org/apache/datasketches/hll/HllSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/hll/HllSketchSerDeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.hll;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 import static org.apache.datasketches.hll.TgtHllType.HLL_4;
 import static org.apache.datasketches.hll.TgtHllType.HLL_6;
@@ -31,7 +32,7 @@ import org.testng.annotations.Test;
 
 public class HllSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {

--- a/src/test/java/org/apache/datasketches/kll/KllCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllCrossLanguageTest.java
@@ -19,6 +19,10 @@
 
 package org.apache.datasketches.kll;
 
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_FILES;
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_HISTORICAL_FILES;
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
+import static org.apache.datasketches.common.TestUtil.cppHistPath;
 import static org.apache.datasketches.common.TestUtil.cppPath;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 import static org.testng.Assert.assertEquals;
@@ -39,7 +43,7 @@ import org.testng.annotations.Test;
 public class KllCrossLanguageTest {
   private ArrayOfStringsSerDe serDe = new ArrayOfStringsSerDe();
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateKllDoublesSketchBinaries() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -49,7 +53,7 @@ public class KllCrossLanguageTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateKllFloatsSketchBinaries() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -59,7 +63,7 @@ public class KllCrossLanguageTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateKllItemsSketchBinaries() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1_000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -70,7 +74,7 @@ public class KllCrossLanguageTest {
     }
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkCppKllDoublesSketchEstimationMode() throws IOException {
     final byte[] byteArr = Files.readAllBytes(cppPath.resolve("kll_double_estimation_cpp.sk"));
     final KllDoublesSketch sk = KllDoublesSketch.heapify(Memory.wrap(byteArr));
@@ -79,9 +83,9 @@ public class KllCrossLanguageTest {
     assertEquals(sk.getN(), 1000);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   public void checkCppKllDoublesSketchOneItemVersion1() throws IOException {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("kll_sketch_double_one_item_v1.sk"));
+    final byte[] byteArr = Files.readAllBytes(cppHistPath.resolve("kll_sketch_double_one_item_v1.sk"));
     final KllDoublesSketch sk = KllDoublesSketch.heapify(Memory.wrap(byteArr));
     assertFalse(sk.isEmpty());
     assertFalse(sk.isEstimationMode());
@@ -91,7 +95,7 @@ public class KllCrossLanguageTest {
     assertEquals(sk.getMaxItem(), 1.0);
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void checkCppKllFloatsSketchEstimationMode() throws IOException {
     final byte[] byteArr = Files.readAllBytes(cppPath.resolve("kll_float_estimation_cpp.sk"));
     final KllFloatsSketch sk = KllFloatsSketch.heapify(Memory.wrap(byteArr));
@@ -100,9 +104,9 @@ public class KllCrossLanguageTest {
     assertEquals(sk.getN(), 1000);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   public void checkCppKllFloatsSketchOneItemVersion1() throws IOException {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("kll_sketch_float_one_item_v1.sk"));
+    final byte[] byteArr = Files.readAllBytes(cppHistPath.resolve("kll_sketch_float_one_item_v1.sk"));
     final KllFloatsSketch sk = KllFloatsSketch.heapify(Memory.wrap(byteArr));
     assertFalse(sk.isEmpty());
     assertFalse(sk.isEstimationMode());

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchSerDeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.quantiles;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ import org.testng.annotations.Test;
 
 public class DoublesSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (final int n: nArr) {

--- a/src/test/java/org/apache/datasketches/quantiles/ForwardCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ForwardCompatibilityTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.datasketches.quantiles;
 
-import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_HISTORICAL_FILES;
+import static org.apache.datasketches.common.TestUtil.cppHistPath;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.EXCLUSIVE;
 
 import java.io.IOException;
@@ -33,7 +34,7 @@ import org.testng.annotations.Test;
 public class ForwardCompatibilityTest {
   private static final String LS = System.getProperty("line.separator");
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n50_v0.3.0.sk
   //Median2: 26.0
   public void check030_50() {
@@ -43,7 +44,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n1000_v0.3.0.sk
   //Median2: 501.0
   public void check030_1000() {
@@ -53,7 +54,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n50_v0.6.0.sk
   //Median2: 26.0
   public void check060_50() {
@@ -63,7 +64,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n1000_v0.6.0.sk
   //Median2: 501.0
   public void check060_1000() {
@@ -73,7 +74,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n50_v0.8.0.sk
   //Median2: 26.0
   public void check080_50() {
@@ -83,7 +84,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n1000_v0.8.0.sk
   //Median2: 501.0
   public void check080_1000() {
@@ -93,7 +94,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n50_v0.8.3.sk
   //Median2: 26.0
   public void check083_50() {
@@ -103,7 +104,7 @@ public class ForwardCompatibilityTest {
     getAndCheck(ver, n, expected);
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   //fullPath: sketches/src/test/resources/Qk128_n1000_v0.8.0.sk
   //Median2: 501.0
   public void check083_1000() {
@@ -124,7 +125,7 @@ public class ForwardCompatibilityTest {
     //Read File bytes
     byte[] byteArr;
     try {
-      byteArr = Files.readAllBytes(cppPath.resolve(fileName));
+      byteArr = Files.readAllBytes(cppHistPath.resolve(fileName));
     } catch (IOException e) { throw new SketchesArgumentException(e.getCause().toString()); }
     Memory srcMem = Memory.wrap(byteArr);
 

--- a/src/test/java/org/apache/datasketches/quantiles/ItemsSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ItemsSketchSerDeTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.quantiles;
 
-import static org.apache.datasketches.common.TestUtil.javaPath;
+import static org.apache.datasketches.common.TestUtil.*;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 public class ItemsSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (final int n: nArr) {

--- a/src/test/java/org/apache/datasketches/req/ReqSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchSerDeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.req;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 
 import java.io.IOException;
@@ -28,7 +29,7 @@ import org.testng.annotations.Test;
 
 public class ReqSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {

--- a/src/test/java/org/apache/datasketches/sampling/VarOptSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptSketchSerDeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.sampling;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 
 import java.io.IOException;
@@ -30,7 +31,8 @@ import org.testng.annotations.Test;
 
 public class VarOptSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -41,7 +43,7 @@ public class VarOptSketchSerDeTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingStringExact() throws IOException {
     final VarOptItemsSketch<String> sketch = VarOptItemsSketch.newInstance(1024);
     for (int i = 1; i <= 200; ++i) {
@@ -51,7 +53,7 @@ public class VarOptSketchSerDeTest {
       .write(sketch.toByteArray(new ArrayOfStringsSerDe()));
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingLongSampling() throws IOException {
     final VarOptItemsSketch<Long> sketch = VarOptItemsSketch.newInstance(1024);
     for (long i = 0; i < 2000; ++i) {

--- a/src/test/java/org/apache/datasketches/sampling/VarOptUnionSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/sampling/VarOptUnionSerDeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.sampling;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 
 import java.io.IOException;
@@ -29,7 +30,7 @@ import org.testng.annotations.Test;
 
 public class VarOptUnionSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int kSmall = 16;
     final int n1 = 32;

--- a/src/test/java/org/apache/datasketches/theta/CompactSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/CompactSketchTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.datasketches.theta;
 
-import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_HISTORICAL_FILES;
+import static org.apache.datasketches.common.TestUtil.cppHistPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -590,9 +591,9 @@ public class CompactSketchTest {
     }
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   public void compatibilityWithCppEstimationModeV4() throws IOException {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("theta_estimation_mode_v4.sk"));
+    final byte[] byteArr = Files.readAllBytes(cppHistPath.resolve("theta_estimation_mode_v4.sk"));
     CompactSketch cs1 = CompactSketch.heapify(Memory.wrap(byteArr));
 
     // construct sketch the same way

--- a/src/test/java/org/apache/datasketches/theta/ThetaSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ThetaSketchSerDeTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.theta;
 
-import static org.apache.datasketches.common.TestUtil.javaPath;
+import static org.apache.datasketches.common.TestUtil.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 public class ThetaSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTesting() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -40,7 +40,7 @@ public class ThetaSketchSerDeTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingNonEmptyNoEntries() throws IOException {
     final UpdateSketch sk = UpdateSketch.builder().setP(0.01f).build();
     sk.update(1);

--- a/src/test/java/org/apache/datasketches/tuple/CompactSketchWithDoubleSummaryTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/CompactSketchWithDoubleSummaryTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.datasketches.tuple;
 
-import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_HISTORICAL_FILES;
+import static org.apache.datasketches.common.TestUtil.cppHistPath;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -191,9 +192,10 @@ public class CompactSketchWithDoubleSummaryTest {
         new DoubleSummaryFactory(mode));
   }
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   public void serialVersion1Compatibility() throws IOException {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("CompactSketchWithDoubleSummary4K_serialVersion1.sk"));
+    final byte[] byteArr =
+        Files.readAllBytes(cppHistPath.resolve("CompactSketchWithDoubleSummary4K_serialVersion1.sk"));
     Sketch<DoubleSummary> sketch = Sketches.heapifySketch(Memory.wrap(byteArr), new DoubleSummaryDeserializer());
     Assert.assertTrue(sketch.isEstimationMode());
     Assert.assertEquals(sketch.getEstimate(), 8192, 8192 * 0.99);

--- a/src/test/java/org/apache/datasketches/tuple/SerialVersion3Test.java
+++ b/src/test/java/org/apache/datasketches/tuple/SerialVersion3Test.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.tuple;
 
-import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,9 +30,9 @@ import org.testng.annotations.Test;
 
 public class SerialVersion3Test {
 
-  @Test(groups = {"check_cpp_historical_files"})
+  @Test(groups = {CHECK_CPP_HISTORICAL_FILES})
   public void version2Compatibility() throws IOException {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("TupleWithTestIntegerSummary4kTrimmedSerVer2.sk"));
+    final byte[] byteArr = Files.readAllBytes(cppHistPath.resolve("TupleWithTestIntegerSummary4kTrimmedSerVer2.sk"));
     Sketch<IntegerSummary> sketch1 = Sketches.heapifySketch(Memory.wrap(byteArr), new IntegerSummaryDeserializer());
 
     // construct the same way
@@ -53,7 +53,7 @@ public class SerialVersion3Test {
     Assert.assertEquals(sketch1.isEstimationMode(), sketch2.isEstimationMode());
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void emptyFromCpp() throws IOException {
     final byte[] byteArr = Files.readAllBytes(cppPath.resolve("tuple-int-empty-cpp.sk"));
     Sketch<IntegerSummary> sketch = Sketches.heapifySketch(Memory.wrap(byteArr), new IntegerSummaryDeserializer());
@@ -63,7 +63,7 @@ public class SerialVersion3Test {
     Assert.assertEquals(sketch.getThetaLong(), Long.MAX_VALUE);
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void singleItemFromCpp() throws IOException {
     final byte[] byteArr = Files.readAllBytes(cppPath.resolve("tuple-int-single-cpp.sk"));
     Sketch<IntegerSummary> sketch = Sketches.heapifySketch(Memory.wrap(byteArr), new IntegerSummaryDeserializer());
@@ -73,7 +73,7 @@ public class SerialVersion3Test {
     Assert.assertEquals(sketch.getThetaLong(), Long.MAX_VALUE);
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void exactModeFromCpp() throws IOException {
     final byte[] byteArr = Files.readAllBytes(cppPath.resolve("tuple-int-two-cpp.sk"));
     Sketch<IntegerSummary> sketch = Sketches.heapifySketch(Memory.wrap(byteArr), new IntegerSummaryDeserializer());
@@ -83,7 +83,7 @@ public class SerialVersion3Test {
     Assert.assertEquals(sketch.getThetaLong(), Long.MAX_VALUE);
   }
 
-  @Test(groups = {"check_cpp_files"})
+  @Test(groups = {CHECK_CPP_FILES})
   public void estimationModeFromCpp() throws IOException {
     final byte[] byteArr = Files.readAllBytes(cppPath.resolve("tuple-int-est-trim-cpp.sk"));
     Sketch<IntegerSummary> sketch = Sketches.heapifySketch(Memory.wrap(byteArr), new IntegerSummaryDeserializer());

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesSketchSerDeTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesSketchSerDeTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.tuple.arrayofdoubles;
 
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -30,7 +31,7 @@ import org.testng.annotations.Test;
 
 public class ArrayOfDoublesSketchSerDeTest {
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingOneValue() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -40,7 +41,7 @@ public class ArrayOfDoublesSketchSerDeTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingThreeValues() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n: nArr) {
@@ -50,7 +51,7 @@ public class ArrayOfDoublesSketchSerDeTest {
     }
   }
 
-  @Test(groups = {"generate_java_files"})
+  @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingNonEmptyNoEntries() throws IOException {
     final ArrayOfDoublesUpdatableSketch sk =
         new ArrayOfDoublesUpdatableSketchBuilder().setSamplingProbability(0.01f).build();

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnionTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUnionTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.datasketches.tuple.arrayofdoubles;
 
-import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.*;
 
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -202,15 +202,15 @@ public class ArrayOfDoublesUnionTest {
     }
   }
 
-  @Test(expectedExceptions = SketchesArgumentException.class, groups = {"check_cpp_historical_files"})
+  @Test(expectedExceptions = SketchesArgumentException.class, groups = {CHECK_CPP_HISTORICAL_FILES})
   public void noSupportHeapifyV0_9_1() throws Exception {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("ArrayOfDoublesUnion_v0.9.1.sk"));
+    final byte[] byteArr = Files.readAllBytes(cppHistPath.resolve("ArrayOfDoublesUnion_v0.9.1.sk"));
     ArrayOfDoublesUnion.heapify(Memory.wrap(byteArr));
   }
 
-  @Test(expectedExceptions = SketchesArgumentException.class, groups = {"check_cpp_historical_files"})
+  @Test(expectedExceptions = SketchesArgumentException.class, groups = {CHECK_CPP_HISTORICAL_FILES})
   public void noSupportWrapV0_9_1() throws Exception {
-    final byte[] byteArr = Files.readAllBytes(cppPath.resolve("ArrayOfDoublesUnion_v0.9.1.sk"));
+    final byte[] byteArr = Files.readAllBytes(cppHistPath.resolve("ArrayOfDoublesUnion_v0.9.1.sk"));
     ArrayOfDoublesUnion.wrap(WritableMemory.writableWrap(byteArr));
   }
 


### PR DESCRIPTION
Also fixed a number of the CHECK_CPP_HISTORICAL_FILES groups were not correctly associated with the corresponding "cppHistPath".