### PR TITLE
Fix pom xml header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="https://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
According to Maven documentation [https://maven.apache.org/pom.html#The_Basics](https://maven.apache.org/pom.html#The_Basics), only the xsd URI can be https. the other 3 URIs in the header have to be http.

Only XML validators will pick this up. So I don't think this warrants a bug fix.