### PR TITLE
HLL Union toString is not pure and can trigger a rebuild

### DIFF
--- a/src/main/java/org/apache/datasketches/hll/Union.java
+++ b/src/main/java/org/apache/datasketches/hll/Union.java
@@ -306,8 +306,9 @@ public class Union extends BaseHllSketch {
   @Override
   public String toString(final boolean summary, final boolean hllDetail,
       final boolean auxDetail, final boolean all) {
-    checkRebuildCurMinNumKxQ(gadget);
-    return gadget.toString(summary, hllDetail, auxDetail, all);
+    HllSketch clone = gadget.copy();
+    checkRebuildCurMinNumKxQ(clone);
+    return clone.toString(summary, hllDetail, auxDetail, all);
   }
 
   /**

--- a/src/test/java/org/apache/datasketches/hll/UnionTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionTest.java
@@ -449,6 +449,7 @@ public class UnionTest {
     Union union1 = new Union(lgK, wmem); //Create original union off-heap
     union1.update(sk1);
     union1.update(sk2); //oooFlag = Rebuild_KxQ = TRUE
+    assertTrue(!union1.toString().isEmpty());
     boolean rebuild = PreambleUtil.extractRebuildCurMinNumKxQFlag(wmem);
     double hipAccum = PreambleUtil.extractHipAccum(wmem);
     assertTrue(rebuild);


### PR DESCRIPTION
Hello,

The toString method of Union can mutate the object if a rebuild is necessary.
This make some test fail when running in debug (as some IDE will render object value automatically).

Not a major issue, but surely unexpected to have toString() mutate the object.

Thanks !
