### PR TITLE
use serialization_test_data instead of target2 for cross-repo test data

### DIFF
--- a/.github/workflows/check_cpp_files.yml
+++ b/.github/workflows/check_cpp_files.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Run C++ tests
         run: cd cpp && cmake --build build --config Release --target test
       - name: Make dir
-        run: mkdir -p target/cpp_generated_files
+        run: mkdir -p serialization_test_data/cpp_generated_files
       - name: Copy files
-        run: cp cpp/build/*/test/*_cpp.sk target/cpp_generated_files
+        run: cp cpp/build/*/test/*_cpp.sk serialization_test_data/cpp_generated_files
       - name: Run Java tests
         run: mvn test -P check-cpp-files

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ tmp/
 
 # Build artifacts
 target/
-target2/
+serialization_test_data/
 out/
 build/
 jarsIn/

--- a/src/test/java/org/apache/datasketches/common/TestUtil.java
+++ b/src/test/java/org/apache/datasketches/common/TestUtil.java
@@ -52,12 +52,12 @@ public final class TestUtil  {
   /**
    * The full target Path for Java serialized sketches to be tested by other languages.
    */
-  public static final Path javaPath = createPath("target2/java_generated_files");
+  public static final Path javaPath = createPath("serialization_test_data/java_generated_files");
 
   /**
    * The full target Path for C++ serialized sketches to be tested by Java.
    */
-  public static final Path cppPath = createPath("target2/cpp_generated_files");
+  public static final Path cppPath = createPath("serialization_test_data/cpp_generated_files");
 
   private static Path createPath(final String projectLocalDir) {
     try {


### PR DESCRIPTION
Need to make corresponding changes in c++ but this uses a more descriptive name for the directory