### PR TITLE
These fixes address security related issues.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -59,6 +59,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/src/main/java/org/apache/datasketches/fdt/FdtSketch.java
+++ b/src/main/java/org/apache/datasketches/fdt/FdtSketch.java
@@ -46,7 +46,7 @@ import org.apache.datasketches.tuple.strings.ArrayOfStringsSketch;
  *
  * @author Lee Rhodes
  */
-public class FdtSketch extends ArrayOfStringsSketch {
+public final class FdtSketch extends ArrayOfStringsSketch {
 
   /**
    * Create new instance of Frequent Distinct Tuples sketch with the given

--- a/src/main/java/org/apache/datasketches/hll/CouponHashSet.java
+++ b/src/main/java/org/apache/datasketches/hll/CouponHashSet.java
@@ -42,7 +42,7 @@ import org.apache.datasketches.memory.Memory;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
-class CouponHashSet extends CouponList {
+final class CouponHashSet extends CouponList {
 
   /**
    * Constructs this sketch with the intent of loading it with data

--- a/src/main/java/org/apache/datasketches/hll/CouponList.java
+++ b/src/main/java/org/apache/datasketches/hll/CouponList.java
@@ -41,6 +41,11 @@ class CouponList extends AbstractCoupons {
   int couponCount;
   int[] couponIntArr;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * New instance constructor for LIST or SET.
    * @param lgConfigK the configured Lg K

--- a/src/main/java/org/apache/datasketches/hll/CouponList.java
+++ b/src/main/java/org/apache/datasketches/hll/CouponList.java
@@ -41,9 +41,9 @@ class CouponList extends AbstractCoupons {
   int couponCount;
   int[] couponIntArr;
 
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  private static int checkLgConfigK(final CurMode curMode, final int lgConfigK) {
+    if (curMode == CurMode.SET) { assert lgConfigK > 7; }
+    return lgConfigK;
   }
 
   /**
@@ -53,12 +53,11 @@ class CouponList extends AbstractCoupons {
    * @param curMode LIST or SET
    */
   CouponList(final int lgConfigK, final TgtHllType tgtHllType, final CurMode curMode) {
-    super(lgConfigK, tgtHllType, curMode);
+    super(checkLgConfigK(curMode, lgConfigK), tgtHllType, curMode);
     if (curMode == CurMode.LIST) {
       lgCouponArrInts = LG_INIT_LIST_SIZE;
     } else { //SET
       lgCouponArrInts = LG_INIT_SET_SIZE;
-      assert lgConfigK > 7;
     }
     couponIntArr = new int[1 << lgCouponArrInts];
     couponCount = 0;

--- a/src/main/java/org/apache/datasketches/hll/DirectAuxHashMap.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectAuxHashMap.java
@@ -36,7 +36,7 @@ import org.apache.datasketches.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
-class DirectAuxHashMap implements AuxHashMap {
+final class DirectAuxHashMap implements AuxHashMap {
   private final DirectHllArray host; //hosts the WritableMemory and read-only Memory
   private final boolean readOnly;
 

--- a/src/main/java/org/apache/datasketches/hll/DirectCouponHashSet.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectCouponHashSet.java
@@ -42,7 +42,7 @@ import org.apache.datasketches.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
-class DirectCouponHashSet extends DirectCouponList {
+final class DirectCouponHashSet extends DirectCouponList {
 
   //Constructs this sketch with data.
   DirectCouponHashSet(final int lgConfigK, final TgtHllType tgtHllType,

--- a/src/main/java/org/apache/datasketches/hll/DirectCouponList.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectCouponList.java
@@ -61,6 +61,11 @@ class DirectCouponList extends AbstractCoupons {
   Memory mem;
   final boolean compact;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   //called from newInstance, writableWrap and DirectCouponHashSet
   DirectCouponList(final int lgConfigK, final TgtHllType tgtHllType, final CurMode curMode,
       final WritableMemory wmem) {

--- a/src/main/java/org/apache/datasketches/hll/DirectCouponList.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectCouponList.java
@@ -61,24 +61,21 @@ class DirectCouponList extends AbstractCoupons {
   Memory mem;
   final boolean compact;
 
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  private static int checkMemCompactFlag(final WritableMemory wmem, final int lgConfigK) {
+    assert !extractCompactFlag(wmem);
+    return lgConfigK;
   }
 
-  //called from newInstance, writableWrap and DirectCouponHashSet
-  DirectCouponList(final int lgConfigK, final TgtHllType tgtHllType, final CurMode curMode,
-      final WritableMemory wmem) {
-    super(lgConfigK, tgtHllType, curMode);
+  //called from newInstance, writableWrap and DirectCouponHashSet, must be compact
+  DirectCouponList(final int lgConfigK, final TgtHllType tgtHllType, final CurMode curMode, final WritableMemory wmem) {
+    super(checkMemCompactFlag(wmem, lgConfigK), tgtHllType, curMode);
     this.wmem = wmem;
     mem = wmem;
     compact = extractCompactFlag(wmem);
-    assert !compact;
   }
 
-  //called from HllSketch.wrap and from DirectCouponHashSet constructor, may be compact
-  DirectCouponList(final int lgConfigK, final TgtHllType tgtHllType, final CurMode curMode,
-      final Memory mem) {
+  //called from HllSketch.wrap and from DirectCouponHashSet constructor, may or may not be compact
+  DirectCouponList(final int lgConfigK, final TgtHllType tgtHllType, final CurMode curMode, final Memory mem) {
     super(lgConfigK, tgtHllType, curMode);
     wmem = null;
     this.mem = mem;

--- a/src/main/java/org/apache/datasketches/hll/DirectHllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectHllArray.java
@@ -59,20 +59,19 @@ abstract class DirectHllArray extends AbstractHllArray {
   long memAdd;
   final boolean compact;
 
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  private static int checkMemCompactFlag(final WritableMemory wmem, final int lgConfigK) {
+    assert !extractCompactFlag(wmem);
+    return lgConfigK;
   }
 
   //Memory must be already initialized and may have data
   DirectHllArray(final int lgConfigK, final TgtHllType tgtHllType, final WritableMemory wmem) {
-    super(lgConfigK, tgtHllType, CurMode.HLL);
+    super(checkMemCompactFlag(wmem, lgConfigK), tgtHllType, CurMode.HLL);
     this.wmem = wmem;
     mem = wmem;
     memObj = wmem.getArray();
     memAdd = wmem.getCumulativeOffset(0L);
     compact = extractCompactFlag(mem);
-    assert !compact;
     insertEmptyFlag(wmem, false);
   }
 

--- a/src/main/java/org/apache/datasketches/hll/DirectHllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/DirectHllArray.java
@@ -59,6 +59,11 @@ abstract class DirectHllArray extends AbstractHllArray {
   long memAdd;
   final boolean compact;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   //Memory must be already initialized and may have data
   DirectHllArray(final int lgConfigK, final TgtHllType tgtHllType, final WritableMemory wmem) {
     super(lgConfigK, tgtHllType, CurMode.HLL);

--- a/src/main/java/org/apache/datasketches/hll/HeapAuxHashMap.java
+++ b/src/main/java/org/apache/datasketches/hll/HeapAuxHashMap.java
@@ -33,7 +33,7 @@ import org.apache.datasketches.memory.Memory;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
-class HeapAuxHashMap implements AuxHashMap {
+final class HeapAuxHashMap implements AuxHashMap {
   private final int lgConfigK; //required for #slot bits
   private int lgAuxArrInts;
   private int auxCount;

--- a/src/main/java/org/apache/datasketches/hllmap/UniqueCountMap.java
+++ b/src/main/java/org/apache/datasketches/hllmap/UniqueCountMap.java
@@ -80,7 +80,7 @@ import org.apache.datasketches.common.SketchesArgumentException;
  * @author Alexander Saydakov
  * @author Kevin Lang
  */
-public class UniqueCountMap {
+public final class UniqueCountMap {
   private static final String LS = System.getProperty("line.separator");
   private static final int NUM_LEVELS = 10; // total of single coupon + traverse + coupon maps + hll
   private static final int NUM_TRAVERSE_MAPS = 3;

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
@@ -25,6 +25,7 @@ import static org.apache.datasketches.kll.KllSketch.SketchStructure.UPDATABLE;
 import static org.apache.datasketches.kll.KllSketch.SketchType.ITEMS_SKETCH;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -37,7 +38,6 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.quantilescommon.GenericPartitionBoundaries;
 import org.apache.datasketches.quantilescommon.PartitioningFeature;
 import org.apache.datasketches.quantilescommon.QuantileSearchCriteria;
-import org.apache.datasketches.quantilescommon.QuantilesAPI;
 import org.apache.datasketches.quantilescommon.QuantilesGenericAPI;
 import org.apache.datasketches.quantilescommon.QuantilesGenericSketchIterator;
 
@@ -155,7 +155,7 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   @Override
   public GenericPartitionBoundaries<T> getPartitionBoundaries(final int numEquallySized,
       final QuantileSearchCriteria searchCrit) {
-    if (isEmpty()) { throw new IllegalArgumentException(QuantilesAPI.EMPTY_MSG); }
+    if (isEmpty()) { throw new IllegalArgumentException(EMPTY_MSG); }
     refreshSortedView();
     return kllItemsSV.getPartitionBoundaries(numEquallySized, searchCrit);
   }
@@ -323,13 +323,6 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   @Override
   abstract int getMinMaxSizeBytes();
 
-  private final KllItemsSketchSortedView<T> refreshSortedView() {
-    final KllItemsSketchSortedView<T> sv = (kllItemsSV == null)
-        ? kllItemsSV = new KllItemsSketchSortedView<>(this)
-        : kllItemsSV;
-    return sv;
-  }
-
   abstract T[] getRetainedItemsArray();
 
   @Override
@@ -399,5 +392,135 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
       setMaxItem(Util.maxT(getMaxItem(), item, comparator));
     }
   }
+
+  private final KllItemsSketchSortedView<T> refreshSortedView() {
+    if (kllItemsSV == null) {
+      final CreateSortedView csv = new CreateSortedView();
+      kllItemsSV = csv.getSV();
+    }
+    return kllItemsSV;
+  }
+
+  private final class CreateSortedView {
+    T[] quantiles;
+    long[] cumWeights;
+
+    KllItemsSketchSortedView<T> getSV() {
+      if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
+      if (getN() == 0) { throw new SketchesArgumentException(EMPTY_MSG); }
+      final T[] srcQuantiles = getTotalItemsArray();
+      final int[] srcLevels = levelsArr;
+      final int srcNumLevels = getNumLevels();
+
+      if (!isLevelZeroSorted()) {
+        Arrays.sort(srcQuantiles, srcLevels[0], srcLevels[1], comparator);
+        if (!hasMemory()) { setLevelZeroSorted(true); }
+      }
+      final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove free space
+      quantiles = (T[]) Array.newInstance(serDe.getClassOfT(), numQuantiles);
+      cumWeights = new long[numQuantiles];
+      populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);
+      return new KllItemsSketchSortedView<>(quantiles, cumWeights, getN(), comparator, getMaxItem(), getMinItem());
+    }
+
+    private void populateFromSketch(final Object[] srcQuantiles, final int[] srcLevels,
+        final int srcNumLevels, final int numItems) {
+        final int[] myLevels = new int[srcNumLevels + 1];
+        final int offset = srcLevels[0];
+        System.arraycopy(srcQuantiles, offset, quantiles, 0, numItems);
+        int srcLevel = 0;
+        int dstLevel = 0;
+        long weight = 1;
+        while (srcLevel < srcNumLevels) {
+          final int fromIndex = srcLevels[srcLevel] - offset;
+          final int toIndex = srcLevels[srcLevel + 1] - offset; // exclusive
+          if (fromIndex < toIndex) { // if equal, skip empty level
+            Arrays.fill(cumWeights, fromIndex, toIndex, weight);
+            myLevels[dstLevel] = fromIndex;
+            myLevels[dstLevel + 1] = toIndex;
+            dstLevel++;
+          }
+          srcLevel++;
+          weight *= 2;
+        }
+        final int numLevels = dstLevel;
+        blockyTandemMergeSort(quantiles, cumWeights, myLevels, numLevels, comparator); //create unit weights
+        KllHelper.convertToCumulative(cumWeights);
+      }
+  }
+
+    private static <T> void blockyTandemMergeSort(final Object[] quantiles, final long[] weights,
+        final int[] levels, final int numLevels, final Comparator<? super T> comp) {
+      if (numLevels == 1) { return; }
+
+      // duplicate the input in preparation for the "ping-pong" copy reduction strategy.
+      final Object[] quantilesTmp = Arrays.copyOf(quantiles, quantiles.length);
+      final long[] weightsTmp = Arrays.copyOf(weights, quantiles.length); // don't need the extra one here
+
+      blockyTandemMergeSortRecursion(quantilesTmp, weightsTmp, quantiles, weights, levels, 0, numLevels, comp);
+    }
+
+    private static <T> void blockyTandemMergeSortRecursion(
+        final Object[] quantilesSrc, final long[] weightsSrc,
+        final Object[] quantilesDst, final long[] weightsDst,
+        final int[] levels, final int startingLevel, final int numLevels, final Comparator<? super T> comp) {
+      if (numLevels == 1) { return; }
+      final int numLevels1 = numLevels / 2;
+      final int numLevels2 = numLevels - numLevels1;
+      assert numLevels1 >= 1;
+      assert numLevels2 >= numLevels1;
+      final int startingLevel1 = startingLevel;
+      final int startingLevel2 = startingLevel + numLevels1;
+      // swap roles of src and dst
+      blockyTandemMergeSortRecursion(
+          quantilesDst, weightsDst,
+          quantilesSrc, weightsSrc,
+          levels, startingLevel1, numLevels1, comp);
+      blockyTandemMergeSortRecursion(
+          quantilesDst, weightsDst,
+          quantilesSrc, weightsSrc,
+          levels, startingLevel2, numLevels2, comp);
+      tandemMerge(
+          quantilesSrc, weightsSrc,
+          quantilesDst, weightsDst,
+          levels,
+          startingLevel1, numLevels1,
+          startingLevel2, numLevels2, comp);
+    }
+
+    private static <T> void tandemMerge(
+        final Object[] quantilesSrc, final long[] weightsSrc,
+        final Object[] quantilesDst, final long[] weightsDst,
+        final int[] levelStarts,
+        final int startingLevel1, final int numLevels1,
+        final int startingLevel2, final int numLevels2, final Comparator<? super T> comp) {
+      final int fromIndex1 = levelStarts[startingLevel1];
+      final int toIndex1 = levelStarts[startingLevel1 + numLevels1]; // exclusive
+      final int fromIndex2 = levelStarts[startingLevel2];
+      final int toIndex2 = levelStarts[startingLevel2 + numLevels2]; // exclusive
+      int iSrc1 = fromIndex1;
+      int iSrc2 = fromIndex2;
+      int iDst = fromIndex1;
+
+      while (iSrc1 < toIndex1 && iSrc2 < toIndex2) {
+        if (Util.lt((T) quantilesSrc[iSrc1], (T) quantilesSrc[iSrc2], comp)) {
+          quantilesDst[iDst] = quantilesSrc[iSrc1];
+          weightsDst[iDst] = weightsSrc[iSrc1];
+          iSrc1++;
+        } else {
+          quantilesDst[iDst] = quantilesSrc[iSrc2];
+          weightsDst[iDst] = weightsSrc[iSrc2];
+          iSrc2++;
+        }
+        iDst++;
+      }
+      if (iSrc1 < toIndex1) {
+        System.arraycopy(quantilesSrc, iSrc1, quantilesDst, iDst, toIndex1 - iSrc1);
+        System.arraycopy(weightsSrc, iSrc1, weightsDst, iDst, toIndex1 - iSrc1);
+      } else if (iSrc2 < toIndex2) {
+        System.arraycopy(quantilesSrc, iSrc2, quantilesDst, iDst, toIndex2 - iSrc2);
+        System.arraycopy(weightsSrc, iSrc2, weightsDst, iDst, toIndex2 - iSrc2);
+      }
+    }
 
 }

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
@@ -56,6 +56,11 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T>, Partit
   private final T minItem;
   private final Class<T> clazz;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * Construct from elements for testing only.
    * @param quantiles sorted array of quantiles

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
@@ -55,7 +55,7 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T>, Partit
   private final Class<T> clazz;
 
   /**
-   * Construct from elements for testing only.
+   * Construct from elements, also used in testing.
    * @param quantiles sorted array of quantiles
    * @param cumWeights sorted, monotonically increasing cumulative weights.
    * @param totalN the total number of items presented to the sketch.

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketchSortedView.java
@@ -26,11 +26,9 @@ import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.getNaturalRank;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
 import java.util.Comparator;
 
 import org.apache.datasketches.common.SketchesArgumentException;
-import org.apache.datasketches.common.Util;
 import org.apache.datasketches.quantilescommon.GenericInequalitySearch.Inequality;
 import org.apache.datasketches.quantilescommon.GenericPartitionBoundaries;
 import org.apache.datasketches.quantilescommon.GenericSortedView;
@@ -56,11 +54,6 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T>, Partit
   private final T minItem;
   private final Class<T> clazz;
 
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
-  }
-
   /**
    * Construct from elements for testing only.
    * @param quantiles sorted array of quantiles
@@ -84,34 +77,6 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T>, Partit
     this.maxItem = maxItem;
     this.minItem = minItem;
     this.clazz = (Class<T>)quantiles[0].getClass();
-  }
-
-  /**
-   * Constructs this Sorted View given the sketch
-   * @param sketch the given KllItemsSketch.
-   */
-  @SuppressWarnings("unchecked")
-  KllItemsSketchSortedView(final KllItemsSketch<T> sketch) {
-    if (sketch.isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
-    this.totalN = sketch.getN();
-    final T[] srcQuantiles = sketch.getTotalItemsArray();
-    final int[] srcLevels = sketch.levelsArr;
-    final int srcNumLevels = sketch.getNumLevels();
-    this.comparator = sketch.comparator;
-    this.maxItem = sketch.getMaxItem();
-    this.minItem = sketch.getMinItem();
-    this.clazz = sketch.serDe.getClassOfT();
-
-    if (totalN == 0) { throw new SketchesArgumentException(EMPTY_MSG); }
-    if (!sketch.isLevelZeroSorted()) {
-      Arrays.sort(srcQuantiles, srcLevels[0], srcLevels[1], comparator);
-      if (!sketch.hasMemory()) { sketch.setLevelZeroSorted(true); }
-    }
-
-    final int numQuantiles = srcLevels[srcNumLevels] - srcLevels[0]; //remove free space
-    quantiles = (T[]) Array.newInstance(sketch.serDe.getClassOfT(), numQuantiles);
-    cumWeights = new long[numQuantiles];
-    populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);
   }
 
   //end of constructors
@@ -251,108 +216,6 @@ public class KllItemsSketchSortedView<T> implements GenericSortedView<T>, Partit
   @Override
   public GenericSortedViewIterator<T> iterator() {
     return new GenericSortedViewIterator<>(quantiles, cumWeights);
-  }
-
-  //restricted methods
-
-  private void populateFromSketch(final Object[] srcQuantiles, final int[] srcLevels,
-    final int srcNumLevels, final int numItems) {
-    final int[] myLevels = new int[srcNumLevels + 1];
-    final int offset = srcLevels[0];
-    System.arraycopy(srcQuantiles, offset, quantiles, 0, numItems);
-    int srcLevel = 0;
-    int dstLevel = 0;
-    long weight = 1;
-    while (srcLevel < srcNumLevels) {
-      final int fromIndex = srcLevels[srcLevel] - offset;
-      final int toIndex = srcLevels[srcLevel + 1] - offset; // exclusive
-      if (fromIndex < toIndex) { // if equal, skip empty level
-        Arrays.fill(cumWeights, fromIndex, toIndex, weight);
-        myLevels[dstLevel] = fromIndex;
-        myLevels[dstLevel + 1] = toIndex;
-        dstLevel++;
-      }
-      srcLevel++;
-      weight *= 2;
-    }
-    final int numLevels = dstLevel;
-    blockyTandemMergeSort(quantiles, cumWeights, myLevels, numLevels, comparator); //create unit weights
-    KllHelper.convertToCumulative(cumWeights);
-  }
-
-  private static <T> void blockyTandemMergeSort(final Object[] quantiles, final long[] weights,
-      final int[] levels, final int numLevels, final Comparator<? super T> comp) {
-    if (numLevels == 1) { return; }
-
-    // duplicate the input in preparation for the "ping-pong" copy reduction strategy.
-    final Object[] quantilesTmp = Arrays.copyOf(quantiles, quantiles.length);
-    final long[] weightsTmp = Arrays.copyOf(weights, quantiles.length); // don't need the extra one here
-
-    blockyTandemMergeSortRecursion(quantilesTmp, weightsTmp, quantiles, weights, levels, 0, numLevels, comp);
-  }
-
-  private static <T> void blockyTandemMergeSortRecursion(
-      final Object[] quantilesSrc, final long[] weightsSrc,
-      final Object[] quantilesDst, final long[] weightsDst,
-      final int[] levels, final int startingLevel, final int numLevels, final Comparator<? super T> comp) {
-    if (numLevels == 1) { return; }
-    final int numLevels1 = numLevels / 2;
-    final int numLevels2 = numLevels - numLevels1;
-    assert numLevels1 >= 1;
-    assert numLevels2 >= numLevels1;
-    final int startingLevel1 = startingLevel;
-    final int startingLevel2 = startingLevel + numLevels1;
-    // swap roles of src and dst
-    blockyTandemMergeSortRecursion(
-        quantilesDst, weightsDst,
-        quantilesSrc, weightsSrc,
-        levels, startingLevel1, numLevels1, comp);
-    blockyTandemMergeSortRecursion(
-        quantilesDst, weightsDst,
-        quantilesSrc, weightsSrc,
-        levels, startingLevel2, numLevels2, comp);
-    tandemMerge(
-        quantilesSrc, weightsSrc,
-        quantilesDst, weightsDst,
-        levels,
-        startingLevel1, numLevels1,
-        startingLevel2, numLevels2, comp);
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <T> void tandemMerge(
-      final Object[] quantilesSrc, final long[] weightsSrc,
-      final Object[] quantilesDst, final long[] weightsDst,
-      final int[] levelStarts,
-      final int startingLevel1, final int numLevels1,
-      final int startingLevel2, final int numLevels2, final Comparator<? super T> comp) {
-    final int fromIndex1 = levelStarts[startingLevel1];
-    final int toIndex1 = levelStarts[startingLevel1 + numLevels1]; // exclusive
-    final int fromIndex2 = levelStarts[startingLevel2];
-    final int toIndex2 = levelStarts[startingLevel2 + numLevels2]; // exclusive
-    int iSrc1 = fromIndex1;
-    int iSrc2 = fromIndex2;
-    int iDst = fromIndex1;
-
-    while (iSrc1 < toIndex1 && iSrc2 < toIndex2) {
-      if (Util.lt((T) quantilesSrc[iSrc1], (T) quantilesSrc[iSrc2], comp)) {
-        quantilesDst[iDst] = quantilesSrc[iSrc1];
-        weightsDst[iDst] = weightsSrc[iSrc1];
-        iSrc1++;
-      } else {
-        quantilesDst[iDst] = quantilesSrc[iSrc2];
-        weightsDst[iDst] = weightsSrc[iSrc2];
-        iSrc2++;
-      }
-      iDst++;
-    }
-    if (iSrc1 < toIndex1) {
-      System.arraycopy(quantilesSrc, iSrc1, quantilesDst, iDst, toIndex1 - iSrc1);
-      System.arraycopy(weightsSrc, iSrc1, weightsDst, iDst, toIndex1 - iSrc1);
-    } else if (iSrc2 < toIndex2) {
-      System.arraycopy(quantilesSrc, iSrc2, quantilesDst, iDst, toIndex2 - iSrc2);
-      System.arraycopy(weightsSrc, iSrc2, weightsDst, iDst, toIndex2 - iSrc2);
-    }
   }
 
 }

--- a/src/main/java/org/apache/datasketches/quantiles/DirectDoublesSketchAccessor.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DirectDoublesSketchAccessor.java
@@ -26,7 +26,7 @@ import org.apache.datasketches.memory.WritableMemory;
 /**
  * @author Jon Malkin
  */
-class DirectDoublesSketchAccessor extends DoublesSketchAccessor {
+final class DirectDoublesSketchAccessor extends DoublesSketchAccessor {
   DirectDoublesSketchAccessor(final DoublesSketch ds,
                               final boolean forceSize,
                               final int level) {

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesSketchAccessor.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesSketchAccessor.java
@@ -45,10 +45,12 @@ abstract class DoublesSketchAccessor extends DoublesBufferAccessor {
     final boolean forceSize,
     final int level) {
     this(checkLvl(level), ds, forceSize, level);
+    //SpotBugs CT_CONSTRUCTOR_THROW is false positive.
+    //this construction scheme is compliant with SEI CERT Oracle Coding Standard for Java / OBJ11-J
   }
 
   private DoublesSketchAccessor(
-      final boolean secure,
+      final boolean secure, //required part of Finalizer Attack prevention
       final DoublesSketch ds,
       final boolean forceSize,
       final int level) {

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesSketchAccessor.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesSketchAccessor.java
@@ -39,6 +39,11 @@ abstract class DoublesSketchAccessor extends DoublesBufferAccessor {
   int numItems_;
   int offset_;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   DoublesSketchAccessor(final DoublesSketch ds, final boolean forceSize, final int level) {
     ds_ = ds;
     forceSize_ = forceSize;

--- a/src/main/java/org/apache/datasketches/quantiles/HeapDoublesSketchAccessor.java
+++ b/src/main/java/org/apache/datasketches/quantiles/HeapDoublesSketchAccessor.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 /**
  * @author Jon Malkin
  */
-class HeapDoublesSketchAccessor extends DoublesSketchAccessor {
+final class HeapDoublesSketchAccessor extends DoublesSketchAccessor {
   HeapDoublesSketchAccessor(final DoublesSketch ds,
                             final boolean forceSize,
                             final int level) {

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketch.java
@@ -36,7 +36,6 @@ import static org.apache.datasketches.quantiles.PreambleUtil.extractK;
 import static org.apache.datasketches.quantiles.PreambleUtil.extractN;
 import static org.apache.datasketches.quantiles.PreambleUtil.extractPreLongs;
 import static org.apache.datasketches.quantiles.PreambleUtil.extractSerVer;
-//import static org.apache.datasketches.quantilescommon.QuantilesAPI.EMPTY_MSG;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
@@ -27,11 +27,11 @@ import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.getNaturalRank;
 
 import java.lang.reflect.Array;
-import java.util.Arrays;
+//import java.util.Arrays;
 import java.util.Comparator;
 
 import org.apache.datasketches.common.SketchesArgumentException;
-import org.apache.datasketches.common.SketchesStateException;
+//import org.apache.datasketches.common.SketchesStateException;
 import org.apache.datasketches.quantilescommon.GenericInequalitySearch.Inequality;
 import org.apache.datasketches.quantilescommon.GenericPartitionBoundaries;
 import org.apache.datasketches.quantilescommon.GenericSortedView;
@@ -58,13 +58,8 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T>, Partition
   private final Class<T> clazz;
   private final int k;
 
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
-  }
-
   /**
-   * Construct from elements for testing.
+   * Construct from elements, also used in testing.
    * @param quantiles sorted array of quantiles
    * @param cumWeights sorted, monotonically increasing cumulative weights.
    * @param totalN the total number of items presented to the sketch.
@@ -89,39 +84,39 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T>, Partition
     this.k = k;
   }
 
-  /**
-   * Constructs this Sorted View given the sketch
-   * @param sketch the given Classic Quantiles ItemsSketch
-   */
-  @SuppressWarnings("unchecked")
-  ItemsSketchSortedView(final ItemsSketch<T> sketch) {
-    if (sketch.isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
-    this.totalN = sketch.getN();
-    final int numQuantiles = sketch.getNumRetained();
-    this.quantiles = (T[]) Array.newInstance(sketch.clazz, numQuantiles);
-    this.minItem = sketch.minItem_;
-    this.maxItem = sketch.maxItem_;
-    this.cumWeights = new long[numQuantiles];
-    this.comparator = sketch.getComparator();
-    this.clazz = sketch.clazz;
-    this.k = sketch.getK();
-
-    final Object[] combinedBuffer = sketch.getCombinedBuffer();
-    final int baseBufferCount = sketch.getBaseBufferCount();
-
-    // Populate from ItemsSketch:
-    // copy over the "levels" and then the base buffer, all with appropriate weights
-    populateFromItemsSketch(k, totalN, sketch.getBitPattern(), (T[]) combinedBuffer, baseBufferCount,
-        numQuantiles, quantiles, cumWeights, sketch.getComparator());
-
-    // Sort the first "numSamples" slots of the two arrays in tandem,
-    // taking advantage of the already sorted blocks of length k
-    ItemsMergeImpl.blockyTandemMergeSort(quantiles, cumWeights, numQuantiles, k, sketch.getComparator());
-
-    if (convertToCumulative(cumWeights) != totalN) {
-      throw new SketchesStateException("Sorted View is misconfigured. TotalN does not match cumWeights.");
-    }
-  }
+//  /**
+//   * Constructs this Sorted View given the sketch
+//   * @param sketch the given Classic Quantiles ItemsSketch
+//   */
+//  @SuppressWarnings("unchecked")
+//  ItemsSketchSortedView(final ItemsSketch<T> sketch) {
+//    if (sketch.isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
+//    this.totalN = sketch.getN();
+//    final int numQuantiles = sketch.getNumRetained();
+//    this.quantiles = (T[]) Array.newInstance(sketch.clazz, numQuantiles);
+//    this.minItem = sketch.minItem_;
+//    this.maxItem = sketch.maxItem_;
+//    this.cumWeights = new long[numQuantiles];
+//    this.comparator = sketch.getComparator();
+//    this.clazz = sketch.clazz;
+//    this.k = sketch.getK();
+//
+//    final Object[] combinedBuffer = sketch.getCombinedBuffer();
+//    final int baseBufferCount = sketch.getBaseBufferCount();
+//
+//    // Populate from ItemsSketch:
+//    // copy over the "levels" and then the base buffer, all with appropriate weights
+//    populateFromItemsSketch(k, totalN, sketch.getBitPattern(), (T[]) combinedBuffer, baseBufferCount,
+//        numQuantiles, quantiles, cumWeights, sketch.getComparator());
+//
+//    // Sort the first "numSamples" slots of the two arrays in tandem,
+//    // taking advantage of the already sorted blocks of length k
+//    ItemsMergeImpl.blockyTandemMergeSort(quantiles, cumWeights, numQuantiles, k, sketch.getComparator());
+//
+//    if (convertToCumulative(cumWeights) != totalN) {
+//      throw new SketchesStateException("Sorted View is misconfigured. TotalN does not match cumWeights.");
+//    }
+//  }
 
   //end of constructors
 
@@ -318,68 +313,68 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T>, Partition
 
   //restricted methods
 
-  /**
-   * Populate the arrays and registers from an ItemsSketch
-   * @param <T> the data type
-   * @param k K parameter of sketch
-   * @param n The current size of the stream
-   * @param bitPattern the bit pattern for valid log levels
-   * @param combinedBuffer the combined buffer reference
-   * @param baseBufferCount the count of the base buffer
-   * @param numQuantiles number of retained quantiles in the sketch
-   * @param quantilesArr the consolidated array of all quantiles from the sketch
-   * @param weightsArr the weights for each item from the sketch
-   * @param comparator the given comparator for data type T
-   */
-  private final static <T> void populateFromItemsSketch(
-      final int k, final long n, final long bitPattern, final T[] combinedBuffer,
-      final int baseBufferCount, final int numQuantiles, final T[] quantilesArr, final long[] weightsArr,
-      final Comparator<? super T> comparator) {
-    long weight = 1;
-    int nxt = 0;
-    long bits = bitPattern;
-    assert bits == (n / (2L * k)); // internal consistency check
-    for (int lvl = 0; bits != 0L; lvl++, bits >>>= 1) {
-      weight *= 2;
-      if ((bits & 1L) > 0L) {
-        final int offset = (2 + lvl) * k;
-        for (int i = 0; i < k; i++) {
-          quantilesArr[nxt] = combinedBuffer[i + offset];
-          weightsArr[nxt] = weight;
-          nxt++;
-        }
-      }
-    }
-
-    weight = 1; //NOT a mistake! We just copied the highest level; now we need to copy the base buffer
-    final int startOfBaseBufferBlock = nxt;
-
-    // Copy BaseBuffer over, along with weight = 1
-    for (int i = 0; i < baseBufferCount; i++) {
-      quantilesArr[nxt] = combinedBuffer[i];
-      weightsArr[nxt] = weight;
-      nxt++;
-    }
-    assert nxt == numQuantiles;
-
-    // Must sort the items that came from the base buffer.
-    // Don't need to sort the corresponding weights because they are all the same.
-    Arrays.sort(quantilesArr, startOfBaseBufferBlock, numQuantiles, comparator);
-  }
-
-  /**
-   * Convert the individual weights into cumulative weights.
-   * An array of {1,1,1,1} becomes {1,2,3,4}
-   * @param array of actual weights from the sketch, none of the weights may be zero
-   * @return total weight
-   */
-  private static long convertToCumulative(final long[] array) {
-    long subtotal = 0;
-    for (int i = 0; i < array.length; i++) {
-      final long newSubtotal = subtotal + array[i];
-      subtotal = array[i] = newSubtotal;
-    }
-    return subtotal;
-  }
+//  /**
+//   * Populate the arrays and registers from an ItemsSketch
+//   * @param <T> the data type
+//   * @param k K parameter of sketch
+//   * @param n The current size of the stream
+//   * @param bitPattern the bit pattern for valid log levels
+//   * @param combinedBuffer the combined buffer reference
+//   * @param baseBufferCount the count of the base buffer
+//   * @param numQuantiles number of retained quantiles in the sketch
+//   * @param quantilesArr the consolidated array of all quantiles from the sketch
+//   * @param weightsArr the weights for each item from the sketch
+//   * @param comparator the given comparator for data type T
+//   */
+//  private final static <T> void populateFromItemsSketch(
+//      final int k, final long n, final long bitPattern, final T[] combinedBuffer,
+//      final int baseBufferCount, final int numQuantiles, final T[] quantilesArr, final long[] weightsArr,
+//      final Comparator<? super T> comparator) {
+//    long weight = 1;
+//    int nxt = 0;
+//    long bits = bitPattern;
+//    assert bits == (n / (2L * k)); // internal consistency check
+//    for (int lvl = 0; bits != 0L; lvl++, bits >>>= 1) {
+//      weight *= 2;
+//      if ((bits & 1L) > 0L) {
+//        final int offset = (2 + lvl) * k;
+//        for (int i = 0; i < k; i++) {
+//          quantilesArr[nxt] = combinedBuffer[i + offset];
+//          weightsArr[nxt] = weight;
+//          nxt++;
+//        }
+//      }
+//    }
+//
+//    weight = 1; //NOT a mistake! We just copied the highest level; now we need to copy the base buffer
+//    final int startOfBaseBufferBlock = nxt;
+//
+//    // Copy BaseBuffer over, along with weight = 1
+//    for (int i = 0; i < baseBufferCount; i++) {
+//      quantilesArr[nxt] = combinedBuffer[i];
+//      weightsArr[nxt] = weight;
+//      nxt++;
+//    }
+//    assert nxt == numQuantiles;
+//
+//    // Must sort the items that came from the base buffer.
+//    // Don't need to sort the corresponding weights because they are all the same.
+//    Arrays.sort(quantilesArr, startOfBaseBufferBlock, numQuantiles, comparator);
+//  }
+//
+//  /**
+//   * Convert the individual weights into cumulative weights.
+//   * An array of {1,1,1,1} becomes {1,2,3,4}
+//   * @param array of actual weights from the sketch, none of the weights may be zero
+//   * @return total weight
+//   */
+//  private static long convertToCumulative(final long[] array) {
+//    long subtotal = 0;
+//    for (int i = 0; i < array.length; i++) {
+//      final long newSubtotal = subtotal + array[i];
+//      subtotal = array[i] = newSubtotal;
+//    }
+//    return subtotal;
+//  }
 
 }

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
@@ -27,11 +27,9 @@ import static org.apache.datasketches.quantilescommon.QuantilesUtil.evenlySpaced
 import static org.apache.datasketches.quantilescommon.QuantilesUtil.getNaturalRank;
 
 import java.lang.reflect.Array;
-//import java.util.Arrays;
 import java.util.Comparator;
 
 import org.apache.datasketches.common.SketchesArgumentException;
-//import org.apache.datasketches.common.SketchesStateException;
 import org.apache.datasketches.quantilescommon.GenericInequalitySearch.Inequality;
 import org.apache.datasketches.quantilescommon.GenericPartitionBoundaries;
 import org.apache.datasketches.quantilescommon.GenericSortedView;

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
@@ -84,40 +84,6 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T>, Partition
     this.k = k;
   }
 
-//  /**
-//   * Constructs this Sorted View given the sketch
-//   * @param sketch the given Classic Quantiles ItemsSketch
-//   */
-//  @SuppressWarnings("unchecked")
-//  ItemsSketchSortedView(final ItemsSketch<T> sketch) {
-//    if (sketch.isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
-//    this.totalN = sketch.getN();
-//    final int numQuantiles = sketch.getNumRetained();
-//    this.quantiles = (T[]) Array.newInstance(sketch.clazz, numQuantiles);
-//    this.minItem = sketch.minItem_;
-//    this.maxItem = sketch.maxItem_;
-//    this.cumWeights = new long[numQuantiles];
-//    this.comparator = sketch.getComparator();
-//    this.clazz = sketch.clazz;
-//    this.k = sketch.getK();
-//
-//    final Object[] combinedBuffer = sketch.getCombinedBuffer();
-//    final int baseBufferCount = sketch.getBaseBufferCount();
-//
-//    // Populate from ItemsSketch:
-//    // copy over the "levels" and then the base buffer, all with appropriate weights
-//    populateFromItemsSketch(k, totalN, sketch.getBitPattern(), (T[]) combinedBuffer, baseBufferCount,
-//        numQuantiles, quantiles, cumWeights, sketch.getComparator());
-//
-//    // Sort the first "numSamples" slots of the two arrays in tandem,
-//    // taking advantage of the already sorted blocks of length k
-//    ItemsMergeImpl.blockyTandemMergeSort(quantiles, cumWeights, numQuantiles, k, sketch.getComparator());
-//
-//    if (convertToCumulative(cumWeights) != totalN) {
-//      throw new SketchesStateException("Sorted View is misconfigured. TotalN does not match cumWeights.");
-//    }
-//  }
-
   //end of constructors
 
   @Override
@@ -310,71 +276,5 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T>, Partition
   public GenericSortedViewIterator<T> iterator() {
     return new GenericSortedViewIterator<>(quantiles, cumWeights);
   }
-
-  //restricted methods
-
-//  /**
-//   * Populate the arrays and registers from an ItemsSketch
-//   * @param <T> the data type
-//   * @param k K parameter of sketch
-//   * @param n The current size of the stream
-//   * @param bitPattern the bit pattern for valid log levels
-//   * @param combinedBuffer the combined buffer reference
-//   * @param baseBufferCount the count of the base buffer
-//   * @param numQuantiles number of retained quantiles in the sketch
-//   * @param quantilesArr the consolidated array of all quantiles from the sketch
-//   * @param weightsArr the weights for each item from the sketch
-//   * @param comparator the given comparator for data type T
-//   */
-//  private final static <T> void populateFromItemsSketch(
-//      final int k, final long n, final long bitPattern, final T[] combinedBuffer,
-//      final int baseBufferCount, final int numQuantiles, final T[] quantilesArr, final long[] weightsArr,
-//      final Comparator<? super T> comparator) {
-//    long weight = 1;
-//    int nxt = 0;
-//    long bits = bitPattern;
-//    assert bits == (n / (2L * k)); // internal consistency check
-//    for (int lvl = 0; bits != 0L; lvl++, bits >>>= 1) {
-//      weight *= 2;
-//      if ((bits & 1L) > 0L) {
-//        final int offset = (2 + lvl) * k;
-//        for (int i = 0; i < k; i++) {
-//          quantilesArr[nxt] = combinedBuffer[i + offset];
-//          weightsArr[nxt] = weight;
-//          nxt++;
-//        }
-//      }
-//    }
-//
-//    weight = 1; //NOT a mistake! We just copied the highest level; now we need to copy the base buffer
-//    final int startOfBaseBufferBlock = nxt;
-//
-//    // Copy BaseBuffer over, along with weight = 1
-//    for (int i = 0; i < baseBufferCount; i++) {
-//      quantilesArr[nxt] = combinedBuffer[i];
-//      weightsArr[nxt] = weight;
-//      nxt++;
-//    }
-//    assert nxt == numQuantiles;
-//
-//    // Must sort the items that came from the base buffer.
-//    // Don't need to sort the corresponding weights because they are all the same.
-//    Arrays.sort(quantilesArr, startOfBaseBufferBlock, numQuantiles, comparator);
-//  }
-//
-//  /**
-//   * Convert the individual weights into cumulative weights.
-//   * An array of {1,1,1,1} becomes {1,2,3,4}
-//   * @param array of actual weights from the sketch, none of the weights may be zero
-//   * @return total weight
-//   */
-//  private static long convertToCumulative(final long[] array) {
-//    long subtotal = 0;
-//    for (int i = 0; i < array.length; i++) {
-//      final long newSubtotal = subtotal + array[i];
-//      subtotal = array[i] = newSubtotal;
-//    }
-//    return subtotal;
-//  }
 
 }

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsSketchSortedView.java
@@ -58,6 +58,11 @@ public class ItemsSketchSortedView<T> implements GenericSortedView<T>, Partition
   private final Class<T> clazz;
   private final int k;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * Construct from elements for testing.
    * @param quantiles sorted array of quantiles

--- a/src/main/java/org/apache/datasketches/quantilescommon/GenericPartitionBoundaries.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/GenericPartitionBoundaries.java
@@ -39,6 +39,11 @@ public class GenericPartitionBoundaries<T> implements PartitionBoundaries {
   private long[] numDeltaItems; //num of items in each part
   private int numPartitions;    //num of partitions
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   public GenericPartitionBoundaries(
       final long totalN,
       final T[] boundaries,

--- a/src/main/java/org/apache/datasketches/quantilescommon/GenericPartitionBoundaries.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/GenericPartitionBoundaries.java
@@ -27,7 +27,7 @@ import org.apache.datasketches.common.SketchesStateException;
 /**
  * Implements PartitionBoundaries
  */
-public class GenericPartitionBoundaries<T> implements PartitionBoundaries {
+final public class GenericPartitionBoundaries<T> implements PartitionBoundaries {
   private long totalN; //totalN of source sketch
   private T[] boundaries;       //quantiles at the boundaries
   private long[] natRanks;      //natural ranks at the boundaries
@@ -38,11 +38,6 @@ public class GenericPartitionBoundaries<T> implements PartitionBoundaries {
   //computed
   private long[] numDeltaItems; //num of items in each part
   private int numPartitions;    //num of partitions
-
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
-  }
 
   public GenericPartitionBoundaries(
       final long totalN,

--- a/src/main/java/org/apache/datasketches/sampling/EbppsItemsSample.java
+++ b/src/main/java/org/apache/datasketches/sampling/EbppsItemsSample.java
@@ -29,18 +29,13 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.datasketches.common.SketchesArgumentException;
 
 // this is a supporting class used to hold the raw data sample
-class EbppsItemsSample<T> {
+final class EbppsItemsSample<T> {
 
   private double c_;            // Current sample size, including fractional part
   private T partialItem_;       // a sample item corresponding to a partial weight
   private ArrayList<T> data_;   // full sample items
 
   private Random rand_;         // ThreadLocalRandom.current() in general
-
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
-  }
 
   // basic constructor
   EbppsItemsSample(final int reservedSize) {

--- a/src/main/java/org/apache/datasketches/sampling/EbppsItemsSample.java
+++ b/src/main/java/org/apache/datasketches/sampling/EbppsItemsSample.java
@@ -34,8 +34,13 @@ class EbppsItemsSample<T> {
   private double c_;            // Current sample size, including fractional part
   private T partialItem_;       // a sample item corresponding to a partial weight
   private ArrayList<T> data_;   // full sample items
-  
+
   private Random rand_;         // ThreadLocalRandom.current() in general
+
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
 
   // basic constructor
   EbppsItemsSample(final int reservedSize) {
@@ -60,7 +65,7 @@ class EbppsItemsSample<T> {
     if (c < 0.0 || Double.isNaN(c) || Double.isInfinite(c)) {
       throw new SketchesArgumentException("C must be nonnegative and finite. Found: " + c);
     }
-    
+
     c_ = c;
     partialItem_ = partialItem;
     data_ = data;
@@ -76,14 +81,14 @@ class EbppsItemsSample<T> {
     if (theta < 0.0 || theta > 1.0 || Double.isNaN(theta)) {
       throw new SketchesArgumentException("Theta must be in the range [0.0, 1.0]. Found: " + theta);
     }
-    
+
     c_ = theta;
     if (theta == 1.0) {
       if (data_ != null && data_.size() == 1) {
         data_.set(0, item);
       } else {
         data_ = new ArrayList<>(1);
-        data_.add(item);  
+        data_.add(item);
       }
       partialItem_ = null;
     } else {
@@ -116,7 +121,7 @@ class EbppsItemsSample<T> {
       result.add(partialItem_);
     }
 
-    return result;      
+    return result;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/org/apache/datasketches/sampling/EbppsItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/EbppsItemsSketch.java
@@ -35,14 +35,14 @@ import org.apache.datasketches.memory.WritableMemory;
 
 /**
  * An implementation of an Exact and Bounded Sampling Proportional to Size sketch.
- * 
+ *
  * <p>From: "Exact PPS Sampling with Bounded Sample Size",
  * B. Hentschel, P. J. Haas, Y. Tian. Information Processing Letters, 2023.
- * 
+ *
  * <p>This sketch samples data from a stream of items proportional to the weight of each item.
  * The sample guarantees the presence of an item in the result is proportional to that item's
  * portion of the total weight seen by the sketch, and returns a sample no larger than size k.
- * 
+ *
  * <p>The sample may be smaller than k and the resulting size of the sample potentially includes
  * a probabilistic component, meaning the resulting sample size is not always constant.
  *
@@ -63,6 +63,11 @@ public class EbppsItemsSketch<T> {
   private EbppsItemsSample<T> sample_; // Object holding the current state of the sample
 
   final private EbppsItemsSample<T> tmp_;    // temporary storage
+
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
 
   /**
    * Constructor
@@ -256,7 +261,7 @@ public class EbppsItemsSketch<T> {
    * pathological cases, most obvious with k=2 and A.cum_wt == B.cum_wt where that
    * approach will always take exactly 1 item from A and 1 from B, meaning the
    * co-occurrence rate for two items from either sketch is guaranteed to be 0.0.
-   * 
+   *
    * With EBPPS, once an item is accepted into the sketch we no longer need to
    * track the item's weight: All accepted items are treated equally. As a result, we
    * can take inspiration from the reservoir sampling merge in the datasketches-java
@@ -338,7 +343,7 @@ public class EbppsItemsSketch<T> {
       if (cumulativeWt_ > 0.0) {
         sample_.downsample(newRho / rho_);
       }
-  
+
       tmp_.replaceContent(other.sample_.getPartialItem(), newRho * otherCFrac * avgWt);
       sample_.merge(tmp_);
 
@@ -354,7 +359,7 @@ public class EbppsItemsSketch<T> {
 
   /**
    * Returns a copy of the current sample. The exact size may be
-   * probabilsitic, differing by at most 1 item.
+   * probabilistic, differing by at most 1 item.
    * @return the current sketch sample
    */
   public ArrayList<T> getResult() { return sample_.getSample(); }
@@ -389,7 +394,7 @@ public class EbppsItemsSketch<T> {
 
   /**
    * Returns the expected number of samples returned upon a call to
-   * getResult(). The number is a floating point value, where the 
+   * getResult(). The number is a floating point value, where the
    * fractional portion represents the probability of including a
    * "partial item" from the sample.
    *
@@ -505,14 +510,14 @@ public class EbppsItemsSketch<T> {
       PreambleUtil.insertFlags(mem, sample_.hasPartialItem() ? HAS_PARTIAL_ITEM_MASK : 0);
     }
     PreambleUtil.insertK(mem, k_);                           // Bytes 4-7
-    
+
     // conditional elements
     if (!empty) {
       PreambleUtil.insertN(mem, n_);
       PreambleUtil.insertEbppsCumulativeWeight(mem, cumulativeWt_);
       PreambleUtil.insertEbppsMaxWeight(mem, wtMax_);
       PreambleUtil.insertEbppsRho(mem, rho_);
-      
+
       // data from sample_ -- itemBytes includes the partial item
       mem.putDouble(EBPPS_C_DOUBLE, sample_.getC());
       mem.putByteArray(EBPPS_ITEMS_START, itemBytes, 0, itemBytes.length);

--- a/src/main/java/org/apache/datasketches/sampling/EbppsItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/sampling/EbppsItemsSketch.java
@@ -49,7 +49,7 @@ import org.apache.datasketches.memory.WritableMemory;
  *
  * @author Jon Malkin
  */
-public class EbppsItemsSketch<T> {
+public final class EbppsItemsSketch<T> {
   private static final int MAX_K = Integer.MAX_VALUE - 2;
   private static final int EBPPS_C_DOUBLE        = 40; // part of sample state, not preamble
   private static final int EBPPS_ITEMS_START     = 48;
@@ -64,11 +64,6 @@ public class EbppsItemsSketch<T> {
   private EbppsItemsSample<T> sample_; // Object holding the current state of the sample
 
   final private EbppsItemsSample<T> tmp_;    // temporary storage
-
-  @Override
-  protected final void finalize() {
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
-  }
 
   /**
    * Constructor

--- a/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketch.java
@@ -121,7 +121,7 @@ class DirectQuickSelectSketch extends DirectQuickSelectSketchR {
   }
 
   private DirectQuickSelectSketch(
-      final boolean secure,
+      final boolean secure, //required part of Finalizer Attack prevention
       final int lgNomLongs,
       final long seed,
       final float p,

--- a/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketch.java
@@ -81,6 +81,11 @@ class DirectQuickSelectSketch extends DirectQuickSelectSketchR {
     super(seed, wmem);
   }
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * Construct a new sketch instance and initialize the given Memory as its backing store.
    *

--- a/src/main/java/org/apache/datasketches/tuple/CompactSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/CompactSketch.java
@@ -51,6 +51,11 @@ public class CompactSketch<S extends Summary> extends Sketch<S> {
 
   private enum Flags { IS_BIG_ENDIAN, IS_READ_ONLY, IS_EMPTY, IS_COMPACT, IS_ORDERED }
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * Create a CompactSketch from correct components
    * @param hashArr compacted hash array

--- a/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
@@ -47,24 +47,18 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
 
   private enum Flags { IS_BIG_ENDIAN, IS_IN_SAMPLING_MODE, IS_EMPTY, HAS_ENTRIES, IS_THETA_INCLUDED }
 
-  static final int DEFAULT_LG_RESIZE_FACTOR = ResizeFactor.X8.lg();
+  private static final int DEFAULT_LG_RESIZE_FACTOR = ResizeFactor.X8.lg();
   private final int nomEntries_;
-  private int lgCurrentCapacity_;
   private final int lgResizeFactor_;
-  private int count_;
   private final float samplingProbability_;
+  private int lgCurrentCapacity_;
+  private int retEntries_;
   private int rebuildThreshold_;
   private long[] hashTable_;
   S[] summaryTable_;
 
-  @Override
-  protected final void finalize() throws Throwable {
-    super.finalize();
-    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
-  }
-
   /**
-   * This is to create an instance of a QuickSelectSketch with default resize factor.
+   * This is to create a new instance of a QuickSelectSketch with default resize factor.
    * @param nomEntries Nominal number of entries. Forced to the nearest power of 2 greater than
    * given value.
    * @param summaryFactory An instance of a SummaryFactory.
@@ -76,7 +70,7 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   }
 
   /**
-   * This is to create an instance of a QuickSelectSketch with custom resize factor
+   * This is to create a new instance of a QuickSelectSketch with custom resize factor
    * @param nomEntries Nominal number of entries. Forced to the nearest power of 2 greater than
    * given value.
    * @param lgResizeFactor log2(resizeFactor) - value from 0 to 3:
@@ -96,7 +90,7 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   }
 
   /**
-   * This is to create an instance of a QuickSelectSketch with custom resize factor and sampling
+   * This is to create a new instance of a QuickSelectSketch with custom resize factor and sampling
    * probability
    * @param nomEntries Nominal number of entries. Forced to the nearest power of 2 greater than
    * or equal to the given value.
@@ -124,38 +118,50 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
     );
   }
 
-  QuickSelectSketch(
+  /**
+   * Target constructor for above constructors for a new instance.
+   * @param nomEntries Nominal number of entries.
+   * @param lgResizeFactor log2(resizeFactor)
+   * @param samplingProbability the given sampling probability
+   * @param summaryFactory An instance of a SummaryFactory.
+   * @param startingSize starting size of the sketch.
+   */
+  private QuickSelectSketch(
       final int nomEntries,
       final int lgResizeFactor,
       final float samplingProbability,
       final SummaryFactory<S> summaryFactory,
       final int startingSize) {
+    super(
+        (long) (Long.MAX_VALUE * (double) samplingProbability),
+        true,
+        summaryFactory);
     nomEntries_ = ceilingPowerOf2(nomEntries);
     lgResizeFactor_ = lgResizeFactor;
     samplingProbability_ = samplingProbability;
-    summaryFactory_ = summaryFactory; //super
-    thetaLong_ = (long) (Long.MAX_VALUE * (double) samplingProbability); //super
     lgCurrentCapacity_ = Integer.numberOfTrailingZeros(startingSize);
-    hashTable_ = new long[startingSize];
+    retEntries_ = 0;
+    hashTable_ = new long[startingSize]; //must be before setRebuildThreshold
+    rebuildThreshold_ = setRebuildThreshold(hashTable_, nomEntries_);
     summaryTable_ = null; // wait for the first summary to call Array.newInstance()
-    setRebuildThreshold();
   }
 
   /**
    * Copy constructor
-   * @param sketch the QuickSelectSketch to be copied.
+   * @param sketch the QuickSelectSketch to be deep copied.
    */
   QuickSelectSketch(final QuickSelectSketch<S> sketch) {
+    super(
+        sketch.thetaLong_,
+        sketch.empty_,
+        sketch.summaryFactory_);
     nomEntries_ = sketch.nomEntries_;
-    lgCurrentCapacity_ = sketch.lgCurrentCapacity_;
     lgResizeFactor_ = sketch.lgResizeFactor_;
-    count_ = sketch.count_;
     samplingProbability_ = sketch.samplingProbability_;
-    rebuildThreshold_ = sketch.rebuildThreshold_;
-    thetaLong_ = sketch.thetaLong_;
-    empty_ = sketch.empty_;
-    summaryFactory_ = sketch.summaryFactory_;
+    lgCurrentCapacity_ = sketch.lgCurrentCapacity_;
+    retEntries_ = sketch.retEntries_;
     hashTable_ = sketch.hashTable_.clone();
+    rebuildThreshold_ = sketch.rebuildThreshold_;
     summaryTable_ = Util.copySummaryArray(sketch.summaryTable_);
   }
 
@@ -164,75 +170,128 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
    * @param mem Memory object with serialized QuickSelectSketch
    * @param deserializer the SummaryDeserializer
    * @param summaryFactory the SummaryFactory
-   * @deprecated As of 3.0.0, heapifying an UpdatableSketch is deprecated.
    * This capability will be removed in a future release.
    * Heapifying a CompactSketch is not deprecated.
    */
-  @Deprecated
   QuickSelectSketch(
       final Memory mem,
       final SummaryDeserializer<S> deserializer,
       final SummaryFactory<S> summaryFactory) {
-    Objects.requireNonNull(mem, "SourceMemory must not be null.");
-    Objects.requireNonNull(deserializer, "Deserializer must not be null.");
-    checkBounds(0, 8, mem.getCapacity());
-    summaryFactory_ = summaryFactory;
-    int offset = 0;
-    final byte preambleLongs = mem.getByte(offset++); //byte 0 PreLongs
-    final byte version = mem.getByte(offset++);       //byte 1 SerVer
-    final byte familyId = mem.getByte(offset++);      //byte 2 FamID
-    SerializerDeserializer.validateFamily(familyId, preambleLongs);
-    if (version > serialVersionUID) {
-      throw new SketchesArgumentException(
-          "Unsupported serial version. Expected: " + serialVersionUID + " or lower, actual: "
-              + version);
-    }
-    SerializerDeserializer.validateType(mem.getByte(offset++), //byte 3
-        SerializerDeserializer.SketchType.QuickSelectSketch);
-    final byte flags = mem.getByte(offset++); //byte 4
-    final boolean isBigEndian = (flags & 1 << Flags.IS_BIG_ENDIAN.ordinal()) > 0;
-    if (isBigEndian ^ ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)) {
-      throw new SketchesArgumentException("Endian byte order mismatch");
-    }
-    nomEntries_ = 1 << mem.getByte(offset++); //byte 5
-    lgCurrentCapacity_ = mem.getByte(offset++); //byte 6
-    lgResizeFactor_ = mem.getByte(offset++); //byte 7
-
-    checkBounds(0, preambleLongs * 8L, mem.getCapacity());
-    final boolean isInSamplingMode = (flags & 1 << Flags.IS_IN_SAMPLING_MODE.ordinal()) > 0;
-    samplingProbability_ = isInSamplingMode ? mem.getFloat(offset) : 1f; //bytes 8 - 11
-    if (isInSamplingMode) {
-      offset += Float.BYTES;
-    }
-
-    final boolean isThetaIncluded = (flags & 1 << Flags.IS_THETA_INCLUDED.ordinal()) > 0;
-    if (isThetaIncluded) {
-      thetaLong_ = mem.getLong(offset);
-      offset += Long.BYTES;
-    } else {
-      thetaLong_ = (long) (Long.MAX_VALUE * (double) samplingProbability_);
-    }
-
-    int count = 0;
-    final boolean hasEntries = (flags & 1 << Flags.HAS_ENTRIES.ordinal()) > 0;
-    if (hasEntries) {
-      count = mem.getInt(offset);
-      offset += Integer.BYTES;
-    }
-    final int currentCapacity = 1 << lgCurrentCapacity_;
-    hashTable_ = new long[currentCapacity];
-    for (int i = 0; i < count; i++) {
-      final long hash = mem.getLong(offset);
-      offset += Long.BYTES;
-      final Memory memRegion = mem.region(offset, mem.getCapacity() - offset);
-      final DeserializeResult<S> summaryResult = deserializer.heapifySummary(memRegion);
-      final S summary = summaryResult.getObject();
-      offset += summaryResult.getSize();
-      insert(hash, summary);
-    }
-    empty_ = (flags & 1 << Flags.IS_EMPTY.ordinal()) > 0;
-    setRebuildThreshold();
+    this(new Validate<>(), mem, deserializer, summaryFactory);
   }
+
+  /*
+   * This private constructor is used to protect against "Finalizer attacks".
+   * The private static inner class Validate performs validation and deserialization
+   * from the input Memory and may throw exceptions. In order to protect against the attack, we must
+   * perform this validation prior to the constructor's super reaches the Object class.
+   * Making QuickSelectSketch final won't work here because UpdatableSketch is a subclass.
+   * Using an empty final finalizer() is not recommended and is deprecated as of Java9.
+   */
+  private QuickSelectSketch(
+      final Validate<S> val,
+      final Memory mem,
+      final SummaryDeserializer<S> deserializer,
+      final SummaryFactory<S> summaryFactory) {
+    super(val.validate(mem, deserializer), val.myEmpty, summaryFactory);
+    nomEntries_ = val.myNomEntries;
+    lgResizeFactor_ = val.myLgResizeFactor;
+    samplingProbability_ = val.mySamplingProbability;
+    lgCurrentCapacity_ = val.myLgCurrentCapacity;
+    retEntries_ = val.myRetEntries;
+    rebuildThreshold_ = val.myRebuildThreshold;
+    hashTable_ = val.myHashTable;
+    summaryTable_ = val.mySummaryTable;
+  }
+
+  private static final class Validate<S> {
+    //super fields
+    long myThetaLong;
+    boolean myEmpty;
+    //this fields
+    int myNomEntries;
+    int myLgResizeFactor;
+    float mySamplingProbability;
+    int myLgCurrentCapacity;
+    int myRetEntries;
+    int myRebuildThreshold;
+    long[] myHashTable;
+    S[] mySummaryTable;
+
+    @SuppressWarnings("unchecked")
+    long validate(
+        final Memory mem,
+        final SummaryDeserializer<?> deserializer) {
+      Objects.requireNonNull(mem, "SourceMemory must not be null.");
+      Objects.requireNonNull(deserializer, "Deserializer must not be null.");
+      checkBounds(0, 8, mem.getCapacity());
+
+      int offset = 0;
+      final byte preambleLongs = mem.getByte(offset++); //byte 0 PreLongs
+      final byte version = mem.getByte(offset++);       //byte 1 SerVer
+      final byte familyId = mem.getByte(offset++);      //byte 2 FamID
+      SerializerDeserializer.validateFamily(familyId, preambleLongs);
+      if (version > serialVersionUID) {
+        throw new SketchesArgumentException(
+            "Unsupported serial version. Expected: " + serialVersionUID + " or lower, actual: "
+                + version);
+      }
+      SerializerDeserializer.validateType(mem.getByte(offset++), //byte 3
+          SerializerDeserializer.SketchType.QuickSelectSketch);
+      final byte flags = mem.getByte(offset++); //byte 4
+      final boolean isBigEndian = (flags & 1 << Flags.IS_BIG_ENDIAN.ordinal()) > 0;
+      if (isBigEndian ^ ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)) {
+        throw new SketchesArgumentException("Endian byte order mismatch");
+      }
+      myNomEntries = 1 << mem.getByte(offset++); //byte 5
+      myLgCurrentCapacity = mem.getByte(offset++); //byte 6
+      myLgResizeFactor = mem.getByte(offset++); //byte 7
+
+      checkBounds(0, preambleLongs * 8L, mem.getCapacity());
+      final boolean isInSamplingMode = (flags & 1 << Flags.IS_IN_SAMPLING_MODE.ordinal()) > 0;
+      mySamplingProbability = isInSamplingMode ? mem.getFloat(offset) : 1f; //bytes 8 - 11
+      if (isInSamplingMode) {
+        offset += Float.BYTES;
+      }
+
+      final boolean isThetaIncluded = (flags & 1 << Flags.IS_THETA_INCLUDED.ordinal()) > 0;
+      if (isThetaIncluded) {
+        myThetaLong = mem.getLong(offset);
+        offset += Long.BYTES;
+      } else {
+        myThetaLong = (long) (Long.MAX_VALUE * (double) mySamplingProbability);
+      }
+
+      int count = 0;
+      final boolean hasEntries = (flags & (1 << Flags.HAS_ENTRIES.ordinal())) > 0;
+      if (hasEntries) {
+        count = mem.getInt(offset);
+        offset += Integer.BYTES;
+      }
+      final int currentCapacity = 1 << myLgCurrentCapacity;
+      myHashTable = new long[currentCapacity];
+      for (int i = 0; i < count; i++) {
+        final long hash = mem.getLong(offset);
+        offset += Long.BYTES;
+        final Memory memRegion = mem.region(offset, mem.getCapacity() - offset);
+        final DeserializeResult<?> summaryResult = deserializer.heapifySummary(memRegion);
+        final S summary = (S) summaryResult.getObject();
+        offset += summaryResult.getSize();
+        //in-place equivalent to insert(hash, summary):
+        final int index = HashOperations.hashInsertOnly(myHashTable, myLgCurrentCapacity, hash);
+        if (mySummaryTable == null) {
+          mySummaryTable = (S[]) Array.newInstance(summary.getClass(), myHashTable.length);
+        }
+        mySummaryTable[index] = summary;
+        myRetEntries++;
+        myEmpty = false;
+      }
+      myEmpty = (flags & 1 << Flags.IS_EMPTY.ordinal()) > 0;
+      myRebuildThreshold = setRebuildThreshold(myHashTable, myNomEntries);
+      return myThetaLong;
+    }
+
+  } //end class Validate
 
   /**
    * @return a deep copy of this sketch
@@ -247,7 +306,7 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
 
   @Override
   public int getRetainedEntries() {
-    return count_;
+    return retEntries_;
   }
 
   @Override
@@ -303,7 +362,7 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
    * Rebuilds reducing the actual number of entries to the nominal number of entries if needed
    */
   public void trim() {
-    if (count_ > nomEntries_) {
+    if (retEntries_ > nomEntries_) {
       updateTheta();
       resize(hashTable_.length);
     }
@@ -314,13 +373,13 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
    */
   public void reset() {
     empty_ = true;
-    count_ = 0;
+    retEntries_ = 0;
     thetaLong_ = (long) (Long.MAX_VALUE * (double) samplingProbability_);
     final int startingCapacity = Util.getStartingCapacity(nomEntries_, lgResizeFactor_);
     lgCurrentCapacity_ = Integer.numberOfTrailingZeros(startingCapacity);
     hashTable_ = new long[startingCapacity];
     summaryTable_ = null; // wait for the first summary to call Array.newInstance()
-    setRebuildThreshold();
+    rebuildThreshold_ = setRebuildThreshold(hashTable_, nomEntries_);
   }
 
   /**
@@ -364,8 +423,8 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   public byte[] toByteArray() {
     byte[][] summariesBytes = null;
     int summariesBytesLength = 0;
-    if (count_ > 0) {
-      summariesBytes = new byte[count_][];
+    if (retEntries_ > 0) {
+      summariesBytes = new byte[retEntries_][];
       int i = 0;
       for (int j = 0; j < summaryTable_.length; j++) {
         if (summaryTable_[j] != null) {
@@ -392,10 +451,10 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
     if (isThetaIncluded) {
       sizeBytes += Long.BYTES;
     }
-    if (count_ > 0) {
+    if (retEntries_ > 0) {
       sizeBytes += Integer.BYTES; // count
     }
-    sizeBytes += Long.BYTES * count_ + summariesBytesLength;
+    sizeBytes += Long.BYTES * retEntries_ + summariesBytesLength;
     final byte[] bytes = new byte[sizeBytes];
     int offset = 0;
     bytes[offset++] = PREAMBLE_LONGS;
@@ -407,7 +466,7 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
       (isBigEndian ? 1 << Flags.IS_BIG_ENDIAN.ordinal() : 0)
       | (isInSamplingMode() ? 1 << Flags.IS_IN_SAMPLING_MODE.ordinal() : 0)
       | (empty_ ? 1 << Flags.IS_EMPTY.ordinal() : 0)
-      | (count_ > 0 ? 1 << Flags.HAS_ENTRIES.ordinal() : 0)
+      | (retEntries_ > 0 ? 1 << Flags.HAS_ENTRIES.ordinal() : 0)
       | (isThetaIncluded ? 1 << Flags.IS_THETA_INCLUDED.ordinal() : 0)
     );
     bytes[offset++] = (byte) Integer.numberOfTrailingZeros(nomEntries_);
@@ -421,11 +480,11 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
       ByteArrayUtil.putLongLE(bytes, offset, thetaLong_);
       offset += Long.BYTES;
     }
-    if (count_ > 0) {
-      ByteArrayUtil.putIntLE(bytes, offset, count_);
+    if (retEntries_ > 0) {
+      ByteArrayUtil.putIntLE(bytes, offset, retEntries_);
       offset += Integer.BYTES;
     }
-    if (count_ > 0) {
+    if (retEntries_ > 0) {
       int i = 0;
       for (int j = 0; j < hashTable_.length; j++) {
         if (summaryTable_[j] != null) {
@@ -473,13 +532,13 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   int findOrInsert(final long hash) {
     final int index = HashOperations.hashSearchOrInsert(hashTable_, lgCurrentCapacity_, hash);
     if (index < 0) {
-      count_++;
+      retEntries_++;
     }
     return index;
   }
 
   boolean rebuildIfNeeded() {
-    if (count_ <= rebuildThreshold_) {
+    if (retEntries_ <= rebuildThreshold_) {
       return false;
     }
     if (hashTable_.length > nomEntries_) {
@@ -498,12 +557,12 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   void insert(final long hash, final S summary) {
     final int index = HashOperations.hashInsertOnly(hashTable_, lgCurrentCapacity_, hash);
     insertSummary(index, summary);
-    count_++;
+    retEntries_++;
     empty_ = false;
   }
 
   private void updateTheta() {
-    final long[] hashArr = new long[count_];
+    final long[] hashArr = new long[retEntries_];
     int i = 0;
     //Because of the association of the hashTable with the summaryTable we cannot destroy the
     // hashTable structure. So we must copy. May as well compact at the same time.
@@ -514,7 +573,7 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
         hashArr[i++] = hashTable_[j];
       }
     }
-    thetaLong_ = QuickSelect.select(hashArr, 0, count_ - 1, nomEntries_);
+    thetaLong_ = QuickSelect.select(hashArr, 0, retEntries_ - 1, nomEntries_);
   }
 
   private void resize(final int newSize) {
@@ -523,20 +582,20 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
     hashTable_ = new long[newSize];
     summaryTable_ = Util.newSummaryArray(summaryTable_, newSize);
     lgCurrentCapacity_ = Integer.numberOfTrailingZeros(newSize);
-    count_ = 0;
+    retEntries_ = 0;
     for (int i = 0; i < oldHashTable.length; i++) {
       if (oldSummaryTable[i] != null && oldHashTable[i] < thetaLong_) {
         insert(oldHashTable[i], oldSummaryTable[i]);
       }
     }
-    setRebuildThreshold();
+    rebuildThreshold_ = setRebuildThreshold(hashTable_, nomEntries_);
   }
 
-  private void setRebuildThreshold() {
-    if (hashTable_.length > nomEntries_) {
-      rebuildThreshold_ = (int) (hashTable_.length * ThetaUtil.REBUILD_THRESHOLD);
+  private static int setRebuildThreshold(final long[] hashTable, final int nomEntries) {
+    if (hashTable.length > nomEntries) {
+      return (int) (hashTable.length * ThetaUtil.REBUILD_THRESHOLD);
     } else {
-      rebuildThreshold_ = (int) (hashTable_.length * ThetaUtil.RESIZE_THRESHOLD);
+      return (int) (hashTable.length * ThetaUtil.RESIZE_THRESHOLD);
     }
   }
 

--- a/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
@@ -58,7 +58,8 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   S[] summaryTable_;
 
   @Override
-  protected final void finalize() {
+  protected final void finalize() throws Throwable {
+    super.finalize();
     // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
   }
 

--- a/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
@@ -170,9 +170,11 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
    * @param mem Memory object with serialized QuickSelectSketch
    * @param deserializer the SummaryDeserializer
    * @param summaryFactory the SummaryFactory
+   * @deprecated As of 3.0.0, heapifying an UpdatableSketch is deprecated.
    * This capability will be removed in a future release.
    * Heapifying a CompactSketch is not deprecated.
    */
+  @Deprecated
   QuickSelectSketch(
       final Memory mem,
       final SummaryDeserializer<S> deserializer,

--- a/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/QuickSelectSketch.java
@@ -57,6 +57,11 @@ class QuickSelectSketch<S extends Summary> extends Sketch<S> {
   private long[] hashTable_;
   S[] summaryTable_;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * This is to create an instance of a QuickSelectSketch with default resize factor.
    * @param nomEntries Nominal number of entries. Forced to the nearest power of 2 greater than

--- a/src/main/java/org/apache/datasketches/tuple/Sketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/Sketch.java
@@ -35,9 +35,13 @@ public abstract class Sketch<S extends Summary> {
 
   long thetaLong_;
   boolean empty_ = true;
-  protected SummaryFactory<S> summaryFactory_;
+  protected SummaryFactory<S> summaryFactory_ = null;
 
-  Sketch() {}
+  Sketch(final long thetaLong, final boolean empty, final SummaryFactory<S> summaryFactory) {
+    this.thetaLong_ = thetaLong;
+    this.empty_ = empty;
+    this.summaryFactory_ = summaryFactory;
+  }
 
   /**
    * Converts this sketch to a CompactSketch on the Java heap.

--- a/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
@@ -69,7 +69,9 @@ public class UpdatableSketch<U, S extends UpdatableSummary<U>> extends QuickSele
    * Heapifying a CompactSketch is not deprecated.
    */
   @Deprecated
-  public UpdatableSketch(final Memory srcMem, final SummaryDeserializer<S> deserializer,
+  public UpdatableSketch(
+      final Memory srcMem,
+      final SummaryDeserializer<S> deserializer,
       final SummaryFactory<S> summaryFactory) {
     super(srcMem, deserializer, summaryFactory);
   }

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketch.java
@@ -57,9 +57,7 @@ abstract class ArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesUpdatableSk
   int rebuildThreshold_; //absolute value relative to current capacity
   int lgCurrentCapacity_;
 
-  ArrayOfDoublesQuickSelectSketch(
-      final int numValues,
-      final long seed) {
+  ArrayOfDoublesQuickSelectSketch(final int numValues, final long seed) {
     super(numValues, seed);
   }
 

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesQuickSelectSketch.java
@@ -57,7 +57,9 @@ abstract class ArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesUpdatableSk
   int rebuildThreshold_; //absolute value relative to current capacity
   int lgCurrentCapacity_;
 
-  ArrayOfDoublesQuickSelectSketch(final int numValues, final long seed) {
+  ArrayOfDoublesQuickSelectSketch(
+      final int numValues,
+      final long seed) {
     super(numValues, seed);
   }
 

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketch.java
@@ -45,6 +45,11 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
   private int keysOffset_;
   private int valuesOffset_;
 
+  @Override
+  protected final void finalize() {
+    // SpotBugs CT_CONSTUCTOR_THROW, OBJ11-J
+  }
+
   /**
    * Construct a new sketch using the given Memory as its backing store.
    *

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketch.java
@@ -68,7 +68,9 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
       final int numValues,
       final long seed,
       final WritableMemory dstMem) {
-    this(validate1(nomEntries, lgResizeFactor, numValues, dstMem),
+    this(checkMemory(nomEntries, lgResizeFactor, numValues, dstMem),
+    //SpotBugs CT_CONSTRUCTOR_THROW is false positive.
+    //this construction scheme is compliant with SEI CERT Oracle Coding Standard for Java / OBJ11-J
         nomEntries,
         lgResizeFactor,
         samplingProbability,
@@ -78,7 +80,7 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
   }
 
   private DirectArrayOfDoublesQuickSelectSketch(
-      final boolean secure,
+      final boolean secure, //required part of Finalizer Attack prevention
       final int nomEntries,
       final int lgResizeFactor,
       final float samplingProbability,
@@ -115,7 +117,7 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
     setRebuildThreshold();
   }
 
-  private static final boolean validate1(
+  private static final boolean checkMemory(
       final int nomEntries,
       final int lgResizeFactor,
       final int numValues,
@@ -133,13 +135,13 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
   DirectArrayOfDoublesQuickSelectSketch(
       final WritableMemory mem,
       final long seed) {
-    this(validate2(mem), mem, seed);
+    this(checkSerVer_Endianness(mem), mem, seed);
     //SpotBugs CT_CONSTRUCTOR_THROW is false positive.
     //this construction scheme is compliant with SEI CERT Oracle Coding Standard for Java / OBJ11-J
   }
 
   private DirectArrayOfDoublesQuickSelectSketch(
-      final boolean secure,
+      final boolean secure, //required part of Finalizer Attack prevention
       final WritableMemory mem,
       final long seed) {
     super(mem.getByte(NUM_VALUES_BYTE), seed);
@@ -159,7 +161,7 @@ class DirectArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelectSke
     setRebuildThreshold();
   }
 
-  private static final boolean validate2(final Memory mem) {
+  private static final boolean checkSerVer_Endianness(final Memory mem) {
     final byte version = mem.getByte(SERIAL_VERSION_BYTE);
     if (version != serialVersionUID) {
       throw new SketchesArgumentException("Serial version mismatch. Expected: " + serialVersionUID

--- a/src/main/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSummary.java
+++ b/src/main/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSummary.java
@@ -33,7 +33,7 @@ import org.apache.datasketches.tuple.UpdatableSummary;
 /**
  * @author Lee Rhodes
  */
-public class ArrayOfStringsSummary implements UpdatableSummary<String[]> {
+public final class ArrayOfStringsSummary implements UpdatableSummary<String[]> {
 
   private String[] nodesArr = null;
 

--- a/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/strings/ArrayOfStringsSketchTest.java
@@ -46,11 +46,11 @@ public class ArrayOfStringsSketchTest {
       sketch1.update(strArrArr[i], strArrArr[i]);
     }
     sketch1.update(strArrArr[0], strArrArr[0]); //insert duplicate
-    //printSummaries(sketch1.iterator());
+    printSummaries(sketch1.iterator());
     byte[] array = sketch1.toByteArray();
     WritableMemory wmem = WritableMemory.writableWrap(array);
     ArrayOfStringsSketch sketch2 = new ArrayOfStringsSketch(wmem);
-    //printSummaries(sketch2.iterator());
+    printSummaries(sketch2.iterator());
     checkSummaries(sketch2, sketch2);
 
     String[] strArr3 = {"g", "h" };

--- a/tools/FindBugsExcludeFilter.xml
+++ b/tools/FindBugsExcludeFilter.xml
@@ -79,10 +79,27 @@ under the License.
     <Class name="org.apache.datasketches.quantilescommon.GenericSortedViewIterator"/>
   </Match>
 
-  <Match>
+  <Match> <!-- False Positive: These are intentional -->
     <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
     <Class name="org.apache.datasketches.sampling.EbppsItemsSample" />
-    <Method name="merge" />
+    <Or>
+      <Method name="merge" />
+      <Method name="downsample" />
+    </Or>
+  </Match>
+
+  <Match> <!-- False Positive: Application is single threaded. -->
+    <Bug pattern="SING_SINGLETON_GETTER_NOT_SYNCHRONIZED" />
+    <Class name="org.apache.datasketches.theta.EmptyCompactSketch"/>
+    <Method name="getHeapInstance" />
+  </Match>
+
+  <Match> <!-- False Positive: Code is the recommended solution for Finalizer Attack. -->
+    <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    <Or>
+      <Class name="org.apache.datasketches.tuple.arrayofdoubles.DirectArrayOfDoublesQuickSelectSketch"/>
+      <Class name="org.apache.datasketches.theta.DirectQuickSelectSketch"/>
+    </Or>
   </Match>
 
 </FindBugsFilter>

--- a/tools/FindBugsExcludeFilter.xml
+++ b/tools/FindBugsExcludeFilter.xml
@@ -79,4 +79,10 @@ under the License.
     <Class name="org.apache.datasketches.quantilescommon.GenericSortedViewIterator"/>
   </Match>
 
+  <Match>
+    <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
+    <Class name="org.apache.datasketches.sampling.EbppsItemsSample" />
+    <Method name="merge" />
+  </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
SpotBugs introduced the CT_CONSTRUCTOR_THROW detector recently (4.8.0, 2023-10-11), which is described as "Classes that throw exceptions in their constructors are vulnerable to Finalizer Attacks" (FA), which is a security issue.  We recently upgraded our version of SpotBugs from an older version to 4.8.4, which revealed a number of places in the library where the possibility of exceptions being thrown were inside constructors.  

We take security very seriously and certainly want to harden our classes against FA:  Some of the techniques to do this can be found in the following link, which are used in this PR:

[https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions](https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions)

Nonetheless, it is important to do a risk assessment to evaluate the seriousness of a FA in the context of our sketching library.  To the best of our knowledge (and we are not security experts), we have not been able to identify realistic scenarios where a FA would have any _increased_ access to internal sketch data that is not already available through current public methods or through normal reflection.  This also applies to the ability to insert code.  A number of our classes are explicitly designed to allow extension, whereby the user can extend a class and add almost any code they wish but with no higher levels of access than the sketch code itself, which has no access to other parts of the system.

The general use-case for our sketch library is usually deep inside a much larger system where "security" is generally managed at higher levels than where the actual sketches are deployed. To the extent that a sketch becomes directly vulnerable to an attack usually means that there are much more serious security issues at the higher levels in the system, which is outside of our control.

Thus, the "security" of sketches and of the data they might contain is very reliant on the systems context in which they are deployed.  