### PR TITLE
Kll weighted updates group2

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllDirectDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectDoublesSketch.java
@@ -178,7 +178,7 @@ class KllDirectDoublesSketch extends KllDoublesSketch {
 
   //restricted
 
-  @Override //returns updatable, expanded array including empty/garbage space at bottom
+  @Override //returns updatable, expanded array including free space at bottom
   double[] getDoubleItemsArray() {
     final int k = getK();
     if (sketchStructure == COMPACT_EMPTY) { return new double[k]; }
@@ -196,7 +196,7 @@ class KllDirectDoublesSketch extends KllDoublesSketch {
     return doubleItemsArr;
   }
 
-  @Override //returns compact items array of retained items, no empty/garbage.
+  @Override //returns compact items array of retained items, no free space.
   double[] getDoubleRetainedItemsArray() {
     if (sketchStructure == COMPACT_EMPTY) { return new double[0]; }
     if (sketchStructure == COMPACT_SINGLE) { return new double[] { getDoubleSingleItem() }; }

--- a/src/main/java/org/apache/datasketches/kll/KllDirectFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectFloatsSketch.java
@@ -178,7 +178,7 @@ class KllDirectFloatsSketch extends KllFloatsSketch {
 
   //restricted
 
-  @Override //returns updatable, expanded array including empty/garbage space at bottom
+  @Override //returns updatable, expanded array including free space at bottom
   float[] getFloatItemsArray() {
     final int k = getK();
     if (sketchStructure == COMPACT_EMPTY) { return new float[k]; }
@@ -196,7 +196,7 @@ class KllDirectFloatsSketch extends KllFloatsSketch {
     return floatItemsArr;
   }
 
-  @Override //returns compact items array of retained items, no empty/garbage.
+  @Override //returns compact items array of retained items, no free space.
   float[] getFloatRetainedItemsArray() {
     if (sketchStructure == COMPACT_EMPTY) { return new float[0]; }
     if (sketchStructure == COMPACT_SINGLE) { return new float[] { getFloatSingleItem() }; }

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketchSortedView.java
@@ -77,7 +77,7 @@ public final class KllDoublesSketchSortedView implements DoublesSortedView {
       if (!sketch.hasMemory()) { sketch.setLevelZeroSorted(true); }
     }
 
-    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove garbage
+    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove free space
     quantiles = new double[numQuantiles];
     cumWeights = new long[numQuantiles];
     populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketchSortedView.java
@@ -77,7 +77,7 @@ public final class KllFloatsSketchSortedView implements FloatsSortedView {
       if (!sketch.hasMemory()) { sketch.setLevelZeroSorted(true); }
     }
 
-    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove garbage
+    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove free space
     quantiles = new float[numQuantiles];
     cumWeights = new long[numQuantiles];
     populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);

--- a/src/main/java/org/apache/datasketches/kll/KllHeapDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHeapDoublesSketch.java
@@ -136,10 +136,10 @@ final class KllHeapDoublesSketch extends KllDoublesSketch {
       maxDoubleItem = srcMem.getDouble(offsetBytes);
       offsetBytes += Double.BYTES;
       final int capacityItems = levelsArr[getNumLevels()];
-      final int garbageItems = levelsArr[0];
-      final int retainedItems = capacityItems - garbageItems;
+      final int freeItems = levelsArr[0];
+      final int retainedItems = capacityItems - freeItems;
       doubleItems = new double[capacityItems];
-      srcMem.getDoubleArray(offsetBytes, doubleItems, garbageItems, retainedItems);
+      srcMem.getDoubleArray(offsetBytes, doubleItems, freeItems, retainedItems);
     }
     else { //(memStructure == UPDATABLE)
       int offsetBytes = DATA_START_ADR;
@@ -300,14 +300,5 @@ final class KllHeapDoublesSketch extends KllDoublesSketch {
 
   @Override
   void setWritableMemory(final WritableMemory wmem) { }
-
-  static void weightedUpdateDouble(final KllDoublesSketch dblSk, final double item, final int weight) {
-    if (weight < dblSk.getLevelsArray(UPDATABLE)[0]) {
-      for (int i = 0; i < weight; i++) { dblSk.update(item); }
-    } else {
-      final KllHeapDoublesSketch tmpSk = new KllHeapDoublesSketch(dblSk.getK(), DEFAULT_M, item, weight);
-      dblSk.merge(tmpSk);
-    }
-  }
 
 }

--- a/src/main/java/org/apache/datasketches/kll/KllHeapDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHeapDoublesSketch.java
@@ -136,10 +136,10 @@ final class KllHeapDoublesSketch extends KllDoublesSketch {
       maxDoubleItem = srcMem.getDouble(offsetBytes);
       offsetBytes += Double.BYTES;
       final int capacityItems = levelsArr[getNumLevels()];
-      final int freeItems = levelsArr[0];
-      final int retainedItems = capacityItems - freeItems;
+      final int freeSpace = levelsArr[0];
+      final int retainedItems = capacityItems - freeSpace;
       doubleItems = new double[capacityItems];
-      srcMem.getDoubleArray(offsetBytes, doubleItems, freeItems, retainedItems);
+      srcMem.getDoubleArray(offsetBytes, doubleItems, freeSpace, retainedItems);
     }
     else { //(memStructure == UPDATABLE)
       int offsetBytes = DATA_START_ADR;

--- a/src/main/java/org/apache/datasketches/kll/KllHeapFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHeapFloatsSketch.java
@@ -117,10 +117,10 @@ final class KllHeapFloatsSketch extends KllFloatsSketch {
       maxFloatItem = srcMem.getFloat(offsetBytes);
       offsetBytes += Float.BYTES;
       final int capacityItems = levelsArr[getNumLevels()];
-      final int freeItems = levelsArr[0];
-      final int retainedItems = capacityItems - freeItems;
+      final int freeSpace = levelsArr[0];
+      final int retainedItems = capacityItems - freeSpace;
       floatItems = new float[capacityItems];
-      srcMem.getFloatArray(offsetBytes, floatItems, freeItems, retainedItems);
+      srcMem.getFloatArray(offsetBytes, floatItems, freeSpace, retainedItems);
     }
     else { //(memStructure == UPDATABLE)
       int offsetBytes = DATA_START_ADR;

--- a/src/main/java/org/apache/datasketches/kll/KllHeapFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHeapFloatsSketch.java
@@ -117,10 +117,10 @@ final class KllHeapFloatsSketch extends KllFloatsSketch {
       maxFloatItem = srcMem.getFloat(offsetBytes);
       offsetBytes += Float.BYTES;
       final int capacityItems = levelsArr[getNumLevels()];
-      final int garbageItems = levelsArr[0];
-      final int retainedItems = capacityItems - garbageItems;
+      final int freeItems = levelsArr[0];
+      final int retainedItems = capacityItems - freeItems;
       floatItems = new float[capacityItems];
-      srcMem.getFloatArray(offsetBytes, floatItems, garbageItems, retainedItems);
+      srcMem.getFloatArray(offsetBytes, floatItems, freeItems, retainedItems);
     }
     else { //(memStructure == UPDATABLE)
       int offsetBytes = DATA_START_ADR;

--- a/src/main/java/org/apache/datasketches/kll/KllHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHelper.java
@@ -365,10 +365,10 @@ final class KllHelper {
     final int k = sketch.getK();
     final int m = sketch.getM();
     final StringBuilder sb =  new StringBuilder();
-    sb.append("### KllSketch itemsArray & levelsArray data:").append(LS);
+    sb.append(LS + "### KLL ItemsArray & LevelsArray Detail:").append(LS);
     sb.append("Index, Value").append(LS);
     if (levelsArr[0] > 0) {
-      final String gbg = " Empty or Garbage, size = " + levelsArr[0];
+      final String gbg = " Free Space, Size = " + levelsArr[0];
       for (int i = 0; i < levelsArr[0]; i++) {
         sb.append("    ").append(i + ", ").append(sketch.getItemAsString(i));
         if (i == 0) { sb.append(gbg); }
@@ -381,10 +381,10 @@ final class KllHelper {
       final int toIndex = levelsArr[level + 1]; // exclusive
       String lvlData = "";
       if (fromIndex < toIndex) {
-        lvlData = " level[" + level + "]=" + levelsArr[level]
-            + ", cap=" + KllHelper.levelCapacity(k, numLevels, level, m)
-            + ", size=" + KllHelper.currentLevelSizeItems(level, numLevels, levelsArr)
-            + ", wt=" + (1 << level) + LS;
+        lvlData = " Level[" + level + "]=" + levelsArr[level]
+            + ", Cap=" + KllHelper.levelCapacity(k, numLevels, level, m)
+            + ", Size=" + KllHelper.currentLevelSizeItems(level, numLevels, levelsArr)
+            + ", Wt=" + (1 << level) + LS;
       }
 
       for (int i = fromIndex; i < toIndex; i++) {
@@ -393,10 +393,25 @@ final class KllHelper {
       }
       level++;
     }
-    sb.append("   ----------level[" + level + "]=" + levelsArr[level] + ": itemsArray[].length");
+    sb.append("   ----------Level[" + level + "]=" + levelsArr[level] + ": ItemsArray[].length");
     sb.append(LS);
-    sb.append("### End data").append(LS);
+    sb.append("### End ItemsArray & LevelsArray Detail").append(LS);
+    return sb.toString();
+  }
 
+  static String outputLevels(final int k, final int m, final int numLevels, final int[] levelsArr) {
+    final StringBuilder sb =  new StringBuilder();
+    sb.append(LS + "### KLL Levels Array:").append(LS)
+    .append(" Level, Offset: Nominal Capacity, Actual Capacity").append(LS);
+    int level = 0;
+    for ( ; level < numLevels; level++) {
+      sb.append("     ").append(level).append(", ").append(levelsArr[level]).append(": ")
+      .append(KllHelper.levelCapacity(k, numLevels, level, m))
+      .append(", ").append(KllHelper.currentLevelSizeItems(level, numLevels, levelsArr)).append(LS);
+    }
+    sb.append("     ").append(level).append(", ").append(levelsArr[level]).append(": ----ItemsArray[].length")
+    .append(LS);
+    sb.append("### End Levels Array").append(LS);
     return sb.toString();
   }
 
@@ -479,55 +494,58 @@ final class KllHelper {
 
   static <T> String toStringImpl(final KllSketch sketch, final boolean withSummary, final boolean withData,
       final ArrayOfItemsSerDe<T> serDe) {
-    final SketchType sketchType = sketch.sketchType;
-    final boolean hasMemory = sketch.hasMemory();
+    final StringBuilder sb = new StringBuilder();
     final int k = sketch.getK();
     final int m = sketch.getM();
-    final long n = sketch.getN();
     final int numLevels = sketch.getNumLevels();
     final int[] fullLevelsArr = sketch.getLevelsArray(UPDATABLE);
-    //final int[] levelsArr = sketch.getLevelsArray(sketch.sketchStructure);
-    final String epsPct = String.format("%.3f%%", sketch.getNormalizedRankError(false) * 100);
-    final String epsPMFPct = String.format("%.3f%%", sketch.getNormalizedRankError(true) * 100);
-    final boolean compact = sketch.isCompactMemoryFormat();
 
-    final StringBuilder sb = new StringBuilder();
-    final String directStr = hasMemory ? "Direct" : "";
-    final String compactStr = compact ? "Compact" : "";
-    final String readOnlyStr = sketch.isReadOnly() ? "true" + ("(" + (compact ? "Format" : "Memory") + ")") : "false";
-    final String skTypeStr = sketchType.getName();
-    final String className = "Kll" + directStr + compactStr + skTypeStr;
+    if (withSummary) {
+      final SketchType sketchType = sketch.sketchType;
+      final boolean hasMemory = sketch.hasMemory();
+      final long n = sketch.getN();
+      final String epsPct = String.format("%.3f%%", sketch.getNormalizedRankError(false) * 100);
+      final String epsPMFPct = String.format("%.3f%%", sketch.getNormalizedRankError(true) * 100);
+      final boolean compact = sketch.isCompactMemoryFormat();
 
-    sb.append(LS).append("### ").append(className).append(" Summary:").append(LS);
-    sb.append("   K                      : ").append(k).append(LS);
-    sb.append("   Dynamic min K          : ").append(sketch.getMinK()).append(LS);
-    sb.append("   M                      : ").append(m).append(LS);
-    sb.append("   N                      : ").append(n).append(LS);
-    sb.append("   Epsilon                : ").append(epsPct).append(LS);
-    sb.append("   Epsilon PMF            : ").append(epsPMFPct).append(LS);
-    sb.append("   Empty                  : ").append(sketch.isEmpty()).append(LS);
-    sb.append("   Estimation Mode        : ").append(sketch.isEstimationMode()).append(LS);
-    sb.append("   Levels                 : ").append(numLevels).append(LS);
-    sb.append("   Level 0 Sorted         : ").append(sketch.isLevelZeroSorted()).append(LS);
-    sb.append("   Capacity Items         : ").append(fullLevelsArr[numLevels]).append(LS);
-    sb.append("   Retained Items         : ").append(sketch.getNumRetained()).append(LS);
-    sb.append("   Empty/Garbage Items    : ").append(sketch.levelsArr[0]).append(LS);
-    sb.append("   ReadOnly               : ").append(readOnlyStr).append(LS);
-    if (sketchType != ITEMS_SKETCH) {
-      sb.append("   Updatable Storage Bytes: ").append(sketch.currentSerializedSizeBytes(true)).append(LS);
+      final String directStr = hasMemory ? "Direct" : "";
+      final String compactStr = compact ? "Compact" : "";
+      final String readOnlyStr = sketch.isReadOnly() ? "true" + ("(" + (compact ? "Format" : "Memory") + ")") : "false";
+      final String skTypeStr = sketchType.getName();
+      final String className = "Kll" + directStr + compactStr + skTypeStr;
+
+      sb.append(LS + "### ").append(className).append(" Summary:").append(LS);
+      sb.append("   K                      : ").append(k).append(LS);
+      sb.append("   Dynamic min K          : ").append(sketch.getMinK()).append(LS);
+      sb.append("   M                      : ").append(m).append(LS);
+      sb.append("   N                      : ").append(n).append(LS);
+      sb.append("   Epsilon                : ").append(epsPct).append(LS);
+      sb.append("   Epsilon PMF            : ").append(epsPMFPct).append(LS);
+      sb.append("   Empty                  : ").append(sketch.isEmpty()).append(LS);
+      sb.append("   Estimation Mode        : ").append(sketch.isEstimationMode()).append(LS);
+      sb.append("   Levels                 : ").append(numLevels).append(LS);
+      sb.append("   Level 0 Sorted         : ").append(sketch.isLevelZeroSorted()).append(LS);
+      sb.append("   Capacity Items         : ").append(fullLevelsArr[numLevels]).append(LS);
+      sb.append("   Retained Items         : ").append(sketch.getNumRetained()).append(LS);
+      sb.append("   Free Space             : ").append(sketch.levelsArr[0]).append(LS);
+      sb.append("   ReadOnly               : ").append(readOnlyStr).append(LS);
+      if (sketchType != ITEMS_SKETCH) {
+        sb.append("   Updatable Storage Bytes: ").append(sketch.currentSerializedSizeBytes(true)).append(LS);
+      }
+      sb.append("   Compact Storage Bytes  : ").append(sketch.currentSerializedSizeBytes(false)).append(LS);
+
+      final String emptyStr = (sketchType == ITEMS_SKETCH) ? "Null" : "NaN";
+
+      sb.append("   Min Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMinItemAsString())
+          .append(LS);
+      sb.append("   Max Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMaxItemAsString())
+          .append(LS);
+      sb.append("### End sketch summary").append(LS);
     }
-    sb.append("   Compact Storage Bytes  : ").append(sketch.currentSerializedSizeBytes(false)).append(LS);
-
-    final String emptyStr = (sketchType == ITEMS_SKETCH) ? "Null" : "NaN";
-
-    sb.append("   Min Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMinItemAsString())
-        .append(LS);
-    sb.append("   Max Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMaxItemAsString())
-        .append(LS);
-    sb.append("### End sketch summary").append(LS);
-
-    if (! withSummary) { sb.setLength(0); }
-    if (withData) { sb.append(outputData(sketch)); }
+    if (withData) {
+      sb.append(outputLevels(k, m, numLevels, fullLevelsArr));
+      sb.append(outputData(sketch));
+    }
     return sb.toString();
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
@@ -337,7 +337,7 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
 
   /**
    * @return a full array of items as if the sketch was in COMPACT_FULL or UPDATABLE format.
-   * This will include zeros and possibly some garbage items.
+   * This will include zeros and possibly some free space.
    */
   abstract T[] getTotalItemsArray();
 

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
@@ -103,7 +103,7 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T>, Partit
       if (!sketch.hasMemory()) { sketch.setLevelZeroSorted(true); }
     }
 
-    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove garbage
+    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove free space
     quantiles = (T[]) Array.newInstance(sketch.serDe.getClassOfT(), numQuantiles);
     cumWeights = new long[numQuantiles];
     populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);

--- a/src/main/java/org/apache/datasketches/kll/KllPreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/kll/KllPreambleUtil.java
@@ -67,13 +67,13 @@ import org.apache.datasketches.memory.WritableMemory;
  * in the table below.
  * The 5 int preamble is followed by the <i>levelsArr int[numLevels]</i> as bytes,
  * followed by the min and max values as bytes,
- * followed by a packed items data array as bytes. There are no empty or garbage slots in this structure.
+ * followed by a packed items data array as bytes. There are no free slots in this structure.
  * It is not updatable.
  * It is identified by the <i>enum SketchStructure.COMPACT_FULL</i>.</li>
  *
  * <li>A serialized, <i>n &gt; 1</i> non-compact, updatable structure requires 20 bytes of preamble (5 ints).
  * This is followed by the LevelsArr int[NumLevels + 1], followed by the min and max values, and then
- * followed by an items data array that may include empty or garbage slots. It is updatable.
+ * followed by an items data array that may include free slots. It is updatable.
  * The details of these fields can be found in the code..
  * It is identified by the <i>enum SketchStructure.UPDATABLE</i>. This structure may not be implemented by
  * some sketches.</li>
@@ -300,7 +300,7 @@ final class KllPreambleUtil<T> {
           sb.append("<<<Updatable Structure is not suppported by ItemsSketch>>>").append(LS);
         }
 
-        sb.append("ALL DATA (including empty & garbage data)").append(LS);
+        sb.append("ALL DATA (including free space)").append(LS);
         final int itemsSpace = (sketchBytes - offsetBytes) / typeBytes;
         if (sketchType == DOUBLES_SKETCH) {
           for (int i = 0; i < itemsSpace; i++) {

--- a/src/main/java/org/apache/datasketches/kll/KllPreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/kll/KllPreambleUtil.java
@@ -67,13 +67,13 @@ import org.apache.datasketches.memory.WritableMemory;
  * in the table below.
  * The 5 int preamble is followed by the <i>levelsArr int[numLevels]</i> as bytes,
  * followed by the min and max values as bytes,
- * followed by a packed items data array as bytes. There are no free slots in this structure.
+ * followed by a packed items data array as bytes. There is no free space in this structure.
  * It is not updatable.
  * It is identified by the <i>enum SketchStructure.COMPACT_FULL</i>.</li>
  *
  * <li>A serialized, <i>n &gt; 1</i> non-compact, updatable structure requires 20 bytes of preamble (5 ints).
  * This is followed by the LevelsArr int[NumLevels + 1], followed by the min and max values, and then
- * followed by an items data array that may include free slots. It is updatable.
+ * followed by an items data array that may include free space. It is updatable.
  * The details of these fields can be found in the code..
  * It is identified by the <i>enum SketchStructure.UPDATABLE</i>. This structure may not be implemented by
  * some sketches.</li>

--- a/src/main/java/org/apache/datasketches/kll/KllSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllSketch.java
@@ -53,7 +53,7 @@ import org.apache.datasketches.quantilescommon.QuantilesAPI;
  * The data for level i lies in positions levelsArr[i] through levelsArr[i + 1] - 1 inclusive.
  * Hence, the levelsArr must contain (numLevels + 1) elements.
  * The valid portion of the itemsArr is completely packed and sorted, except for level 0,
- * which is filled from the top down. Any items below the index levelsArr[0] is garbage and will be
+ * which is filled from the top down. Any items below the index levelsArr[0] is free space and will be
  * overwritten by subsequent updates.
  *
  * Invariants:
@@ -287,11 +287,11 @@ public abstract class KllSketch implements QuantilesAPI {
   /**
    * Returns a summary of the sketch as a string.
    * @param withSummary if true includes sketch summary information
-   * @param withData if true include sketch data
+   * @param withDetail if true include detail of levels array and items array
    * @return string representation of sketch summary
    */
-  public String toString(final boolean withSummary, final boolean withData) {
-    return KllHelper.toStringImpl(this, withSummary, withData, getSerDe());
+  public String toString(final boolean withSummary, final boolean withDetail) {
+    return KllHelper.toStringImpl(this, withSummary, withDetail, getSerDe());
   }
 
   //restricted
@@ -390,14 +390,14 @@ public abstract class KllSketch implements QuantilesAPI {
 
   /**
    * Gets the serialized byte array of the valid retained items as a byte array.
-   * It does not include the preamble, the levels array, minimum or maximum items, or garbage data.
+   * It does not include the preamble, the levels array, minimum or maximum items, or free space.
    * @return the serialized bytes of the retained data.
    */
   abstract byte[] getRetainedItemsByteArr();
 
   /**
    * Gets the size in bytes of the valid retained items.
-   * It does not include the preamble, the levels array, minimum or maximum items, or garbage data.
+   * It does not include the preamble, the levels array, minimum or maximum items, or free space.
    * @return the size of the retained data in bytes.
    */
   abstract int getRetainedItemsSizeBytes();
@@ -423,7 +423,7 @@ public abstract class KllSketch implements QuantilesAPI {
   /**
    * Gets the serialized byte array of the entire internal items hypothetical structure.
    * It does not include the preamble, the levels array, or minimum or maximum items.
-   * It may include empty or garbage items.
+   * It may include empty or free space.
    * @return the serialized bytes of the retained data.
    */
   abstract byte[] getTotalItemsByteArr();
@@ -431,7 +431,7 @@ public abstract class KllSketch implements QuantilesAPI {
   /**
    * Gets the size in bytes of the entire internal items hypothetical structure.
    * It does not include the preamble, the levels array, or minimum or maximum items.
-   * It may include empty or garbage items.
+   * It may include empty or free space.
    * @return the size of the retained data in bytes.
    */
   abstract int getTotalItemsNumBytes();

--- a/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
@@ -249,7 +249,7 @@ public class KllMiscDoublesTest {
     sk.update(item, weight);
     println(sk.toString(true, true));
     assertEquals(sk.getNumRetained(), 7);
-    assertEquals(sk.getN(), 127);
+    assertEquals(sk.getN(), weight);
     sk.update(item, weight);
     println(sk.toString(true, true));
     assertEquals(sk.getNumRetained(), 14);

--- a/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
@@ -506,7 +506,7 @@ public class KllMiscFloatsTest {
     wmem = WritableMemory.writableWrap(upBytes2);
     s = KllPreambleUtil.toString(wmem, FLOATS_SKETCH, true);
     println("step 2: memory to heap sketch, to byte[]/memory & analyze memory. Should match above");
-    println(s); //note: heapify does not copy garbage, while toUpdatableByteArray does
+    println(s); //note: heapify does not copy free space, while toUpdatableByteArray does
     assertEquals(sk.getN(), sk2.getN());
     assertEquals(sk.getMinItem(), sk2.getMinItem());
     assertEquals(sk.getMaxItem(), sk2.getMaxItem());


### PR DESCRIPTION
These changes are relatively minor, but I want to get these in before characterization starts for Doubles.

Summary of changes in this PR

- **KllDoublesHelper.java**
    - Moved the "KllHeapDoublesSketch::weightedUpdateDoubles(..)" to "KllDoublesHelper.updateDouble(..)" next to where the original "updateDouble(..)" was.  It should have been there in the first place.
    - Did some refactoring/optimization of the code in both of the static package-private update methods and the public update methods in "KllDoublesSketch" that make a lot more sense. It avoids unnecessary checking of invariants when the static methods are called internally.

- **KllDoublesSketch.java**
    - Update methods -- see previous comment
    - Changed the variable name in the toString(..) to "withDetail" rather than "withData", since both booleans show data.
    - Added a "updateMinMax(item) method that reduces code duplication as it is used in multiple places.
    
- **KllHelper.java**
    - Refactored the dataOutput(..) and toStringImpl(..) methods to improve visualization of how the new weighted (as well as the original) updates can be understood during compaction.

### The following are all either documentation or variable name changes for consistency across all of KLL.

- **KllSketch.java**
    - Improved terminology of "empty/garbage space" to "free space"
    - The concomitant change to the "toString(..)" boolean name (see above)

- **KllDirectDoublesSketch.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllDirectFloatsSketch.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllDoublesSketchSortedView.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllFloatsSketchSortedView.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllHeapDoublesSketch.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllHeapFloatsSketch.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllItemsSketch.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllItemsSketchSortedView.java**
    - Improved terminology of "empty/garbage space" to "free space"

- **KllPreambleUtil.java**
    - Improved terminology of "empty/garbage space" to "free space"
