### PR TITLE
Fixing SpotBugs exclusions in the /tools/FindBugsExcludeFilter.xml.

### DIFF
--- a/src/main/java/org/apache/datasketches/hll/AbstractHllArray.java
+++ b/src/main/java/org/apache/datasketches/hll/AbstractHllArray.java
@@ -246,7 +246,7 @@ abstract class AbstractHllArray extends HllSketchImpl {
     //update kxq0 and kxq1; subtract first, then add.
     if (oldValue < 32) { host.putKxQ0(kxq0 -= invPow2(oldValue)); }
     else               { host.putKxQ1(kxq1 -= invPow2(oldValue)); }
-    if (newValue < 32) { host.putKxQ0(kxq0 += invPow2(newValue)); }
-    else               { host.putKxQ1(kxq1 += invPow2(newValue)); }
+    if (newValue < 32) { host.putKxQ0(kxq0 + invPow2(newValue)); }
+    else               { host.putKxQ1(kxq1 + invPow2(newValue)); }
   }
 }

--- a/src/main/java/org/apache/datasketches/kll/KllDirectDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectDoublesSketch.java
@@ -286,8 +286,7 @@ class KllDirectDoublesSketch extends KllDoublesSketch {
   @Override
   void incN() {
     if (readOnly) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
-    long n = getMemoryN(wmem);
-    setMemoryN(wmem, ++n);
+    setMemoryN(wmem, getMemoryN(wmem) + 1);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/kll/KllDirectFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectFloatsSketch.java
@@ -286,8 +286,7 @@ class KllDirectFloatsSketch extends KllFloatsSketch {
   @Override
   void incN() {
     if (readOnly) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
-    long n = getMemoryN(wmem);
-    setMemoryN(wmem, ++n);
+    setMemoryN(wmem, getMemoryN(wmem) + 1);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/quantilescommon/GenericPartitionBoundaries.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/GenericPartitionBoundaries.java
@@ -48,9 +48,9 @@ final public class GenericPartitionBoundaries<T> implements PartitionBoundaries 
       final T minItem,
       final QuantileSearchCriteria searchCrit) {
     this.totalN = totalN;
-    this.boundaries = boundaries; //SpotBugs copy
-    this.natRanks = natRanks;
-    this.normRanks = normRanks;
+    this.boundaries = boundaries; //SpotBugs EI_EXPOSE_REP2 copying from sketch class to this "friend" class.
+    this.natRanks = natRanks;     // "
+    this.normRanks = normRanks;   // "
     this.maxItem = maxItem;
     this.minItem = minItem;
     this.searchCrit = searchCrit;
@@ -98,16 +98,16 @@ final public class GenericPartitionBoundaries<T> implements PartitionBoundaries 
    *
    * @return an array of boundaries that sequentially define the upper and lower boundaries of partitions.
    */
-  public T[] getBoundaries() { return boundaries; }
+  public T[] getBoundaries() { return boundaries.clone(); }
 
   @Override
-  public long[] getNaturalRanks() { return natRanks; }
+  public long[] getNaturalRanks() { return natRanks.clone(); }
 
   @Override
-  public double[] getNormalizedRanks() { return normRanks; }
+  public double[] getNormalizedRanks() { return normRanks.clone(); }
 
   @Override
-  public long[] getNumDeltaItems() { return numDeltaItems; }
+  public long[] getNumDeltaItems() { return numDeltaItems.clone(); }
 
   @Override
   public int getNumPartitions() { return numPartitions; }

--- a/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
@@ -41,12 +41,12 @@ final class EmptyCompactSketch extends CompactSketch {
 
   private EmptyCompactSketch() {}
 
-  static EmptyCompactSketch getInstance() {
+  static synchronized EmptyCompactSketch getInstance() {
     return EMPTY_COMPACT_SKETCH;
   }
 
   //This should be a heapify
-  static EmptyCompactSketch getHeapInstance(final Memory srcMem) {
+  static synchronized EmptyCompactSketch getHeapInstance(final Memory srcMem) {
     final long pre0 = srcMem.getLong(0);
     if (testCandidatePre0(pre0)) {
       return EMPTY_COMPACT_SKETCH;

--- a/tools/FindBugsExcludeFilter.xml
+++ b/tools/FindBugsExcludeFilter.xml
@@ -29,57 +29,26 @@ under the License.
     <Class name="~.*\.*TestUtil" />
   </Match>
 
-  <!-- Harmless, Too many False Positives May 2, 2023-->
-  <Match>
-    <Bug pattern="PZLA_PREFER_ZERO_LENGTH_ARRAYS" />
-  </Match>
-
-  <!-- Harmless, Too many False Positives May 2, 2023-->
-  <Match>
-    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
-  </Match>
-
-  <!-- Harmless, Too many False Positives May 2, 2023-->
-  <Match>
-    <Bug pattern="BIT_SIGNED_CHECK" />
-  </Match>
-
-  <!-- Harmless, Too many False Positives May 2, 2023 -->
+  <!-- Harmless, False Positive Mar 6, 2024. Alex may fix this. -->
   <Match>   
     <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+    <Class name="org.apache.datasketches.tdigest.TDigestDouble"/>
+    <Method name="merge" />
   </Match>
 
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP"/>
-    <Class name="org.apache.datasketches.quantilescommon.GenericPartitionBoundaries"/>
-  </Match>
-
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-    <Class name="org.apache.datasketches.quantilescommon.FloatsSortedViewIterator"/>
-  </Match>
-
+  <!-- Complaining about copying of arrays from one internal class to another. 
+       This is harmless since both classes are part of our library and work together. -->
   <Match>
     <Bug pattern="EI_EXPOSE_REP2"/>
-    <Class name="org.apache.datasketches.quantilescommon.DoublesSortedViewIterator"/>
-  </Match>
-  
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-    <Class name="org.apache.datasketches.quantilescommon.GenericSortedViewIterator"/>
-  </Match>
-
-  <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-    <Class name="org.apache.datasketches.quantilescommon.GenericPartitionBoundaries"/>
+    <Or>
+      <Class name="org.apache.datasketches.quantilescommon.FloatsSortedViewIterator"/>
+      <Class name="org.apache.datasketches.quantilescommon.DoublesSortedViewIterator"/>
+      <Class name="org.apache.datasketches.quantilescommon.GenericSortedViewIterator"/>
+      <Class name="org.apache.datasketches.quantilescommon.GenericPartitionBoundaries"/>
+    </Or>
   </Match>
 
-  <Match> <!-- False Positive: Inside scope of TWR -->
-    <Bug pattern="OBL_UNSATISFIED_OBLIGATION" />
-    <Class name="org.apache.datasketches.quantilescommon.GenericSortedViewIterator"/>
-  </Match>
-
-  <Match> <!-- False Positive: These are intentional -->
+  <Match> <!-- False Positive: These are intentional and we know what we are doing. -->
     <Bug pattern="FE_FLOATING_POINT_EQUALITY" />
     <Class name="org.apache.datasketches.sampling.EbppsItemsSample" />
     <Or>
@@ -88,13 +57,7 @@ under the License.
     </Or>
   </Match>
 
-  <Match> <!-- False Positive: Application is single threaded. -->
-    <Bug pattern="SING_SINGLETON_GETTER_NOT_SYNCHRONIZED" />
-    <Class name="org.apache.datasketches.theta.EmptyCompactSketch"/>
-    <Method name="getHeapInstance" />
-  </Match>
-
-  <Match> <!-- False Positive: Code is the recommended solution for Finalizer Attack. -->
+  <Match> <!-- False Positive: Code is the recommended solution for preventing a Finalizer Attack. -->
     <Bug pattern="CT_CONSTRUCTOR_THROW" />
     <Or>
       <Class name="org.apache.datasketches.tuple.arrayofdoubles.DirectArrayOfDoublesQuickSelectSketch"/>


### PR DESCRIPTION
Some of these were no longer needed because newer versions of SpotBugs have fixed earlier False Positive detections.

I was able to fix some just by getting a better understanding of what SpotBugs was complaining about.  Some of it was pretty subtle.

Nonetheless, this is a much shorter list of exclusions than what we had before.