### PR TITLE
Fixes for get partition boundaries

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketchSortedView.java
@@ -83,8 +83,7 @@ public final class KllDoublesSketchSortedView implements DoublesSortedView {
     if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
     QuantilesUtil.checkNormalizedRankBounds(rank);
     final int len = cumWeights.length;
-    final long naturalRank = (searchCrit == INCLUSIVE)
-        ? (long)Math.ceil(rank * totalN) : (long)Math.floor(rank * totalN);
+    final long naturalRank = Math.round(rank * totalN);
     final InequalitySearch crit = (searchCrit == INCLUSIVE) ? InequalitySearch.GE : InequalitySearch.GT;
     final int index = InequalitySearch.find(cumWeights, 0, len - 1, naturalRank, crit);
     if (index == -1) {

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketchSortedView.java
@@ -83,8 +83,7 @@ public final class KllFloatsSketchSortedView implements FloatsSortedView {
     if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
     QuantilesUtil.checkNormalizedRankBounds(rank);
     final int len = cumWeights.length;
-    final long naturalRank = (searchCrit == INCLUSIVE)
-        ? (long)Math.ceil(rank * totalN) : (long)Math.floor(rank * totalN);
+    final long naturalRank = Math.round(rank * totalN);
     final InequalitySearch crit = (searchCrit == INCLUSIVE) ? InequalitySearch.GE : InequalitySearch.GT;
     final int index = InequalitySearch.find(cumWeights, 0, len - 1, naturalRank, crit);
     if (index == -1) {

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
@@ -133,8 +133,7 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T> {
     if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
     QuantilesUtil.checkNormalizedRankBounds(rank);
     final int len = cumWeights.length;
-    final long naturalRank = (searchCrit == INCLUSIVE)
-        ? (long)Math.ceil(rank * totalN) : (long)Math.floor(rank * totalN);
+    final long naturalRank = Math.round(rank * totalN);
     final InequalitySearch crit = (searchCrit == INCLUSIVE) ? InequalitySearch.GE : InequalitySearch.GT;
     final int index = InequalitySearch.find(cumWeights, 0, len - 1, naturalRank, crit);
     if (index == -1) {

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesSketchSortedView.java
@@ -83,8 +83,7 @@ public final class DoublesSketchSortedView implements DoublesSortedView {
     if (isEmpty()) { throw new IllegalArgumentException(QuantilesAPI.EMPTY_MSG); }
     QuantilesUtil.checkNormalizedRankBounds(rank);
     final int len = cumWeights.length;
-    final long naturalRank = (searchCrit == INCLUSIVE)
-        ? (long)Math.ceil(rank * totalN) : (long)Math.floor(rank * totalN);
+    final long naturalRank = Math.round(rank * totalN);
     final InequalitySearch crit = (searchCrit == INCLUSIVE) ? InequalitySearch.GE : InequalitySearch.GT;
     final int index = InequalitySearch.find(cumWeights, 0, len - 1, naturalRank, crit);
     if (index == -1) {

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
@@ -130,8 +130,7 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T> {
     if (isEmpty()) { throw new IllegalArgumentException(QuantilesAPI.EMPTY_MSG); }
     QuantilesUtil.checkNormalizedRankBounds(rank);
     final int len = cumWeights.length;
-    final long naturalRank = (searchCrit == INCLUSIVE)
-        ? (long)Math.ceil(rank * totalN) : (long)Math.floor(rank * totalN);
+    final long naturalRank = Math.round(rank * totalN);
     final InequalitySearch crit = (searchCrit == INCLUSIVE) ? InequalitySearch.GE : InequalitySearch.GT;
     final int index = InequalitySearch.find(cumWeights, 0, len - 1, naturalRank, crit);
     if (index == -1) {

--- a/src/main/java/org/apache/datasketches/quantilescommon/InequalitySearch.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/InequalitySearch.java
@@ -74,6 +74,11 @@ public enum InequalitySearch {
     }
 
     @Override
+    int compare(final long[] arr, final int a, final int b, final double v) {
+      return v <= arr[a] ? -1 : arr[b] < v ? 1 : 0;
+    }
+
+    @Override
     int getIndex(final double[] arr, final int a, final int b, final double v) {
       return a;
     }
@@ -85,6 +90,11 @@ public enum InequalitySearch {
 
     @Override
     int getIndex(final long[] arr, final int a, final int b, final long v) {
+      return a;
+    }
+
+    @Override
+    int getIndex(final long[] arr, final int a, final int b, final double v) {
       return a;
     }
 
@@ -104,6 +114,13 @@ public enum InequalitySearch {
 
     @Override
     int resolve(final long[] arr, final int lo, final int hi, final long v) {
+      return (lo == hi)
+          ? (v > arr[lo] ? lo : -1)
+          : v > arr[hi] ? hi : (v > arr[lo] ? lo : -1);
+    }
+
+    @Override
+    int resolve(final long[] arr, final int lo, final int hi, final double v) {
       return (lo == hi)
           ? (v > arr[lo] ? lo : -1)
           : v > arr[hi] ? hi : (v > arr[lo] ? lo : -1);
@@ -139,6 +156,20 @@ public enum InequalitySearch {
 
     @Override
     public String desc(final long[] arr, final int low, final int high, final long v, final int idx) {
+      if (idx == -1) {
+        return "LT: " + v + " <= arr[" + low + "]=" + arr[low] + "; return -1";
+      }
+      if (idx == high) {
+        return "LT: " + v + " > arr[" + high + "]=" + arr[high]
+            + "; return arr[" + high + "]=" + arr[high];
+      } //idx < high
+      return "LT: " + v
+      + ": arr[" + idx + "]=" + arr[idx] + " < " + v + " <= arr[" + (idx + 1) + "]=" + arr[idx + 1]
+      + "; return arr[" + idx + "]=" + arr[idx];
+    }
+
+    @Override
+    public String desc(final long[] arr, final int low, final int high, final double v, final int idx) {
       if (idx == -1) {
         return "LT: " + v + " <= arr[" + low + "]=" + arr[low] + "; return -1";
       }
@@ -180,6 +211,11 @@ public enum InequalitySearch {
     }
 
     @Override
+    int compare(final long[] arr, final int a, final int b, final double v) {
+      return v < arr[a] ? -1 : arr[b] <= v ? 1 : 0;
+    }
+
+    @Override
     int getIndex(final double[] arr, final int a, final int b, final double v) {
       return a;
     }
@@ -191,6 +227,11 @@ public enum InequalitySearch {
 
     @Override
     int getIndex(final long[] arr, final int a, final int b, final long v) {
+      return a;
+    }
+
+    @Override
+    int getIndex(final long[] arr, final int a, final int b, final double v) {
       return a;
     }
 
@@ -210,6 +251,13 @@ public enum InequalitySearch {
 
     @Override
     int resolve(final long[] arr, final int lo, final int hi, final long v) {
+      return (lo == hi)
+          ? (v >= arr[lo] ? lo : -1)
+          : v >= arr[hi] ? hi : (v >= arr[lo] ? lo : -1);
+    }
+
+    @Override
+    int resolve(final long[] arr, final int lo, final int hi, final double v) {
       return (lo == hi)
           ? (v >= arr[lo] ? lo : -1)
           : v >= arr[hi] ? hi : (v >= arr[lo] ? lo : -1);
@@ -245,6 +293,20 @@ public enum InequalitySearch {
 
     @Override
     public String desc(final long[] arr, final int low, final int high, final long v, final int idx) {
+      if (idx == -1) {
+        return "LE: " + v + " < arr[" + low + "]=" + arr[low] + "; return -1";
+      }
+      if (idx == high) {
+        return "LE: " + v + " >= arr[" + high + "]=" + arr[high]
+            + "; return arr[" + high + "]=" + arr[high];
+      }
+      return "LE: " + v
+      + ": arr[" + idx + "]=" + arr[idx] + " <= " + v + " < arr[" + (idx + 1) + "]=" + arr[idx + 1]
+          + "; return arr[" + idx + "]=" + arr[idx];
+    }
+
+    @Override
+    public String desc(final long[] arr, final int low, final int high, final double v, final int idx) {
       if (idx == -1) {
         return "LE: " + v + " < arr[" + low + "]=" + arr[low] + "; return -1";
       }
@@ -282,6 +344,11 @@ public enum InequalitySearch {
     }
 
     @Override
+    int compare(final long[] arr, final int a, final int b, final double v) {
+      return v < arr[a] ? -1 : arr[b] < v ? 1 : 0;
+    }
+
+    @Override
     int getIndex(final double[] arr, final int a, final int b, final double v) {
       return v == arr[a] ? a : v == arr[b] ? b : -1;
     }
@@ -293,6 +360,11 @@ public enum InequalitySearch {
 
     @Override
     int getIndex(final long[] arr, final int a, final int b, final long v) {
+      return v == arr[a] ? a : v == arr[b] ? b : -1;
+    }
+
+    @Override
+    int getIndex(final long[] arr, final int a, final int b, final double v) {
       return v == arr[a] ? a : v == arr[b] ? b : -1;
     }
 
@@ -312,6 +384,13 @@ public enum InequalitySearch {
 
     @Override
     int resolve(final long[] arr, final int lo, final int hi, final long v) {
+      return (lo == hi)
+          ? (v == arr[lo] ? lo : -1)
+          : v == arr[lo] ? lo : (v == arr[hi] ? hi : -1);
+    }
+
+    @Override
+    int resolve(final long[] arr, final int lo, final int hi, final double v) {
       return (lo == hi)
           ? (v == arr[lo] ? lo : -1)
           : v == arr[lo] ? lo : (v == arr[hi] ? hi : -1);
@@ -347,6 +426,20 @@ public enum InequalitySearch {
 
     @Override
     public String desc(final long[] arr, final int low, final int high, final long v, final int idx) {
+      if (idx == -1) {
+        if (v > arr[high]) {
+          return "EQ: " + v + " > arr[" + high + "]; return -1";
+        }
+        if (v < arr[low]) {
+          return "EQ: " + v + " < arr[" + low + "]; return -1";
+        }
+        return "EQ: " + v + " Cannot be found within arr[" + low + "], arr[" + high + "]; return -1";
+      }
+      return "EQ: " + v + " == arr[" + idx + "]; return arr[" + idx + "]=" + arr[idx];
+    }
+
+    @Override
+    public String desc(final long[] arr, final int low, final int high, final double v, final int idx) {
       if (idx == -1) {
         if (v > arr[high]) {
           return "EQ: " + v + " > arr[" + high + "]; return -1";
@@ -388,6 +481,11 @@ public enum InequalitySearch {
     }
 
     @Override
+    int compare(final long[] arr, final int a, final int b, final double v) {
+      return v <= arr[a] ? -1 : arr[b] < v ? 1 : 0;
+    }
+
+    @Override
     int getIndex(final double[] arr, final int a, final int b, final double v) {
       return b;
     }
@@ -399,6 +497,11 @@ public enum InequalitySearch {
 
     @Override
     int getIndex(final long[] arr, final int a, final int b, final long v) {
+      return b;
+    }
+
+    @Override
+    int getIndex(final long[] arr, final int a, final int b, final double v) {
       return b;
     }
 
@@ -418,6 +521,13 @@ public enum InequalitySearch {
 
     @Override
     int resolve(final long[] arr, final int lo, final int hi, final long v) {
+      return (lo == hi)
+          ? (v <= arr[lo] ? lo : -1)
+          : v <= arr[lo] ? lo : (v <= arr[hi] ? hi : -1);
+    }
+
+    @Override
+    int resolve(final long[] arr, final int lo, final int hi, final double v) {
       return (lo == hi)
           ? (v <= arr[lo] ? lo : -1)
           : v <= arr[lo] ? lo : (v <= arr[hi] ? hi : -1);
@@ -453,6 +563,20 @@ public enum InequalitySearch {
 
     @Override
     public String desc(final long[] arr, final int low, final int high, final long v, final int idx) {
+      if (idx == -1) {
+        return "GE: " + v + " > arr[" + high + "]=" + arr[high] + "; return -1";
+      }
+      if (idx == low) {
+        return "GE: " + v + " <= arr[" + low + "]=" + arr[low]
+            + "; return arr[" + low + "]=" + arr[low];
+      } //idx > low
+      return "GE: " + v
+      + ": arr[" + (idx - 1) + "]=" + arr[idx - 1] + " < " + v + " <= arr[" + idx + "]=" + arr[idx]
+          + "; return arr[" + idx + "]=" + arr[idx];
+    }
+
+    @Override
+    public String desc(final long[] arr, final int low, final int high, final double v, final int idx) {
       if (idx == -1) {
         return "GE: " + v + " > arr[" + high + "]=" + arr[high] + "; return -1";
       }
@@ -494,6 +618,11 @@ public enum InequalitySearch {
     }
 
     @Override
+    int compare(final long[] arr, final int a, final int b, final double v) {
+      return v < arr[a] ? -1 : arr[b] <= v ? 1 : 0;
+    }
+
+    @Override
     int getIndex(final double[] arr, final int a, final int b, final double v) {
       return b;
     }
@@ -505,6 +634,11 @@ public enum InequalitySearch {
 
     @Override
     int getIndex(final long[] arr, final int a, final int b, final long v) {
+      return b;
+    }
+
+    @Override
+    int getIndex(final long[] arr, final int a, final int b, final double v) {
       return b;
     }
 
@@ -524,6 +658,13 @@ public enum InequalitySearch {
 
     @Override
     int resolve(final long[] arr, final int lo, final int hi, final long v) {
+      return (lo == hi)
+          ? (v < arr[lo] ? lo : -1)
+          : v < arr[lo] ? lo : (v < arr[hi] ? hi : -1);
+    }
+
+    @Override
+    int resolve(final long[] arr, final int lo, final int hi, final double v) {
       return (lo == hi)
           ? (v < arr[lo] ? lo : -1)
           : v < arr[lo] ? lo : (v < arr[hi] ? hi : -1);
@@ -570,14 +711,28 @@ public enum InequalitySearch {
       + ": arr[" + (idx - 1) + "]=" + arr[idx - 1] + " <= " + v + " < arr[" + idx + "]=" + arr[idx]
           + "; return arr[" + idx + "]=" + arr[idx];
     }
+
+    @Override
+    public String desc(final long[] arr, final int low, final int high, final double v, final int idx) {
+      if (idx == -1) {
+        return "GT: " + v + " >= arr[" + high + "]=" + arr[high] + "; return -1";
+      }
+      if (idx == low) {
+        return "GT: " + v + " < arr[" + low + "]=" + arr[low]
+            + "; return arr[" + low + "]=" + arr[low];
+      } //idx > low
+      return "GT: " + v
+      + ": arr[" + (idx - 1) + "]=" + arr[idx - 1] + " <= " + v + " < arr[" + idx + "]=" + arr[idx]
+          + "; return arr[" + idx + "]=" + arr[idx];
+    }
   };
 
   /**
    * The call to compare index a and index b with the value v.
-   * @param arr The underlying sorted array of double values
+   * @param arr The underlying sorted array of values
    * @param a the lower index of the current pair
    * @param b the higher index of the current pair
-   * @param v the double value to search for
+   * @param v the value to search for
    * @return +1, which means we must search higher in the array, or -1, which means we must
    * search lower in the array, or 0, which means we have found the correct bounding pair.
    */
@@ -585,10 +740,10 @@ public enum InequalitySearch {
 
   /**
    * The call to compare index a and index b with the value v.
-   * @param arr The underlying sorted array of float values
+   * @param arr The underlying sorted array of values
    * @param a the lower index of the current pair
    * @param b the higher index of the current pair
-   * @param v the float value to search for
+   * @param v the value to search for
    * @return +1, which means we must search higher in the array, or -1, which means we must
    * search lower in the array, or 0, which means we have found the correct bounding pair.
    */
@@ -596,14 +751,25 @@ public enum InequalitySearch {
 
   /**
    * The call to compare index a and index b with the value v.
-   * @param arr The underlying sorted array of long values
+   * @param arr The underlying sorted array of values
    * @param a the lower index of the current pair
    * @param b the higher index of the current pair
-   * @param v the long value to search for
+   * @param v the value to search for
    * @return +1, which means we must search higher in the array, or -1, which means we must
    * search lower in the array, or 0, which means we have found the correct bounding pair.
    */
   abstract int compare(long[] arr, int a, int b, long v);
+
+  /**
+   * The call to compare index a and index b with the value v.
+   * @param arr The underlying sorted array of values
+   * @param a the lower index of the current pair
+   * @param b the higher index of the current pair
+   * @param v the value to search for
+   * @return +1, which means we must search higher in the array, or -1, which means we must
+   * search lower in the array, or 0, which means we have found the correct bounding pair.
+   */
+  abstract int compare(long[] arr, int a, int b, double v);
 
   /**
    * If the compare operation returns 0, which means "found", this returns the index of the
@@ -639,6 +805,17 @@ public enum InequalitySearch {
   abstract int getIndex(long[] arr, int a, int b, long v);
 
   /**
+   * If the compare operation returns 0, which means "found", this returns the index of the
+   * found value that satisfies the selected criteria.
+   * @param arr the array being searched
+   * @param a the lower index of the current pair
+   * @param b the higher index of the current pair
+   * @param v the value being searched for.
+   * @return the index of the found value that satisfies the selected criteria.
+   */
+  abstract int getIndex(long[] arr, int a, int b, double v);
+
+  /**
    * Called to resolve the search when the hi and lo pointers are equal or adjacent.
    * @param arr the array being searched
    * @param lo the current lo value
@@ -669,12 +846,22 @@ public enum InequalitySearch {
   abstract int resolve(long[] arr, int lo, int hi, long v);
 
   /**
+   * Called to resolve the search when the hi and lo pointers are equal or adjacent.
+   * @param arr the array being searched
+   * @param lo the current lo value
+   * @param hi the current hi value
+   * @param v the value being searched for
+   * @return the index of the resolution or -1, if it cannot be resolved.
+   */
+  abstract int resolve(long[] arr, int lo, int hi, double v);
+
+  /**
    * Optional call that describes the details of the results of the search.
    * Used primarily for debugging.
-   * @param arr The underlying sorted array of double values
+   * @param arr The underlying sorted array of values
    * @param low the low index of the range
    * @param high the high index of the range
-   * @param v the double value to search for
+   * @param v the value to search for
    * @param idx the resolved index from the search
    * @return the descriptive string.
    */
@@ -683,10 +870,10 @@ public enum InequalitySearch {
   /**
    * Optional call that describes the details of the results of the search.
    * Used primarily for debugging.
-   * @param arr The underlying sorted array of double values
+   * @param arr The underlying sorted array of values
    * @param low the low index of the range
    * @param high the high index of the range
-   * @param v the double value to search for
+   * @param v the value to search for
    * @param idx the resolved index from the search
    * @return the descriptive string.
    */
@@ -695,14 +882,26 @@ public enum InequalitySearch {
   /**
    * Optional call that describes the details of the results of the search.
    * Used primarily for debugging.
-   * @param arr The underlying sorted array of double values
+   * @param arr The underlying sorted array of values
    * @param low the low index of the range
    * @param high the high index of the range
-   * @param v the double value to search for
+   * @param v the value to search for
    * @param idx the resolved index from the search
    * @return the descriptive string.
    */
   public abstract String desc(long[] arr, int low, int high, long v, int idx);
+
+  /**
+   * Optional call that describes the details of the results of the search.
+   * Used primarily for debugging.
+   * @param arr The underlying sorted array of values
+   * @param low the low index of the range
+   * @param high the high index of the range
+   * @param v the value to search for
+   * @param idx the resolved index from the search
+   * @return the descriptive string.
+   */
+  public abstract String desc(long[] arr, int low, int high, double v, int idx);
 
   /**
    * Binary Search for the index of the double value in the given search range that satisfies
@@ -786,6 +985,38 @@ public enum InequalitySearch {
    */
   public static int find(final long[] arr, final int low, final int high,
       final long v, final InequalitySearch crit) {
+    Objects.requireNonNull(arr, "Input arr must not be null");
+    Objects.requireNonNull(crit, "Input crit must not be null");
+    if (arr.length == 0) { throw new SketchesArgumentException("Input array must not be empty."); }
+    int lo = low;
+    int hi = high;
+    while (lo <= hi) {
+      if (hi - lo <= 1) {
+        return crit.resolve(arr, lo, hi, v);
+      }
+      final int mid = lo + (hi - lo) / 2;
+      final int ret = crit.compare(arr, mid, mid + 1, v);
+      if (ret == -1 ) { hi = mid; }
+      else if (ret == 1) { lo = mid + 1; }
+      else  { return crit.getIndex(arr, mid, mid + 1, v); }
+    }
+    return -1; //should never return here
+  }
+
+  /**
+   * Binary Search for the index of the double value in the given search range that satisfies
+   * the given InequalitySearch criterion.
+   * If -1 is returned there are no values in the search range that satisfy the criterion.
+   *
+   * @param arr the given array that must be sorted.
+   * @param low the lowest index of the lowest value in the search range, inclusive.
+   * @param high the highest index of the highest value in the search range, inclusive.
+   * @param v the value to search for.
+   * @param crit one of LT, LE, EQ, GT, GE
+   * @return the index of the value in the given search range that satisfies the criterion
+   */
+  public static int find(final long[] arr, final int low, final int high,
+      final double v, final InequalitySearch crit) {
     Objects.requireNonNull(arr, "Input arr must not be null");
     Objects.requireNonNull(crit, "Input crit must not be null");
     if (arr.length == 0) { throw new SketchesArgumentException("Input array must not be empty."); }

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -237,7 +237,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * Gets the upper bound of the quantile confidence interval in which the true quantile of the
    * given rank exists.
    *
-   * <p>Although it is possible to estimate the probablity that the true quantile
+   * <p>Although it is possible to estimate the probability that the true quantile
    * exists within the quantile confidence interval specified by the upper and lower quantile bounds,
    * it is not possible to guarantee the width of the quantile interval
    * as an additive or multiplicative percent of the true quantile.</p>

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesFloatsAPI.java
@@ -221,7 +221,7 @@ public interface QuantilesFloatsAPI extends QuantilesAPI {
    * Gets the lower bound of the quantile confidence interval in which the quantile of the
    * given rank exists.
    *
-   * <p>Although it is possible to estimate the probablity that the true quantile
+   * <p>Although it is possible to estimate the probability that the true quantile
    * exists within the quantile confidence interval specified by the upper and lower quantile bounds,
    * it is not possible to guarantee the width of the quantile confidence interval
    * as an additive or multiplicative percent of the true quantile.</p>

--- a/src/main/java/org/apache/datasketches/req/ReqSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSketchSortedView.java
@@ -70,8 +70,7 @@ public final class ReqSketchSortedView implements FloatsSortedView {
     if (isEmpty()) { throw new IllegalArgumentException(QuantilesAPI.EMPTY_MSG); }
     QuantilesUtil.checkNormalizedRankBounds(rank);
     final int len = cumWeights.length;
-    final long naturalRank = (searchCrit == INCLUSIVE)
-        ? (long)Math.ceil(rank * totalN) : (long)Math.floor(rank * totalN);
+    final long naturalRank = Math.round(rank * totalN);
     final InequalitySearch crit = (searchCrit == INCLUSIVE) ? InequalitySearch.GE : InequalitySearch.GT;
     final int index = InequalitySearch.find(cumWeights, 0, len - 1, naturalRank, crit);
     if (index == -1) {


### PR DESCRIPTION
This applies the same fix that eliminates duplicate entries when using getPartitionBoundaries(...) for small values of N, in all the quantile sketches.