### PR TITLE
Made some minor adjustments to the KLL toString(boolean, boolean) methods.

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -307,14 +307,14 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   }
 
   @Override
-  public String toString(final boolean withSummary, final boolean withDetail) {
+  public String toString(final boolean withLevels, final boolean withLevelsAndItems) {
     KllSketch sketch = this;
-    if (withDetail && sketchStructure != UPDATABLE) {
+    if (withLevelsAndItems && sketchStructure != UPDATABLE) {
       final Memory mem = getWritableMemory();
       assert mem != null;
       sketch = KllDoublesSketch.heapify(getWritableMemory());
     }
-    return KllHelper.toStringImpl(sketch, withSummary, withDetail, getSerDe());
+    return KllHelper.toStringImpl(sketch, withLevels, withLevelsAndItems, getSerDe());
   }
 
   @Override
@@ -335,7 +335,7 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
     if (readOnly) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
     if (weight < 1) { throw new SketchesArgumentException("Weight is less than one."); }
     if (weight == 1) { KllDoublesHelper.updateDouble(this, item); }
-    KllDoublesHelper.updateDouble(this, item, weight);
+    else { KllDoublesHelper.updateDouble(this, item, weight); }
     kllDoublesSV = null;
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -307,14 +307,14 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
   }
 
   @Override
-  public String toString(final boolean withSummary, final boolean withData) {
+  public String toString(final boolean withLevels, final boolean withLevelsAndItems) {
     KllSketch sketch = this;
-    if (withData && sketchStructure != UPDATABLE) {
+    if (withLevelsAndItems && sketchStructure != UPDATABLE) {
       final Memory mem = getWritableMemory();
       assert mem != null;
       sketch = KllFloatsSketch.heapify(getWritableMemory());
     }
-    return KllHelper.toStringImpl(sketch, withSummary, withData, getSerDe());
+    return KllHelper.toStringImpl(sketch, withLevels, withLevelsAndItems, getSerDe());
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/kll/KllHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHelper.java
@@ -359,7 +359,7 @@ final class KllHelper {
     return newWmem;
   }
 
-  private static String outputData(final KllSketch sketch) {
+  private static String outputDataDetail(final KllSketch sketch) {
     final int[] levelsArr = sketch.getLevelsArray(SketchStructure.UPDATABLE);
     final int numLevels = sketch.getNumLevels();
     final int k = sketch.getK();
@@ -492,7 +492,7 @@ final class KllHelper {
     return bytesOut;
   }
 
-  static <T> String toStringImpl(final KllSketch sketch, final boolean withSummary, final boolean withData,
+  static <T> String toStringImpl(final KllSketch sketch, final boolean withLevels, final boolean withLevelsAndItems,
       final ArrayOfItemsSerDe<T> serDe) {
     final StringBuilder sb = new StringBuilder();
     final int k = sketch.getK();
@@ -500,51 +500,53 @@ final class KllHelper {
     final int numLevels = sketch.getNumLevels();
     final int[] fullLevelsArr = sketch.getLevelsArray(UPDATABLE);
 
-    if (withSummary) {
-      final SketchType sketchType = sketch.sketchType;
-      final boolean hasMemory = sketch.hasMemory();
-      final long n = sketch.getN();
-      final String epsPct = String.format("%.3f%%", sketch.getNormalizedRankError(false) * 100);
-      final String epsPMFPct = String.format("%.3f%%", sketch.getNormalizedRankError(true) * 100);
-      final boolean compact = sketch.isCompactMemoryFormat();
+    final SketchType sketchType = sketch.sketchType;
+    final boolean hasMemory = sketch.hasMemory();
+    final long n = sketch.getN();
+    final String epsPct = String.format("%.3f%%", sketch.getNormalizedRankError(false) * 100);
+    final String epsPMFPct = String.format("%.3f%%", sketch.getNormalizedRankError(true) * 100);
+    final boolean compact = sketch.isCompactMemoryFormat();
 
-      final String directStr = hasMemory ? "Direct" : "";
-      final String compactStr = compact ? "Compact" : "";
-      final String readOnlyStr = sketch.isReadOnly() ? "true" + ("(" + (compact ? "Format" : "Memory") + ")") : "false";
-      final String skTypeStr = sketchType.getName();
-      final String className = "Kll" + directStr + compactStr + skTypeStr;
+    final String directStr = hasMemory ? "Direct" : "";
+    final String compactStr = compact ? "Compact" : "";
+    final String readOnlyStr = sketch.isReadOnly() ? "true" + ("(" + (compact ? "Format" : "Memory") + ")") : "false";
+    final String skTypeStr = sketchType.getName();
+    final String className = "Kll" + directStr + compactStr + skTypeStr;
 
-      sb.append(LS + "### ").append(className).append(" Summary:").append(LS);
-      sb.append("   K                      : ").append(k).append(LS);
-      sb.append("   Dynamic min K          : ").append(sketch.getMinK()).append(LS);
-      sb.append("   M                      : ").append(m).append(LS);
-      sb.append("   N                      : ").append(n).append(LS);
-      sb.append("   Epsilon                : ").append(epsPct).append(LS);
-      sb.append("   Epsilon PMF            : ").append(epsPMFPct).append(LS);
-      sb.append("   Empty                  : ").append(sketch.isEmpty()).append(LS);
-      sb.append("   Estimation Mode        : ").append(sketch.isEstimationMode()).append(LS);
-      sb.append("   Levels                 : ").append(numLevels).append(LS);
-      sb.append("   Level 0 Sorted         : ").append(sketch.isLevelZeroSorted()).append(LS);
-      sb.append("   Capacity Items         : ").append(fullLevelsArr[numLevels]).append(LS);
-      sb.append("   Retained Items         : ").append(sketch.getNumRetained()).append(LS);
-      sb.append("   Free Space             : ").append(sketch.levelsArr[0]).append(LS);
-      sb.append("   ReadOnly               : ").append(readOnlyStr).append(LS);
-      if (sketchType != ITEMS_SKETCH) {
-        sb.append("   Updatable Storage Bytes: ").append(sketch.currentSerializedSizeBytes(true)).append(LS);
-      }
-      sb.append("   Compact Storage Bytes  : ").append(sketch.currentSerializedSizeBytes(false)).append(LS);
-
-      final String emptyStr = (sketchType == ITEMS_SKETCH) ? "Null" : "NaN";
-
-      sb.append("   Min Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMinItemAsString())
-          .append(LS);
-      sb.append("   Max Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMaxItemAsString())
-          .append(LS);
-      sb.append("### End sketch summary").append(LS);
+    sb.append(LS + "### ").append(className).append(" Summary:").append(LS);
+    sb.append("   K                      : ").append(k).append(LS);
+    sb.append("   Dynamic min K          : ").append(sketch.getMinK()).append(LS);
+    sb.append("   M                      : ").append(m).append(LS);
+    sb.append("   N                      : ").append(n).append(LS);
+    sb.append("   Epsilon                : ").append(epsPct).append(LS);
+    sb.append("   Epsilon PMF            : ").append(epsPMFPct).append(LS);
+    sb.append("   Empty                  : ").append(sketch.isEmpty()).append(LS);
+    sb.append("   Estimation Mode        : ").append(sketch.isEstimationMode()).append(LS);
+    sb.append("   Levels                 : ").append(numLevels).append(LS);
+    sb.append("   Level 0 Sorted         : ").append(sketch.isLevelZeroSorted()).append(LS);
+    sb.append("   Capacity Items         : ").append(fullLevelsArr[numLevels]).append(LS);
+    sb.append("   Retained Items         : ").append(sketch.getNumRetained()).append(LS);
+    sb.append("   Free Space             : ").append(sketch.levelsArr[0]).append(LS);
+    sb.append("   ReadOnly               : ").append(readOnlyStr).append(LS);
+    if (sketchType != ITEMS_SKETCH) {
+      sb.append("   Updatable Storage Bytes: ").append(sketch.currentSerializedSizeBytes(true)).append(LS);
     }
-    if (withData) {
+    sb.append("   Compact Storage Bytes  : ").append(sketch.currentSerializedSizeBytes(false)).append(LS);
+
+    final String emptyStr = (sketchType == ITEMS_SKETCH) ? "Null" : "NaN";
+
+    sb.append("   Min Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMinItemAsString())
+        .append(LS);
+    sb.append("   Max Item               : ").append(sketch.isEmpty() ? emptyStr : sketch.getMaxItemAsString())
+        .append(LS);
+    sb.append("### End sketch summary").append(LS);
+
+    if (withLevels) {
       sb.append(outputLevels(k, m, numLevels, fullLevelsArr));
-      sb.append(outputData(sketch));
+    }
+
+    if (withLevelsAndItems) {
+      sb.append(outputDataDetail(sketch));
     }
     return sb.toString();
   }

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
@@ -276,14 +276,14 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   }
 
   @Override
-  public String toString(final boolean withSummary, final boolean withData) {
+  public String toString(final boolean withLevels, final boolean withLevelsAndItems) {
     KllSketch sketch = this;
-    if (withData && sketchStructure != UPDATABLE) {
+    if (withLevelsAndItems && sketchStructure != UPDATABLE) {
       final Memory mem = getWritableMemory();
       assert mem != null;
       sketch = KllItemsSketch.heapify((Memory)getWritableMemory(), comparator, serDe);
     }
-    return KllHelper.toStringImpl(sketch, withSummary, withData, getSerDe());
+    return KllHelper.toStringImpl(sketch, withLevels, withLevelsAndItems, getSerDe());
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/kll/KllSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllSketch.java
@@ -281,18 +281,16 @@ public abstract class KllSketch implements QuantilesAPI {
 
   @Override
   public final String toString() {
-    return toString(true, false);
+    return toString(false, false);
   }
 
   /**
    * Returns a summary of the sketch as a string.
-   * @param withSummary if true includes sketch summary information
-   * @param withDetail if true include detail of levels array and items array
+   * @param withLevels if true includes sketch levels array summary information
+   * @param withLevelsAndItems if true include detail of levels array and items array together
    * @return string representation of sketch summary
    */
-  public String toString(final boolean withSummary, final boolean withDetail) {
-    return KllHelper.toStringImpl(this, withSummary, withDetail, getSerDe());
-  }
+  public abstract String toString(final boolean withLevels, final boolean withLevelsAndItems);
 
   //restricted
 


### PR DESCRIPTION
These changes make it easier to control what exactly is printed.

The toString() method in KllSketch should have been abstract. Changed the parameter names to be consistent with what is actually implemented.

The Kll Items, Floats and Doubles Classes override the KllSketch methods.  This is not new. I just changed the parameter names to match the actual impl method in KllHelper.

In KllHelper I made printing the summary the default and it always prints. In addition, the user can choose to print a small summary of the Levels information, and /or the detail of the entire ItemsArray.

All of these options were there before. Just the parameters didn't describe them very well.