### PR TITLE
Implemented Inclusion of min/max for Floats, Doubles and Items Sorted Views.

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllDirectCompactItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectCompactItemsSketch.java
@@ -90,8 +90,10 @@ final class KllDirectCompactItemsSketch<T> extends KllItemsSketch<T> {
       return serDe.deserializeFromMemory(mem, DATA_START_ADR_SINGLE_ITEM, 1)[0];
     }
     //sketchStructure == COMPACT_FULL
-    final int offset = DATA_START_ADR + getNumLevels() * Integer.BYTES;
-    return serDe.deserializeFromMemory(mem, offset, 2)[1];
+    final int baseOffset = DATA_START_ADR + getNumLevels() * Integer.BYTES;
+    final int offset = baseOffset + serDe.sizeOf(mem, baseOffset, 1); //size of minItem
+
+    return serDe.deserializeFromMemory(mem, offset, 1)[0];
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -561,7 +561,7 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
       cumWeights = new long[numQuantiles];
       populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);
       return new DoublesSketchSortedView(
-          quantiles, cumWeights, getN(), getMaxItemInternal(), getMinItemInternal());
+          quantiles, cumWeights, KllDoublesSketch.this);
     }
 
     private void populateFromSketch(final double[] srcQuantiles, final int[] srcLevels,

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -560,8 +560,7 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
       quantiles = new float[numQuantiles];
       cumWeights = new long[numQuantiles];
       populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);
-      return new FloatsSketchSortedView(
-          quantiles, cumWeights, getN(), getMaxItemInternal(), getMinItemInternal());
+      return new FloatsSketchSortedView(quantiles, cumWeights, KllFloatsSketch.this);
     }
 
     private void populateFromSketch(final float[] srcQuantiles, final int[] srcLevels,

--- a/src/main/java/org/apache/datasketches/kll/KllHeapDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllHeapDoublesSketch.java
@@ -286,7 +286,7 @@ final class KllHeapDoublesSketch extends KllDoublesSketch {
   void setDoubleItemsArrayAt(final int index, final double item) { this.doubleItems[index] = item; }
 
   @Override
-  void setDoubleItemsArrayAt(final int dstIndex, final double[] srcItems, final int srcOffset, final int length) { //TODO
+  void setDoubleItemsArrayAt(final int dstIndex, final double[] srcItems, final int srcOffset, final int length) {
     System.arraycopy(srcItems, srcOffset, doubleItems, dstIndex, length);
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
@@ -297,7 +297,7 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   @Override
   public String toString(final boolean withLevels, final boolean withLevelsAndItems) {
     KllSketch sketch = this;
-    if (withLevelsAndItems && sketchStructure != UPDATABLE) {
+    if (hasMemory()) {
       final Memory mem = getWritableMemory();
       assert mem != null;
       sketch = KllItemsSketch.heapify((Memory)getWritableMemory(), comparator, serDe);
@@ -422,49 +422,50 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   @SuppressWarnings({"rawtypes"})
   private final class CreateSortedView {
     T[] quantiles;
-    long[] cumWeights;
+    long[] cumWeights; //The new cumWeights array
 
     ItemsSketchSortedView<T> getSV() {
-      if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
-      if (getN() == 0) { throw new SketchesArgumentException(EMPTY_MSG); }
+      if (isEmpty() || getN() == 0) { throw new SketchesArgumentException(EMPTY_MSG); }
       final T[] srcQuantiles = getTotalItemsArray();
-      final int[] srcLevels = levelsArr;
+      final int[] srcLevelsArr = levelsArr;
       final int srcNumLevels = getNumLevels();
 
       if (!isLevelZeroSorted()) {
-        Arrays.sort(srcQuantiles, srcLevels[0], srcLevels[1], comparator);
+        Arrays.sort(srcQuantiles, srcLevelsArr[0], srcLevelsArr[1], comparator);
         if (!hasMemory()) { setLevelZeroSorted(true); }
       }
       final int numQuantiles = getNumRetained();
       quantiles = (T[]) Array.newInstance(serDe.getClassOfT(), numQuantiles);
       cumWeights = new long[numQuantiles];
-      populateFromSketch(srcQuantiles, srcLevels, srcNumLevels, numQuantiles);
+      populateFromSketch(srcQuantiles, srcLevelsArr, srcNumLevels, numQuantiles);
       final QuantilesGenericAPI<T> sk = KllItemsSketch.this;
       return new ItemsSketchSortedView(quantiles, cumWeights, sk);
     }
 
-    private void populateFromSketch(final Object[] srcQuantiles, final int[] srcLevels,
+    private void populateFromSketch(final Object[] srcQuantiles, final int[] srcLevelsArr,
         final int srcNumLevels, final int numItems) {
-        final int[] myLevels = new int[srcNumLevels + 1];
-        final int offset = srcLevels[0];
-        System.arraycopy(srcQuantiles, offset, quantiles, 0, numItems);
+        //Remove free space from both itemsArray and levels array
+        final int[] myLevelsArr = new int[srcLevelsArr.length];
+        final int offset = srcLevelsArr[0];
+        System.arraycopy(srcQuantiles, offset, quantiles, 0, numItems); //remove free space from quantiles arr
+        //fill the new cumWeights array with the correct weights and adjust the levels array to match.
         int srcLevel = 0;
         int dstLevel = 0;
         long weight = 1;
         while (srcLevel < srcNumLevels) {
-          final int fromIndex = srcLevels[srcLevel] - offset;
-          final int toIndex = srcLevels[srcLevel + 1] - offset; // exclusive
+          final int fromIndex = srcLevelsArr[srcLevel] - offset;
+          final int toIndex = srcLevelsArr[srcLevel + 1] - offset; // exclusive
           if (fromIndex < toIndex) { // if equal, skip empty level
             Arrays.fill(cumWeights, fromIndex, toIndex, weight);
-            myLevels[dstLevel] = fromIndex;
-            myLevels[dstLevel + 1] = toIndex;
+            myLevelsArr[dstLevel] = fromIndex;
+            myLevelsArr[dstLevel + 1] = toIndex;
             dstLevel++;
           }
           srcLevel++;
           weight *= 2;
         }
         final int numLevels = dstLevel;
-        blockyTandemMergeSort(quantiles, cumWeights, myLevels, numLevels, comparator); //create unit weights
+        blockyTandemMergeSort(quantiles, cumWeights, myLevelsArr, numLevels, comparator); //create unit weights
         KllHelper.convertToCumulative(cumWeights);
       }
   } //End of class CreateSortedView

--- a/src/main/java/org/apache/datasketches/kll/KllMemoryValidate.java
+++ b/src/main/java/org/apache/datasketches/kll/KllMemoryValidate.java
@@ -174,7 +174,7 @@ final class KllMemoryValidate {
     final int levelsLen = updatable ? levelsArr.length : levelsArr.length - 1;
     final int numItems = updatable ? capacityItems : retainedItems;
 
-    int offsetBytes = DATA_START_ADR + levelsLen * Integer.BYTES;
+    int offsetBytes = DATA_START_ADR + levelsLen * Integer.BYTES; //levels array
     if (sketchType == ITEMS_SKETCH) {
       if (serDe instanceof ArrayOfBooleansSerDe) {
         offsetBytes += serDe.sizeOf(srcMem, offsetBytes, numItems) + 2; //2 for min & max

--- a/src/main/java/org/apache/datasketches/quantiles/DoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/quantiles/DoublesSketch.java
@@ -597,7 +597,7 @@ public abstract class DoublesSketch implements QuantilesDoublesAPI {
     if (convertToCumulative(svCumWeights) != totalN) {
       throw new SketchesStateException("Sorted View is misconfigured. TotalN does not match cumWeights.");
     }
-    return new DoublesSketchSortedView(svQuantiles, svCumWeights, totalN, getMaxItem(), getMinItem());
+    return new DoublesSketchSortedView(svQuantiles, svCumWeights, this);
   }
 
   private final static void populateFromDoublesSketch(

--- a/src/main/java/org/apache/datasketches/quantiles/ItemsUtil.java
+++ b/src/main/java/org/apache/datasketches/quantiles/ItemsUtil.java
@@ -80,7 +80,6 @@ final class ItemsUtil {
     assert (n / (2L * sketch.getK())) == sketch.getBitPattern();  // internal consistency check
   }
 
-  //TODO change booleans to "withLevels", "withLevelsAndItems"
   static <T> String toString(final boolean withLevels, final boolean withLevelsAndItems,
       final ItemsSketch<T> sk) {
     final StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/datasketches/quantilescommon/GenericSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/GenericSortedView.java
@@ -145,13 +145,11 @@ public interface GenericSortedView<T>  extends PartitioningFeature<T>, SketchPar
    * @return a PMF array of m+1 probability masses as doubles on the interval [0.0, 1.0].
    * @throws IllegalArgumentException if sketch is empty.
    */
-  //double[] getPMF(T[] splitPoints,  QuantileSearchCriteria searchCrit);
   default double[] getPMF(final T[] splitPoints, final QuantileSearchCriteria searchCrit) {
     if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
     GenericSortedView.validateItems(splitPoints, getComparator());
     final double[] buckets = getCDF(splitPoints, searchCrit);
-    final int len = buckets.length;
-    for (int i = len; i-- > 1; ) {
+    for (int i = buckets.length; i-- > 1; ) {
       buckets[i] -= buckets[i - 1];
     }
     return buckets;

--- a/src/main/java/org/apache/datasketches/quantilescommon/GenericSortedView.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/GenericSortedView.java
@@ -19,6 +19,8 @@
 
 package org.apache.datasketches.quantilescommon;
 
+import static org.apache.datasketches.quantilescommon.QuantilesAPI.EMPTY_MSG;
+
 import java.util.Comparator;
 
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -67,7 +69,23 @@ public interface GenericSortedView<T>  extends PartitioningFeature<T>, SketchPar
    * @return a discrete CDF array of m+1 double ranks (or cumulative probabilities) on the interval [0.0, 1.0].
    * @throws IllegalArgumentException if sketch is empty.
    */
-  double[] getCDF(T[] splitPoints, QuantileSearchCriteria searchCrit);
+  default double[] getCDF(final T[] splitPoints, final QuantileSearchCriteria searchCrit) {
+    if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
+    GenericSortedView.validateItems(splitPoints, getComparator());
+    final int len = splitPoints.length + 1;
+    final double[] buckets = new double[len];
+    for (int i = 0; i < len - 1; i++) {
+      buckets[i] = getRank(splitPoints[i], searchCrit);
+    }
+    buckets[len - 1] = 1.0;
+    return buckets;
+  }
+
+  /**
+   * Gets the Comparator for this generic type.
+   * @return the Comparator for this generic type.
+   */
+  Comparator<? super T> getComparator();
 
   /**
    * Returns the maximum item of the stream. This may be distinct from the largest item retained by the
@@ -127,7 +145,17 @@ public interface GenericSortedView<T>  extends PartitioningFeature<T>, SketchPar
    * @return a PMF array of m+1 probability masses as doubles on the interval [0.0, 1.0].
    * @throws IllegalArgumentException if sketch is empty.
    */
-  double[] getPMF(T[] splitPoints,  QuantileSearchCriteria searchCrit);
+  //double[] getPMF(T[] splitPoints,  QuantileSearchCriteria searchCrit);
+  default double[] getPMF(final T[] splitPoints, final QuantileSearchCriteria searchCrit) {
+    if (isEmpty()) { throw new SketchesArgumentException(EMPTY_MSG); }
+    GenericSortedView.validateItems(splitPoints, getComparator());
+    final double[] buckets = getCDF(splitPoints, searchCrit);
+    final int len = buckets.length;
+    for (int i = len; i-- > 1; ) {
+      buckets[i] -= buckets[i - 1];
+    }
+    return buckets;
+  }
 
   /**
    * Gets the approximate quantile of the given normalized rank and the given search criterion.

--- a/src/main/java/org/apache/datasketches/quantilescommon/IncludeMinMax.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/IncludeMinMax.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.quantilescommon;
+
+import java.lang.reflect.Array;
+import java.util.Comparator;
+
+/**
+ * This class reinserts the min and max values into the sorted view arrays as required.
+ */
+public class IncludeMinMax {
+
+  public static class DoublesPair {
+    public double[] quantiles;
+    public long[] cumWeights;
+
+    public DoublesPair(final double[] quantiles, final long[] cumWeights) {
+      this.quantiles = quantiles;
+      this.cumWeights = cumWeights;
+    }
+  }
+
+  public static class FloatsPair {
+    public float[] quantiles;
+    public long[] cumWeights;
+
+    public FloatsPair(final float[] quantiles, final long[] cumWeights) {
+      this.quantiles = quantiles;
+      this.cumWeights = cumWeights;
+    }
+  }
+
+  public static class ItemsPair<T> {
+    public T[] quantiles;
+    public long[] cumWeights;
+
+    public ItemsPair(final T[] quantiles, final long[] cumWeights) {
+      this.quantiles = quantiles;
+      this.cumWeights = cumWeights;
+    }
+  }
+
+  public static DoublesPair includeDoublesMinMax(
+      final double[] quantilesIn,
+      final long[] cumWeightsIn,
+      final double maxItem,
+      final double minItem) {
+    final int lenIn = cumWeightsIn.length;
+    final boolean adjLow = quantilesIn[0] != minItem; //if true, adjust the low end
+    final boolean adjHigh = quantilesIn[lenIn - 1] != maxItem; //if true, adjust the high end
+    int adjLen = lenIn; //this will be the length of the local copies of quantiles and cumWeights
+    adjLen += adjLow ? 1 : 0;
+    adjLen += adjHigh ? 1 : 0;
+    final double[] adjQuantiles;
+    final long[] adjCumWeights;
+    if (adjLen > lenIn) { //is any adjustment required at all?
+      adjQuantiles = new double[adjLen];
+      adjCumWeights = new long[adjLen];
+      final int offset = adjLow ? 1 : 0;
+      System.arraycopy(quantilesIn, 0, adjQuantiles, offset, lenIn);
+      System.arraycopy(cumWeightsIn,0, adjCumWeights, offset, lenIn);
+
+      //Adjust the low end if required.
+      if (adjLow) {
+        adjQuantiles[0] = minItem;
+        adjCumWeights[0] = 1;
+      }
+
+      if (adjHigh) {
+        adjQuantiles[adjLen - 1] = maxItem;
+        adjCumWeights[adjLen - 1] = cumWeightsIn[lenIn - 1];
+        adjCumWeights[adjLen - 2] = cumWeightsIn[lenIn - 1] - 1;
+      }
+    } else { //both min and max are already in place, no adjustments are required.
+      adjQuantiles = quantilesIn;
+      adjCumWeights = cumWeightsIn;
+
+    } //END of Adjust End Points
+    return new DoublesPair(adjQuantiles, adjCumWeights);
+  }
+
+  public static FloatsPair includeFloatsMinMax(
+      final float[] quantilesIn,
+      final long[] cumWeightsIn,
+      final float maxItem,
+      final float minItem) {
+    final int lenIn = cumWeightsIn.length;
+    final boolean adjLow = quantilesIn[0] != minItem; //if true, adjust the low end
+    final boolean adjHigh = quantilesIn[lenIn - 1] != maxItem; //if true, adjust the high end
+    int adjLen = lenIn; //this will be the length of the local copies of quantiles and cumWeights
+    adjLen += adjLow ? 1 : 0;
+    adjLen += adjHigh ? 1 : 0;
+    final float[] adjQuantiles;
+    final long[] adjCumWeights;
+    if (adjLen > lenIn) { //is any adjustment required at all?
+      adjQuantiles = new float[adjLen];
+      adjCumWeights = new long[adjLen];
+      final int offset = adjLow ? 1 : 0;
+      System.arraycopy(quantilesIn, 0, adjQuantiles, offset, lenIn);
+      System.arraycopy(cumWeightsIn,0, adjCumWeights, offset, lenIn);
+
+      //Adjust the low end if required.
+      if (adjLow) {
+        adjQuantiles[0] = minItem;
+        adjCumWeights[0] = 1;
+      }
+
+      if (adjHigh) {
+        adjQuantiles[adjLen - 1] = maxItem;
+        adjCumWeights[adjLen - 1] = cumWeightsIn[lenIn - 1];
+        adjCumWeights[adjLen - 2] = cumWeightsIn[lenIn - 1] - 1;
+      }
+    } else { //both min and max are already in place, no adjustments are required.
+      adjQuantiles = quantilesIn;
+      adjCumWeights = cumWeightsIn;
+
+    } //END of Adjust End Points
+    return new FloatsPair(adjQuantiles, adjCumWeights);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> ItemsPair<T> includeItemsMinMax(
+      final T[] quantilesIn,
+      final long[] cumWeightsIn,
+      final T maxItem,
+      final T minItem,
+      final Comparator<? super T> comparator) {
+    final int lenIn = cumWeightsIn.length;
+    final boolean adjLow = comparator.compare(quantilesIn[0], minItem) != 0; //if true, adjust the low end
+    final boolean adjHigh = comparator.compare(quantilesIn[lenIn - 1], maxItem) != 0; //if true, adjust the high end
+    int adjLen = lenIn; //this will be the length of the local copies of quantiles and cumWeights
+    adjLen += adjLow ? 1 : 0;
+    adjLen += adjHigh ? 1 : 0;
+    final T[] adjQuantiles;
+    final long[] adjCumWeights;
+    if (adjLen > lenIn) { //is any adjustment required at all?
+      adjQuantiles = (T[]) Array.newInstance(minItem.getClass(), adjLen);
+      adjCumWeights = new long[adjLen];
+      final int offset = adjLow ? 1 : 0;
+      System.arraycopy(quantilesIn, 0, adjQuantiles, offset, lenIn);
+      System.arraycopy(cumWeightsIn,0, adjCumWeights, offset, lenIn);
+
+      //Adjust the low end if required.
+      if (adjLow) {
+        adjQuantiles[0] = minItem;
+        adjCumWeights[0] = 1;
+      }
+
+      if (adjHigh) {
+        adjQuantiles[adjLen - 1] = maxItem;
+        adjCumWeights[adjLen - 1] = cumWeightsIn[lenIn - 1];
+        adjCumWeights[adjLen - 2] = cumWeightsIn[lenIn - 1] - 1;
+      }
+    } else { //both min and max are already in place, no adjustments are required.
+      adjQuantiles = quantilesIn;
+      adjCumWeights = cumWeightsIn;
+
+    } //END of Adjust End Points
+    return new ItemsPair<>(adjQuantiles, adjCumWeights);
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/quantilescommon/IncludeMinMax.java
+++ b/src/main/java/org/apache/datasketches/quantilescommon/IncludeMinMax.java
@@ -77,7 +77,7 @@ public class IncludeMinMax {
       System.arraycopy(quantilesIn, 0, adjQuantiles, offset, lenIn);
       System.arraycopy(cumWeightsIn,0, adjCumWeights, offset, lenIn);
 
-      //Adjust the low end if required.
+      //Adjust the low end if required. Don't need to adjust weight of next one because it is cumulative.
       if (adjLow) {
         adjQuantiles[0] = minItem;
         adjCumWeights[0] = 1;

--- a/src/main/java/org/apache/datasketches/req/ReqSketch.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSketch.java
@@ -594,8 +594,7 @@ public final class ReqSketch extends BaseReqSketch {
         count += bufInLen;
       }
       createCumulativeNativeRanks();
-      return new FloatsSketchSortedView(
-          quantiles, cumWeights, getN(), getMaxItem(), getMinItem());
+      return new FloatsSketchSortedView(quantiles, cumWeights, ReqSketch.this);
     }
 
     /**

--- a/src/test/java/org/apache/datasketches/kll/KllDirectCompactItemsSketchIteratorTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDirectCompactItemsSketchIteratorTest.java
@@ -31,10 +31,12 @@ import org.apache.datasketches.common.ArrayOfStringsSerDe;
 import org.apache.datasketches.common.Util;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.quantilescommon.GenericSortedViewIterator;
+import org.apache.datasketches.quantilescommon.ItemsSketchSortedView;
 import org.apache.datasketches.quantilescommon.QuantilesGenericSketchIterator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("unused")
 public class KllDirectCompactItemsSketchIteratorTest {
   private ArrayOfStringsSerDe serDe = new ArrayOfStringsSerDe();
 
@@ -84,13 +86,15 @@ public class KllDirectCompactItemsSketchIteratorTest {
 
   @Test
   public void twoItemSketchForSortedViewIterator() {
-    KllItemsSketch<String> sk = KllItemsSketch.newHeapInstance(Comparator.naturalOrder(), serDe);
+    KllItemsSketch<String> sk = KllItemsSketch.newHeapInstance(20, Comparator.naturalOrder(), serDe);
     sk.update("1");
     sk.update("2");
+    println(sk.toString(true, true));
     byte[] byteArr = sk.toByteArray();
     KllItemsSketch<String> sk2 = KllItemsSketch.wrap(Memory.wrap(byteArr), Comparator.naturalOrder(), serDe);
     assertTrue(sk2 instanceof KllDirectCompactItemsSketch);
-    GenericSortedViewIterator<String> itr = sk2.getSortedView().iterator();
+    ItemsSketchSortedView<String> sv = sk2.getSortedView();
+    GenericSortedViewIterator<String> itr = sv.iterator();
 
     assertTrue(itr.next());
 
@@ -133,4 +137,22 @@ public class KllDirectCompactItemsSketchIteratorTest {
       Assert.assertEquals(weight, n);
     }
   }
+
+  private final static boolean enablePrinting = false;
+
+  /**
+   * @param format the format
+   * @param args the args
+   */
+  private static final void printf(final String format, final Object ...args) {
+    if (enablePrinting) { System.out.printf(format, args); }
+  }
+
+  /**
+   * @param o the Object to println
+   */
+  private static final void println(final Object o) {
+    if (enablePrinting) { System.out.println(o.toString()); }
+  }
+
 }

--- a/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscDoublesTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.datasketches.kll;
 
+import static org.apache.datasketches.common.Util.LS;
 import static org.apache.datasketches.common.Util.bitAt;
-import static org.apache.datasketches.kll.KllHelper.getGrowthSchemeForGivenN;
 import static org.apache.datasketches.kll.KllSketch.SketchType.DOUBLES_SKETCH;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
 import static org.testng.Assert.assertEquals;
@@ -30,7 +30,6 @@ import static org.testng.Assert.fail;
 
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.kll.KllDirectDoublesSketch.KllDirectCompactDoublesSketch;
-import org.apache.datasketches.kll.KllSketch.SketchType;
 import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
@@ -42,9 +41,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("unused")
 public class KllMiscDoublesTest {
-  static final String LS = System.getProperty("line.separator");
   private final MemoryRequestServer memReqSvr = new DefaultMemoryRequestServer();
 
   @Test
@@ -155,7 +152,7 @@ public class KllMiscDoublesTest {
     final KllDoublesSketch sk2 = KllDoublesSketch.newHeapInstance(20);
     n = 400;
     for (int i = 101; i <= n + 100; i++) { sk2.update(i); }
-    println("\n" + sk2.toString(true, true));
+    println(LS + sk2.toString(true, true));
     assertEquals(sk2.getNumLevels(), 5);
     assertEquals(sk2.getMinItem(), 101);
     assertEquals(sk2.getMaxItem(), 500);
@@ -228,15 +225,16 @@ public class KllMiscDoublesTest {
     DoublesSortedView sv = sk.getSortedView();
     DoublesSortedViewIterator itr = sv.iterator();
     println("### SORTED VIEW");
-    printf("%12s%12s\n", "Value", "Weight");
-    long[] correct = {2,2,2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
+    printf("%6s %12s %12s" + LS, "Idx", "Value", "CumWeight");
     int i = 0;
     while (itr.next()) {
       double v = itr.getQuantile();
       long wt = itr.getWeight();
-      printf("%12.1f%12d\n", v, wt);
-      assertEquals(wt, correct[i++]);
+      printf("%6d %12.1f %12d" + LS, i, v, wt);
+      i++;
     }
+    assertEquals(sv.getMinItem(), 1.0);
+    assertEquals(sv.getMaxItem(), n * 1.0);
   }
 
   @Test //set static enablePrinting = true for visual checking
@@ -272,7 +270,7 @@ public class KllMiscDoublesTest {
 
     DoublesSortedViewIterator itr = sk.getSortedView().iterator();
     println("### SORTED VIEW");
-    printf("%12s %12s %12s\n", "Value", "Weight", "NaturalRank");
+    printf("%12s %12s %12s" + LS, "Value", "Weight", "NaturalRank");
     long cumWt = 0;
     while (itr.next()) {
       double v = itr.getQuantile();
@@ -280,7 +278,7 @@ public class KllMiscDoublesTest {
       long natRank = itr.getNaturalRank(INCLUSIVE);
       cumWt += wt;
       assertEquals(cumWt, natRank);
-      printf("%12.1f %12d %12d\n", v, wt, natRank);
+      printf("%12.1f %12d %12d" + LS, v, wt, natRank);
     }
     assertEquals(cumWt, sk.getN());
   }
@@ -297,8 +295,8 @@ public class KllMiscDoublesTest {
 
   private static void outputItems(double[] itemsArr) {
     String[] hdr2 = {"Index", "Value"};
-    String hdr2fmt = "%6s %15s\n";
-    String d2fmt = "%6d %15f\n";
+    String hdr2fmt = "%6s %15s" + LS;
+    String d2fmt = "%6d %15f" + LS;
     println("ItemsArr");
     printf(hdr2fmt, (Object[]) hdr2);
     for (int i = 0; i < itemsArr.length; i++) {
@@ -321,9 +319,9 @@ public class KllMiscDoublesTest {
 
   private static void outputLevels(int weight, int[] levelsArr) {
     String[] hdr = {"Lvl", "StartAdr", "BitPattern", "Weight"};
-    String hdrfmt = "%3s %9s %10s %s\n";
-    String dfmt   = "%3d %9d %10d %d\n";
-    String dfmt_2 = "%3d %9d %s\n";
+    String hdrfmt = "%3s %9s %10s %s" + LS;
+    String dfmt   = "%3d %9d %10d %d" + LS;
+    String dfmt_2 = "%3d %9d %s" + LS;
     println("Count = " + weight + " => " + (Integer.toBinaryString(weight)));
     println("LevelsArr");
     printf(hdrfmt, (Object[]) hdr);
@@ -355,8 +353,8 @@ public class KllMiscDoublesTest {
   @Test //set static enablePrinting = true for visual checking
     public void checkIntCapAux() {
       String[] hdr = {"level", "depth", "wt", "cap", "(end)", "MaxN"};
-      String hdrFmt =  "%6s %6s %28s %10s %10s %34s\n";
-      String dataFmt = "%6d %6d %,28d %,10d %,10d %,34.0f\n";
+      String hdrFmt =  "%6s %6s %28s %10s %10s %34s" + LS;
+      String dataFmt = "%6d %6d %,28d %,10d %,10d %,34.0f" + LS;
       int k = 1000;
       int m = 8;
       int numLevels = 20;
@@ -378,8 +376,8 @@ public class KllMiscDoublesTest {
   @Test //set static enablePrinting = true for visual checking
   public void checkIntCapAuxAux() {
     String[] hdr = {"d","twoK","2k*2^d","3^d","tmp=2k*2^d/3^d","(tmp + 1)/2", "(end)"};
-    String hdrFmt =  "%6s %10s %20s %20s %15s %12s %10s\n";
-    String dataFmt = "%6d %10d %,20d %,20d %15d %12d %10d\n";
+    String hdrFmt =  "%6s %10s %20s %20s %15s %12s %10s" + LS;
+    String dataFmt = "%6d %10d %,20d %,20d %15d %12d %10d" + LS;
     long k = (1L << 16) - 1L;
     long m = 8;
     println("k = " + k + ", m = " + m);
@@ -770,7 +768,7 @@ public class KllMiscDoublesTest {
   public void printlnTest() {
     String s = "PRINTING:  printf in " + this.getClass().getName();
     println(s);
-    printf("%s\n", s);
+    printf("%s" + LS, s);
   }
 
   private final static boolean enablePrinting = false;

--- a/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscFloatsTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.datasketches.kll;
 
+import static org.apache.datasketches.common.Util.LS;
 import static org.apache.datasketches.common.Util.bitAt;
-import static org.apache.datasketches.kll.KllHelper.getGrowthSchemeForGivenN;
 import static org.apache.datasketches.kll.KllSketch.SketchType.FLOATS_SKETCH;
 import static org.apache.datasketches.quantilescommon.QuantileSearchCriteria.INCLUSIVE;
 import static org.testng.Assert.assertEquals;
@@ -30,7 +30,6 @@ import static org.testng.Assert.fail;
 
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.kll.KllDirectFloatsSketch.KllDirectCompactFloatsSketch;
-import org.apache.datasketches.kll.KllSketch.SketchType;
 import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
@@ -42,9 +41,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("unused")
 public class KllMiscFloatsTest {
-  static final String LS = System.getProperty("line.separator");
   private final MemoryRequestServer memReqSvr = new DefaultMemoryRequestServer();
 
   @Test
@@ -155,7 +152,7 @@ public class KllMiscFloatsTest {
     final KllFloatsSketch sk2 = KllFloatsSketch.newHeapInstance(20);
     n = 400;
     for (int i = 101; i <= n + 100; i++) { sk2.update(i); }
-    println("\n" + sk2.toString(true, true));
+    println(LS + sk2.toString(true, true));
     assertEquals(sk2.getNumLevels(), 5);
     assertEquals(sk2.getMinItem(), 101);
     assertEquals(sk2.getMaxItem(), 500);
@@ -228,15 +225,16 @@ public class KllMiscFloatsTest {
     FloatsSortedView sv = sk.getSortedView();
     FloatsSortedViewIterator itr = sv.iterator();
     println("### SORTED VIEW");
-    printf("%12s%12s\n", "Value", "Weight");
-    long[] correct = {2,2,2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
+    printf("%6s %12s %12s" + LS, "Idx", "Value", "Weight");
     int i = 0;
     while (itr.next()) {
       float v = itr.getQuantile();
       long wt = itr.getWeight();
-      printf("%12.1f%12d\n", v, wt);
-      assertEquals(wt, correct[i++]);
+      printf("%6d %12.1f %12d" + LS, i, v, wt);
+      i++;
     }
+    assertEquals(sv.getMinItem(), 1.0F);
+    assertEquals(sv.getMaxItem(), n * 1.0F);
   }
 
   @Test //set static enablePrinting = true for visual checking
@@ -272,7 +270,7 @@ public class KllMiscFloatsTest {
 
     FloatsSortedViewIterator itr = sk.getSortedView().iterator();
     println("### SORTED VIEW");
-    printf("%12s %12s %12s\n", "Value", "Weight", "NaturalRank");
+    printf("%12s %12s %12s" + LS, "Value", "Weight", "NaturalRank");
     long cumWt = 0;
     while (itr.next()) {
       double v = itr.getQuantile();
@@ -280,7 +278,7 @@ public class KllMiscFloatsTest {
       long natRank = itr.getNaturalRank(INCLUSIVE);
       cumWt += wt;
       assertEquals(cumWt, natRank);
-      printf("%12.1f %12d %12d\n", v, wt, natRank);
+      printf("%12.1f %12d %12d" + LS, v, wt, natRank);
     }
     assertEquals(cumWt, sk.getN());
   }
@@ -297,8 +295,8 @@ public class KllMiscFloatsTest {
 
   private static void outputItems(float[] itemsArr) {
     String[] hdr2 = {"Index", "Value"};
-    String hdr2fmt = "%6s %15s\n";
-    String d2fmt = "%6d %15f\n";
+    String hdr2fmt = "%6s %15s" + LS;
+    String d2fmt = "%6d %15f" + LS;
     println("ItemsArr");
     printf(hdr2fmt, (Object[]) hdr2);
     for (int i = 0; i < itemsArr.length; i++) {
@@ -321,9 +319,9 @@ public class KllMiscFloatsTest {
 
   private static void outputLevels(int weight, int[] levelsArr) {
     String[] hdr = {"Lvl", "StartAdr", "BitPattern", "Weight"};
-    String hdrfmt = "%3s %9s %10s %s\n";
-    String dfmt   = "%3d %9d %10d %d\n";
-    String dfmt_2 = "%3d %9d %s\n";
+    String hdrfmt = "%3s %9s %10s %s" + LS;
+    String dfmt   = "%3d %9d %10d %d" + LS;
+    String dfmt_2 = "%3d %9d %s" + LS;
     println("Count = " + weight + " => " + (Integer.toBinaryString(weight)));
     println("LevelsArr");
     printf(hdrfmt, (Object[]) hdr);
@@ -355,8 +353,8 @@ public class KllMiscFloatsTest {
   @Test //set static enablePrinting = true for visual checking
     public void checkIntCapAux() {
       String[] hdr = {"level", "depth", "wt", "cap", "(end)", "MaxN"};
-      String hdrFmt =  "%6s %6s %28s %10s %10s %34s\n";
-      String dataFmt = "%6d %6d %,28d %,10d %,10d %,34.0f\n";
+      String hdrFmt =  "%6s %6s %28s %10s %10s %34s" + LS;
+      String dataFmt = "%6d %6d %,28d %,10d %,10d %,34.0f" + LS;
       int k = 1000;
       int m = 8;
       int numLevels = 20;
@@ -378,8 +376,8 @@ public class KllMiscFloatsTest {
   @Test //set static enablePrinting = true for visual checking
   public void checkIntCapAuxAux() {
     String[] hdr = {"d","twoK","2k*2^d","3^d","tmp=2k*2^d/3^d","(tmp + 1)/2", "(end)"};
-    String hdrFmt =  "%6s %10s %20s %20s %15s %12s %10s\n";
-    String dataFmt = "%6d %10d %,20d %,20d %15d %12d %10d\n";
+    String hdrFmt =  "%6s %10s %20s %20s %15s %12s %10s" + LS;
+    String dataFmt = "%6d %10d %,20d %,20d %15d %12d %10d" + LS;
     long k = (1L << 16) - 1L;
     long m = 8;
     println("k = " + k + ", m = " + m);
@@ -770,7 +768,7 @@ public class KllMiscFloatsTest {
   public void printlnTest() {
     String s = "PRINTING:  printf in " + this.getClass().getName();
     println(s);
-    printf("%s\n", s);
+    printf("%s" + LS, s);
   }
 
   private final static boolean enablePrinting = false;

--- a/src/test/java/org/apache/datasketches/kll/KllMiscItemsTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMiscItemsTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-//@SuppressWarnings("unused")
 public class KllMiscItemsTest {
   public ArrayOfStringsSerDe serDe = new ArrayOfStringsSerDe();
 

--- a/src/test/java/org/apache/datasketches/quantilescommon/IncludeMinMaxTest.java
+++ b/src/test/java/org/apache/datasketches/quantilescommon/IncludeMinMaxTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.quantilescommon;
+
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.quantilescommon.IncludeMinMax.DoublesPair;
+import static org.apache.datasketches.quantilescommon.IncludeMinMax.FloatsPair;
+import static org.apache.datasketches.quantilescommon.IncludeMinMax.ItemsPair;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Comparator;
+
+import org.testng.annotations.Test;
+
+/**
+ * Checks the IncludeMinMax process
+ */
+public final class IncludeMinMaxTest {
+
+  @Test
+  public static void checkDoublesEndsAdjustment() {
+    final double[] quantiles = {2, 4, 6, 7};
+    final long[] cumWeights = {2, 4, 6, 8};
+
+    final double maxItem = 8;
+    final double minItem = 1;
+    final DoublesPair dPair = IncludeMinMax.includeDoublesMinMax(quantiles, cumWeights, maxItem, minItem);
+    final double[] adjQuantiles = dPair.quantiles;
+    final long[] adjCumWeights = dPair.cumWeights;
+    int len = adjCumWeights.length;
+    printf("%10s %10s" + LS, "Quantiles", "CumWeights");
+    for (int i = 0; i < len; i++) {
+      printf("%10.1f %10d" + LS, adjQuantiles[i], adjCumWeights[i]);
+    }
+    final int topIn = quantiles.length - 1;
+    final int topAdj = adjQuantiles.length - 1;
+    assertEquals(adjQuantiles[topAdj], maxItem);
+    assertEquals(adjQuantiles[0], minItem);
+    assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
+    assertEquals(adjCumWeights[0], 1);
+  }
+
+  @Test
+  public static void checkDoublesEndsAdjustment2() {
+    final double[] quantiles = {2, 4, 6, 7};
+    final long[] cumWeights = {2, 4, 6, 8};
+
+    final double maxItem = 7;
+    final double minItem = 2;
+    final DoublesPair dPair = IncludeMinMax.includeDoublesMinMax(quantiles, cumWeights, maxItem, minItem);
+    final double[] adjQuantiles = dPair.quantiles;
+    final long[] adjCumWeights = dPair.cumWeights;
+    int len = adjCumWeights.length;
+    printf("%10s %10s" + LS, "Quantiles", "CumWeights");
+    for (int i = 0; i < len; i++) {
+      printf("%10.1f %10d" + LS, adjQuantiles[i], adjCumWeights[i]);
+    }
+    final int topIn = quantiles.length - 1;
+    final int topAdj = adjQuantiles.length - 1;
+    assertEquals(adjQuantiles[topAdj], maxItem);
+    assertEquals(adjQuantiles[0], minItem);
+    assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
+    assertEquals(adjCumWeights[0], cumWeights[0]);
+  }
+
+  @Test
+  public static void checkFloatsEndsAdjustment() {
+    final float[] quantiles = {2, 4, 6, 7};
+    final long[] cumWeights = {2, 4, 6, 8};
+
+    final float maxItem = 8;
+    final float minItem = 1;
+    final FloatsPair dPair = IncludeMinMax.includeFloatsMinMax(quantiles, cumWeights, maxItem, minItem);
+    final float[] adjQuantiles = dPair.quantiles;
+    final long[] adjCumWeights = dPair.cumWeights;
+    int len = adjCumWeights.length;
+    printf("%10s %10s" + LS, "Quantiles", "CumWeights");
+    for (int i = 0; i < len; i++) {
+      printf("%10.1f %10d" + LS, adjQuantiles[i], adjCumWeights[i]);
+    }
+    final int topIn = quantiles.length - 1;
+    final int topAdj = adjQuantiles.length - 1;
+    assertEquals(adjQuantiles[topAdj], maxItem);
+    assertEquals(adjQuantiles[0], minItem);
+    assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
+    assertEquals(adjCumWeights[0], 1);
+  }
+
+  @Test
+  public static void checkFloatsEndsAdjustment2() {
+    final float[] quantiles = {2, 4, 6, 7};
+    final long[] cumWeights = {2, 4, 6, 8};
+
+    final float maxItem = 7;
+    final float minItem = 2;
+    final FloatsPair dPair = IncludeMinMax.includeFloatsMinMax(quantiles, cumWeights, maxItem, minItem);
+    final float[] adjQuantiles = dPair.quantiles;
+    final long[] adjCumWeights = dPair.cumWeights;
+    int len = adjCumWeights.length;
+    printf("%10s %10s" + LS, "Quantiles", "CumWeights");
+    for (int i = 0; i < len; i++) {
+      printf("%10.1f %10d" + LS, adjQuantiles[i], adjCumWeights[i]);
+    }
+    final int topIn = quantiles.length - 1;
+    final int topAdj = adjQuantiles.length - 1;
+    assertEquals(adjQuantiles[topAdj], maxItem);
+    assertEquals(adjQuantiles[0], minItem);
+    assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
+    assertEquals(adjCumWeights[0], cumWeights[0]);
+  }
+
+  @Test
+  public static void checkItemsEndsAdjustment() {
+    final String[] quantiles = {"2", "4", "6", "7"};
+    final long[] cumWeights = {2, 4, 6, 8};
+
+    final String maxItem = "8";
+    final String minItem = "1";
+    final ItemsPair<String> dPair =
+        IncludeMinMax.includeItemsMinMax(quantiles, cumWeights, maxItem, minItem, Comparator.naturalOrder());
+    final String[] adjQuantiles = dPair.quantiles;
+    final long[] adjCumWeights = dPair.cumWeights;
+    int len = adjCumWeights.length;
+    printf("%10s %10s" + LS, "Quantiles", "CumWeights");
+    for (int i = 0; i < len; i++) {
+      printf("%10s %10d" + LS, adjQuantiles[i], adjCumWeights[i]);
+    }
+    final int topIn = quantiles.length - 1;
+    final int topAdj = adjQuantiles.length - 1;
+    assertEquals(adjQuantiles[topAdj], maxItem);
+    assertEquals(adjQuantiles[0], minItem);
+    assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
+    assertEquals(adjCumWeights[0], 1);
+  }
+
+  @Test
+  public static void checkItemsEndsAdjustment2() {
+    final String[] quantiles = {"2", "4", "6", "7"};
+    final long[] cumWeights = {2, 4, 6, 8};
+
+    final String maxItem = "7";
+    final String minItem = "2";
+    final ItemsPair<String> dPair =
+        IncludeMinMax.includeItemsMinMax(quantiles, cumWeights, maxItem, minItem, Comparator.naturalOrder());
+    final String[] adjQuantiles = dPair.quantiles;
+    final long[] adjCumWeights = dPair.cumWeights;
+    int len = adjCumWeights.length;
+    printf("%10s %10s" + LS, "Quantiles", "CumWeights");
+    for (int i = 0; i < len; i++) {
+      printf("%10s %10d" + LS, adjQuantiles[i], adjCumWeights[i]);
+    }
+    final int topIn = quantiles.length - 1;
+    final int topAdj = adjQuantiles.length - 1;
+    assertEquals(adjQuantiles[topAdj], maxItem);
+    assertEquals(adjQuantiles[0], minItem);
+    assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
+    assertEquals(adjCumWeights[0], cumWeights[0]);
+  }
+
+  @Test
+  public void printlnTest() {
+    println("PRINTING: " + this.getClass().getName());
+  }
+
+  private final static boolean enablePrinting = false;
+
+  /**
+   * @param format the format
+   * @param args the args
+   */
+  static final void printf(final String format, final Object ...args) {
+    if (enablePrinting) { System.out.printf(format, args); }
+  }
+
+  /**
+   * @param o the Object to println
+   */
+  static final void println(final Object o) {
+    if (enablePrinting) { System.out.println(o.toString()); }
+  }
+
+}

--- a/src/test/java/org/apache/datasketches/quantilescommon/IncludeMinMaxTest.java
+++ b/src/test/java/org/apache/datasketches/quantilescommon/IncludeMinMaxTest.java
@@ -55,6 +55,8 @@ public final class IncludeMinMaxTest {
     assertEquals(adjQuantiles[0], minItem);
     assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
     assertEquals(adjCumWeights[0], 1);
+    assertEquals(adjQuantiles.length - quantiles.length, 2);
+    assertEquals(adjCumWeights.length - cumWeights.length, 2);
   }
 
   @Test
@@ -78,6 +80,8 @@ public final class IncludeMinMaxTest {
     assertEquals(adjQuantiles[0], minItem);
     assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
     assertEquals(adjCumWeights[0], cumWeights[0]);
+    assertEquals(adjQuantiles.length - quantiles.length, 0);
+    assertEquals(adjCumWeights.length - cumWeights.length, 0);
   }
 
   @Test
@@ -101,6 +105,8 @@ public final class IncludeMinMaxTest {
     assertEquals(adjQuantiles[0], minItem);
     assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
     assertEquals(adjCumWeights[0], 1);
+    assertEquals(adjQuantiles.length - quantiles.length, 2);
+    assertEquals(adjCumWeights.length - cumWeights.length, 2);
   }
 
   @Test
@@ -124,6 +130,8 @@ public final class IncludeMinMaxTest {
     assertEquals(adjQuantiles[0], minItem);
     assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
     assertEquals(adjCumWeights[0], cumWeights[0]);
+    assertEquals(adjQuantiles.length - quantiles.length, 0);
+    assertEquals(adjCumWeights.length - cumWeights.length, 0);
   }
 
   @Test
@@ -148,6 +156,8 @@ public final class IncludeMinMaxTest {
     assertEquals(adjQuantiles[0], minItem);
     assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
     assertEquals(adjCumWeights[0], 1);
+    assertEquals(adjQuantiles.length - quantiles.length, 2);
+    assertEquals(adjCumWeights.length - cumWeights.length, 2);
   }
 
   @Test
@@ -172,6 +182,8 @@ public final class IncludeMinMaxTest {
     assertEquals(adjQuantiles[0], minItem);
     assertEquals(adjCumWeights[topAdj], cumWeights[topIn]);
     assertEquals(adjCumWeights[0], cumWeights[0]);
+    assertEquals(adjQuantiles.length - quantiles.length, 0);
+    assertEquals(adjCumWeights.length - cumWeights.length, 0);
   }
 
   @Test


### PR DESCRIPTION
Also fixed a problem I discovered in the deserialization for Boolean quantiles, but it would also have shown up with other types. The data was ok, but the max value would have been incorrect.

Also fixed some problems with some of the tests.

Along the way I also replaced "back-slash-n" with platform independent "LS" in the files I touched.

Also moved some functions like getCDF(..) and getPMF(...) into parent interfaces as default functions. Now the three parent interfaces for Doubles SV, Floats SV and Items SV are all code-parallel.