### PR TITLE
Fix out-of-order imports and missing finals in PR 533.

### DIFF
--- a/src/main/java/org/apache/datasketches/theta/Union.java
+++ b/src/main/java/org/apache/datasketches/theta/Union.java
@@ -19,11 +19,11 @@
 
 package org.apache.datasketches.theta;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
-
-import java.nio.ByteBuffer;
 
 /**
  * Compute the union of two or more theta sketches.

--- a/src/main/java/org/apache/datasketches/theta/UnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/UnionImpl.java
@@ -38,6 +38,8 @@ import static org.apache.datasketches.theta.PreambleUtil.insertUnionThetaLong;
 import static org.apache.datasketches.theta.SingleItemSketch.otherCheckForSingleItem;
 import static org.apache.datasketches.thetacommon.QuickSelect.selectExcludingZeros;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -46,8 +48,6 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.HashOperations;
 import org.apache.datasketches.thetacommon.ThetaUtil;
-
-import java.nio.ByteBuffer;
 
 /**
  * Shared code for the HeapUnion and DirectUnion implementations.
@@ -483,7 +483,7 @@ final class UnionImpl extends Union {
   }
 
   @Override
-  public void update(ByteBuffer data) {
+  public void update(final ByteBuffer data) {
     gadget_.update(data);
   }
 

--- a/src/main/java/org/apache/datasketches/theta/UpdateSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/UpdateSketch.java
@@ -284,7 +284,7 @@ public abstract class UpdateSketch extends Sketch {
    * @return
    * <a href="{@docRoot}/resources/dictionary.html#updateReturnState">See Update Return State</a>
    */
-  public UpdateReturnState update(ByteBuffer buffer) {
+  public UpdateReturnState update(final ByteBuffer buffer) {
     if (buffer == null || buffer.hasRemaining() == false) {
       return RejectedNullOrEmpty;
     }

--- a/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/UpdatableSketch.java
@@ -19,11 +19,11 @@
 
 package org.apache.datasketches.tuple;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.hash.MurmurHash3;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
-
-import java.nio.ByteBuffer;
 
 /**
  * An extension of QuickSelectSketch&lt;S&gt;, which can be updated with many types of keys.

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUpdatableSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesUpdatableSketch.java
@@ -19,14 +19,14 @@
 
 package org.apache.datasketches.tuple.arrayofdoubles;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.hash.MurmurHash3;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
 import org.apache.datasketches.tuple.Util;
-
-import java.nio.ByteBuffer;
 
 /**
  * The top level for updatable tuple sketches of type ArrayOfDoubles.

--- a/src/test/java/org/apache/datasketches/theta/UpdateSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UpdateSketchTest.java
@@ -30,18 +30,16 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.DefaultMemoryRequestServer;
-import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
 import org.testng.annotations.Test;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * @author Lee Rhodes

--- a/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/adouble/AdoubleTest.java
@@ -21,20 +21,19 @@ package org.apache.datasketches.tuple.adouble;
 
 import static org.testng.Assert.assertEquals;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.tuple.Sketch;
-import org.apache.datasketches.tuple.TupleSketchIterator;
 import org.apache.datasketches.tuple.Sketches;
+import org.apache.datasketches.tuple.TupleSketchIterator;
 import org.apache.datasketches.tuple.UpdatableSketch;
 import org.apache.datasketches.tuple.UpdatableSketchBuilder;
 import org.apache.datasketches.tuple.adouble.DoubleSummary.Mode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 public class AdoubleTest {
   private final DoubleSummary.Mode mode = Mode.Sum;

--- a/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesQuickSelectSketchTest.java
@@ -19,15 +19,13 @@
 
 package org.apache.datasketches.tuple.arrayofdoubles;
 
+import java.nio.ByteBuffer;
+
 import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
-import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 public class DirectArrayOfDoublesQuickSelectSketchTest {
   @Test


### PR DESCRIPTION
Alan was not aware of these Checkstyle rules.
Not a big deal, they are easy to fix.