### PR TITLE
Add rough memory size tracking with KllItemsSketch

### DIFF
--- a/src/main/java/org/apache/datasketches/common/ArrayOfBooleansSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfBooleansSerDe.java
@@ -122,4 +122,10 @@ public class ArrayOfBooleansSerDe extends ArrayOfItemsSerDe<Boolean> {
 
   @Override
   public Class<Boolean> getClassOfT() { return Boolean.class; }
+
+  @Override
+  public boolean isFixedWidth()
+  {
+    return true;
+  }
 }

--- a/src/main/java/org/apache/datasketches/common/ArrayOfDoublesSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfDoublesSerDe.java
@@ -101,4 +101,10 @@ public class ArrayOfDoublesSerDe extends ArrayOfItemsSerDe<Double> {
 
   @Override
   public Class<Double> getClassOfT() { return Double.class; }
+
+  @Override
+  public boolean isFixedWidth()
+  {
+    return true;
+  }
 }

--- a/src/main/java/org/apache/datasketches/common/ArrayOfItemsSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfItemsSerDe.java
@@ -114,4 +114,9 @@ public abstract class ArrayOfItemsSerDe<T> {
    * @return the concrete class of type T
    */
   public abstract Class<T> getClassOfT();
+
+  /**
+   * @return if this class serializes all types to a fixed width.
+   */
+  public abstract boolean isFixedWidth();
 }

--- a/src/main/java/org/apache/datasketches/common/ArrayOfLongsSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfLongsSerDe.java
@@ -100,4 +100,10 @@ public class ArrayOfLongsSerDe extends ArrayOfItemsSerDe<Long> {
 
   @Override
   public Class<Long> getClassOfT() { return Long.class; }
+
+  @Override
+  public boolean isFixedWidth()
+  {
+    return true;
+  }
 }

--- a/src/main/java/org/apache/datasketches/common/ArrayOfNumbersSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfNumbersSerDe.java
@@ -240,4 +240,10 @@ public class ArrayOfNumbersSerDe extends ArrayOfItemsSerDe<Number> {
 
   @Override
   public Class<Number> getClassOfT() { return Number.class; }
+
+  @Override
+  public boolean isFixedWidth()
+  {
+    return false;
+  }
 }

--- a/src/main/java/org/apache/datasketches/common/ArrayOfStringsSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfStringsSerDe.java
@@ -130,4 +130,10 @@ public class ArrayOfStringsSerDe extends ArrayOfItemsSerDe<String> {
 
   @Override
   public Class<String> getClassOfT() { return String.class; }
+
+  @Override
+  public boolean isFixedWidth()
+  {
+    return false;
+  }
 }

--- a/src/main/java/org/apache/datasketches/common/ArrayOfUtf16StringsSerDe.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfUtf16StringsSerDe.java
@@ -124,4 +124,10 @@ public class ArrayOfUtf16StringsSerDe extends ArrayOfItemsSerDe<String> {
 
   @Override
   public Class<String> getClassOfT() { return String.class; }
+
+  @Override
+  public boolean isFixedWidth()
+  {
+    return false;
+  }
 }

--- a/src/main/java/org/apache/datasketches/kll/KllDirectCompactItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDirectCompactItemsSketch.java
@@ -234,6 +234,12 @@ final class KllDirectCompactItemsSketch<T> extends KllItemsSketch<T> {
   }
 
   @Override
+  int getTotalItemsNumBytesInternal()
+  {
+    return getRetainedItemsSizeBytes();
+  }
+
+  @Override
   WritableMemory getWritableMemory() {
     return (WritableMemory)mem;
   }

--- a/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllDoublesSketch.java
@@ -514,7 +514,7 @@ public abstract class KllDoublesSketch extends KllSketch implements QuantilesDou
   abstract byte[] getTotalItemsByteArr();
 
   @Override
-  int getTotalItemsNumBytes() {
+  public int getTotalItemsNumBytes() {
     return levelsArr[getNumLevels()] * Double.BYTES;
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllFloatsSketch.java
@@ -514,7 +514,7 @@ public abstract class KllFloatsSketch extends KllSketch implements QuantilesFloa
   abstract byte[] getTotalItemsByteArr();
 
   @Override
-  int getTotalItemsNumBytes() {
+  public int getTotalItemsNumBytes() {
     return levelsArr[getNumLevels()] * Float.BYTES;
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
@@ -353,8 +353,6 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   @Override
   abstract int getRetainedItemsSizeBytes();
 
-  //abstract Object[] getRetainedItemsArray();
-
   @Override
   ArrayOfItemsSerDe<T> getSerDe() { return serDe; }
 
@@ -378,9 +376,16 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   }
 
   @Override
-  int getTotalItemsNumBytes() {
-    throw new SketchesArgumentException(UNSUPPORTED_MSG);
+  public int getTotalItemsNumBytes() {
+    // if empty, exception is thrown.
+    if (serDe.isFixedWidth() && !isEmpty()) {
+      return levelsArr[getNumLevels()] * serDe.sizeOf(getMinItem());
+    } else {
+      return getTotalItemsNumBytesInternal();
+    }
   }
+
+  abstract int getTotalItemsNumBytesInternal();
 
   @Override
   void incNumLevels() {

--- a/src/main/java/org/apache/datasketches/kll/KllSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllSketch.java
@@ -426,10 +426,11 @@ public abstract class KllSketch implements QuantilesAPI {
   /**
    * Gets the size in bytes of the entire internal items hypothetical structure.
    * It does not include the preamble, the levels array, or minimum or maximum items.
-   * It may include empty or free space.
+   * It may include empty or free space. This can value is useful to estimate
+   * the in-memory usage of the sketch.
    * @return the size of the retained data in bytes.
    */
-  abstract int getTotalItemsNumBytes();
+  public abstract int getTotalItemsNumBytes();
 
   /**
    * This returns the WritableMemory for Direct type sketches,

--- a/src/test/java/org/apache/datasketches/kll/KllItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllItemsSketchTest.java
@@ -716,7 +716,6 @@ public class KllItemsSketchTest {
   public void checkExceptions() {
     final KllItemsSketch<String> sk = KllItemsSketch.newHeapInstance(20, Comparator.naturalOrder(), serDe);
     try { sk.getTotalItemsByteArr();     fail(); } catch (SketchesArgumentException e) { }
-    try { sk.getTotalItemsNumBytes();    fail(); } catch (SketchesArgumentException e) { }
     try { sk.setWritableMemory(null);    fail(); } catch (SketchesArgumentException e) { }
     byte[] byteArr = sk.toByteArray();
     final KllItemsSketch<String> sk2 = KllItemsSketch.wrap(Memory.wrap(byteArr), Comparator.naturalOrder(), serDe);

--- a/src/test/java/org/apache/datasketches/kll/KllTotalItemsBytesTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllTotalItemsBytesTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.kll;
+
+import org.apache.datasketches.common.*;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.function.BiConsumer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class KllTotalItemsBytesTest {
+
+    @DataProvider(name = "emptySketchesItems")
+    public Object[][] emptySketches() {
+        return new Object[][]{
+                new Object[]{KllItemsSketch.newHeapInstance(Double::compareTo, new ArrayOfDoublesSerDe())},
+                new Object[]{KllItemsSketch.newHeapInstance(Long::compareTo, new ArrayOfLongsSerDe())},
+                new Object[]{KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfStringsSerDe())},
+                new Object[]{KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfUtf16StringsSerDe())},
+                new Object[]{KllItemsSketch.newHeapInstance(Boolean::compareTo, new ArrayOfBooleansSerDe())},
+        };
+    }
+
+    @Test(dataProvider = "emptySketchesItems")
+    public void testEmptySketches(KllSketch sketch) {
+        assertEquals(sketch.getTotalItemsNumBytes(), 0);
+    }
+
+    @DataProvider(name = "emptySketchesNative")
+    public Object[][] emptySketchesNative() {
+        return new Object[][]{
+                new Object[]{KllFloatsSketch.newHeapInstance(), Float.BYTES},
+                new Object[]{KllDoublesSketch.newHeapInstance(), Double.BYTES},
+        };
+    }
+
+    @Test(dataProvider = "emptySketchesNative")
+    public void testEmptySketchesNative(KllSketch sketch, int singleItemSize) {
+        assertEquals(sketch.getTotalItemsNumBytes(), singleItemSize * sketch.getK());
+    }
+
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @DataProvider(name = "sketchSingleItem")
+    public Object[][] sketchSingleItem() {
+        return new Object[][]{
+                new Object[]{KllItemsSketch.newHeapInstance(Double::compareTo, new ArrayOfDoublesSerDe()), 1.0d, (BiConsumer<KllItemsSketch, Double>) KllItemsSketch::update},
+                new Object[]{KllItemsSketch.newHeapInstance(Long::compareTo, new ArrayOfLongsSerDe()), 1L, (BiConsumer<KllItemsSketch, Long>) KllItemsSketch::update},
+                new Object[]{KllItemsSketch.newHeapInstance(Boolean::compareTo, new ArrayOfBooleansSerDe()), true, (BiConsumer<KllItemsSketch, Boolean>) KllItemsSketch::update},
+                new Object[]{KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfStringsSerDe()), "1", (BiConsumer<KllItemsSketch, String>) KllItemsSketch::update},
+                new Object[]{KllItemsSketch.newHeapInstance(String::compareTo, new ArrayOfUtf16StringsSerDe()), "1", (BiConsumer<KllItemsSketch, String>) KllItemsSketch::update},
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(dataProvider = "sketchSingleItem")
+    public void testSingleItemIncreases(KllSketch sketch, Object item, BiConsumer<KllSketch, Object> update) {
+        assertEquals(sketch.getTotalItemsNumBytes(), 0);
+        assertEquals(sketch.getNumRetained(), 0);
+        update.accept(sketch, item);
+        assertTrue(sketch.getNumRetained() > 0);
+        if (sketch.getSerDe().isFixedWidth()) {
+            assertEquals(((ArrayOfItemsSerDe<Object>) sketch.getSerDe()).sizeOf(item) * sketch.getK(), sketch.getTotalItemsNumBytes());
+        } else {
+            assertEquals(((ArrayOfItemsSerDe<Object>) sketch.getSerDe()).sizeOf(item), sketch.getTotalItemsNumBytes());
+        }
+    }
+
+    @Test(dataProvider = "sketchSingleItem")
+    public void testManyItemIncreases(KllSketch sketch, Object item, BiConsumer<KllSketch, Object> update) {
+        assertEquals(sketch.getTotalItemsNumBytes(), 0);
+        assertEquals(sketch.getNumRetained(), 0);
+        for (int i = 0; i < 4096; i++) {
+            update.accept(sketch, item);
+        }
+        assertTrue(sketch.getNumRetained() > 0);
+        assertTrue(sketch.getTotalItemsNumBytes() > 0);
+    }
+}


### PR DESCRIPTION
When generating KllSketches, systems may need to have an idea about how much memory utilization there is for a particular sketch. For sketches with fixed-width types the answer can be computed efficiently.

With the KllItemsSketch, this is more difficult because the sketch can support String-types with variable widths. This commit adds implementation support to expose the `getTotalItemsNumBytes` method so that external systems can roughly track the memory utilization of a particular sketch.

The change accomplishes this by intercepting the code where a new item is added to the items array, or when a new array is generated entirely. This will add a slight overhead due to the sketch now needing to compute the length of inputs. For fixed-width types the overhead is low. For string this will require a call to encode the string as UTF-8/16 before adding it to the array.

For fixed-width types, the calculations have little effective overhead as the computation is a single array-access lookup + multiplication with the type width.