### PR TITLE
Improvements realized while analyzing Issue 514

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllDoublesHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesHelper.java
@@ -123,8 +123,7 @@ final class KllDoublesHelper {
   }
 
   //assumes readOnly = false and UPDATABLE, called from KllDoublesSketch::merge
-  static void mergeDoubleImpl(final KllDoublesSketch mySketch,
-      final KllDoublesSketch otherDblSk) {
+  static void mergeDoubleImpl(final KllDoublesSketch mySketch, final KllDoublesSketch otherDblSk) {
     if (otherDblSk.isEmpty()) { return; }
 
     //capture my key mutable fields before doing any merging
@@ -133,6 +132,8 @@ final class KllDoublesHelper {
     final double myMax = myEmpty ? Double.NaN : mySketch.getMaxItem();
     final int myMinK = mySketch.getMinK();
     final long finalN = mySketch.getN() + otherDblSk.getN();
+    assert finalN <= Long.MAX_VALUE && finalN >= 0 :
+      "The input count has exceeded the capacity of a long and the capability of this sketch.";
 
     //buffers that are referenced multiple times
     final int otherNumLevels = otherDblSk.getNumLevels();
@@ -400,6 +401,8 @@ final class KllDoublesHelper {
       // If we are at the current top level, add an empty level above it for convenience,
       // but do not increment numLevels until later
       if (curLevel == (numLevels - 1)) {
+        assert curLevel + 2 < 60 :
+          "The number of levels has exceeded the capability of this sketch.";
         inLevels[curLevel + 2] = inLevels[curLevel + 1];
       }
 

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesHelper.java
@@ -131,9 +131,7 @@ final class KllDoublesHelper {
     final double myMin = myEmpty ? Double.NaN : mySketch.getMinItem();
     final double myMax = myEmpty ? Double.NaN : mySketch.getMaxItem();
     final int myMinK = mySketch.getMinK();
-    final long finalN = mySketch.getN() + otherDblSk.getN();
-    assert finalN <= Long.MAX_VALUE && finalN >= 0 :
-      "The input count has exceeded the capacity of a long and the capability of this sketch.";
+    final long finalN = Math.addExact(mySketch.getN(), otherDblSk.getN());
 
     //buffers that are referenced multiple times
     final int otherNumLevels = otherDblSk.getNumLevels();
@@ -399,10 +397,8 @@ final class KllDoublesHelper {
       curLevel++; // start out at level 0
 
       // If we are at the current top level, add an empty level above it for convenience,
-      // but do not increment numLevels until later
+      // but do not actually increment numLevels until later
       if (curLevel == (numLevels - 1)) {
-        assert curLevel + 2 < 60 :
-          "The number of levels has exceeded the capability of this sketch.";
         inLevels[curLevel + 2] = inLevels[curLevel + 1];
       }
 

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -276,7 +276,8 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   @Override
   public final void merge(final KllSketch other) {
     if (readOnly || sketchStructure != UPDATABLE) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
-    final KllDoublesSketch othDblSk = (KllDoublesSketch)other; //check cast first
+    if (this == other) { throw new SketchesArgumentException(SELF_MERGE_MSG); }
+    final KllDoublesSketch othDblSk = (KllDoublesSketch)other;
     if (othDblSk.isEmpty()) { return; } //then check empty
     KllDoublesHelper.mergeDoubleImpl(this, othDblSk);
     kllDoublesSV = null;

--- a/src/main/java/org/apache/datasketches/kll/KllHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHelper.java
@@ -313,9 +313,9 @@ final class KllHelper {
    * @return the capacity of a specific level
    */
   static int levelCapacity(final int k, final int numLevels, final int level, final int m) {
-    assert (k <= (1 << 29));
-    assert (numLevels >= 1) && (numLevels <= 61);
-    assert (level >= 0) && (level < numLevels);
+    assert (k <= (1 << 29)) : "The given k is > 2^29.";
+    assert (numLevels >= 1) && (numLevels <= 61) : "The given numLevels is < 1 or > 61";
+    assert (level >= 0) && (level < numLevels) : "The given level is < 0 or >= numLevels.";
     final int depth = numLevels - level - 1; //depth is # levels from the top level (= 0)
     return (int) Math.max(m, intCapAux(k, depth));
   }

--- a/src/main/java/org/apache/datasketches/kll/KllHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHelper.java
@@ -632,7 +632,6 @@ final class KllHelper {
       //grow levels arr by one and copy the old data to the new array, extra space at the top.
       myNewLevelsArr = Arrays.copyOf(myCurLevelsArr, myCurNumLevels + 2);
       assert myNewLevelsArr.length == myCurLevelsArr.length + 1;
-      assert myNewLevelsArr.length <= 60 : "The number of levels has exceeded the capability of this sketch.";
       myNewNumLevels = myCurNumLevels + 1;
       sketch.incNumLevels(); //increment for off-heap
     } else {

--- a/src/main/java/org/apache/datasketches/kll/KllHelper.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHelper.java
@@ -632,6 +632,7 @@ final class KllHelper {
       //grow levels arr by one and copy the old data to the new array, extra space at the top.
       myNewLevelsArr = Arrays.copyOf(myCurLevelsArr, myCurNumLevels + 2);
       assert myNewLevelsArr.length == myCurLevelsArr.length + 1;
+      assert myNewLevelsArr.length <= 60 : "The number of levels has exceeded the capability of this sketch.";
       myNewNumLevels = myCurNumLevels + 1;
       sketch.incNumLevels(); //increment for off-heap
     } else {

--- a/src/main/java/org/apache/datasketches/quantilescommon/QuantilesAPI.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/QuantilesAPI.java
@@ -209,6 +209,7 @@ public interface QuantilesAPI {
   static String NOT_SINGLE_ITEM_MSG = "Sketch does not have just one item. ";
   static String MEM_REQ_SVR_NULL_MSG = "MemoryRequestServer must not be null. ";
   static String TGT_IS_READ_ONLY_MSG = "Target sketch is Read Only, cannot write. ";
+  static String SELF_MERGE_MSG = "A sketch cannot merge with itself. ";
 
   /**
    * Gets the user configured parameter k, which controls the accuracy of the sketch

--- a/src/test/java/org/apache/datasketches/common/Shuffle.java
+++ b/src/test/java/org/apache/datasketches/common/Shuffle.java
@@ -99,4 +99,22 @@ public final class Shuffle {
     array[i2] = value;
   }
 
+  /**
+   * Shuffle the given input array of type T
+   * @param array input array
+   */
+  public static <T> void shuffle(final T[] array) {
+    final int arrLen = array.length;
+    for (int i = 0; i < arrLen; i++) {
+      final int r = rand.nextInt(i + 1);
+      swap(array, i, r);
+    }
+  }
+
+  private static<T> void swap(final T[] array, final int i1, final int i2) {
+    final T value = array[i1];
+    array[i1] = array[i2];
+    array[i2] = value;
+  }
+
 }

--- a/src/test/java/org/apache/datasketches/common/Shuffle.java
+++ b/src/test/java/org/apache/datasketches/common/Shuffle.java
@@ -28,10 +28,19 @@ public final class Shuffle {
   private static final Random rand = new Random();
 
   /**
-   * Shuffle the given input float array
-   * @param array input array
+   * Shuffle the given input array using a default source of randomness.
+   * @param array the array to be shuffled.
    */
   public static void shuffle(final float[] array) {
+    shuffle(array, rand);
+  }
+
+  /**
+   * Shuffle the given input array using the given source of randomness.
+   * @param array the array to be shuffled.
+   * @param rand the source of randomness used to shuffle the list.
+   */
+  public static void shuffle(final float[] array, final Random rand) {
     final int arrLen = array.length;
     for (int i = 0; i < arrLen; i++) {
       final int r = rand.nextInt(i + 1);
@@ -46,10 +55,19 @@ public final class Shuffle {
   }
 
   /**
-   * Shuffle the given input double array
-   * @param array input array
+   * Shuffle the given input array using a default source of randomness.
+   * @param array the array to be shuffled.
    */
   public static void shuffle(final double[] array) {
+    shuffle(array, rand);
+  }
+
+  /**
+   * Shuffle the given input array using the given source of randomness.
+   * @param array the array to be shuffled.
+   * @param rand the source of randomness used to shuffle the list.
+   */
+  public static void shuffle(final double[] array, final Random rand) {
     final int arrLen = array.length;
     for (int i = 0; i < arrLen; i++) {
       final int r = rand.nextInt(i + 1);
@@ -64,10 +82,19 @@ public final class Shuffle {
   }
 
   /**
-   * Shuffle the given input long array
-   * @param array input array
+   * Shuffle the given input array using a default source of randomness.
+   * @param array the array to be shuffled.
    */
   public static void shuffle(final long[] array) {
+    shuffle(array, rand);
+  }
+
+  /**
+   * Shuffle the given input array using the given source of randomness.
+   * @param array the array to be shuffled.
+   * @param rand the source of randomness used to shuffle the list.
+   */
+  public static void shuffle(final long[] array, final Random rand) {
     final int arrLen = array.length;
     for (int i = 0; i < arrLen; i++) {
       final int r = rand.nextInt(i + 1);
@@ -82,10 +109,19 @@ public final class Shuffle {
   }
 
   /**
-   * Shuffle the given input int array
-   * @param array input array
+   * Shuffle the given input array using a default source of randomness.
+   * @param array the array to be shuffled.
    */
   public static void shuffle(final int[] array) {
+    shuffle(array, rand);
+  }
+
+  /**
+   * Shuffle the given input array using the given source of randomness.
+   * @param array the array to be shuffled.
+   * @param rand the source of randomness used to shuffle the list.
+   */
+  public static void shuffle(final int[] array, final Random rand) {
     final int arrLen = array.length;
     for (int i = 0; i < arrLen; i++) {
       final int r = rand.nextInt(i + 1);
@@ -100,10 +136,21 @@ public final class Shuffle {
   }
 
   /**
-   * Shuffle the given input array of type T
-   * @param array input array
+   * Shuffle the given input array using a default source of randomness.
+   * @param array the array to be shuffled.
+   * @param <T> the component type of the given array.
    */
   public static <T> void shuffle(final T[] array) {
+    shuffle(array, rand);
+  }
+
+  /**
+   * Shuffle the given input array using the given source of randomness.
+   * @param array the array to be shuffled.
+   * @param rand the source of randomness used to shuffle the list.
+   * @param <T> the component type of the given array.
+   */
+  public static <T> void shuffle(final T[] array, final Random rand) {
     final int arrLen = array.length;
     for (int i = 0; i < arrLen; i++) {
       final int r = rand.nextInt(i + 1);


### PR DESCRIPTION
While analyzing Issue 514, I realized that adding a few new asserts and/or exceptions would be very helpful to users and to us when debugging.  Specifically, they consist of 3 different detections:
- Throwing an exception if a self-merge is detected. This is an easy-to-make user error and warrants an exception.

These next two should be very rare, but are also directly in the update path, so I think an _assert_ is more appropriate.
- Throwing an AssertionError if N (the number of items input into the sketch) exceeds Long.MAX_VALUE.
- Throwing an AssertionError if the number of levels exceed 60

Note that these new assertions and exception have only been implemented so far in KLL Doubles.  Implementation into the other sketches will be a later PR in order to keep the size of the PRs down.

I also realized that our built-in shuffle class could be improved by allowing generic arrays to be shuffled and also providing the option of a user-provided Random generator instead of only the internal default. 