### PR TITLE
Optimise HLL union for mergeHLLtoHLL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@ under the License.
 
     <!-- Test -->
     <testng.version>7.5.1</testng.version>
+    <jmh.version>1.37</jmh.version>
     <!-- these are TestNG groups used for excluding / including groups of tests. See profiles section. -->
     <testng.generate-java-files>generate_java_files</testng.generate-java-files>
     <testng.check-cpp-files>check_cpp_files</testng.check-cpp-files>
@@ -148,6 +149,12 @@ under the License.
       <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!--
     <dependency>
       <groupId>org.apache.datasketches</groupId>
@@ -170,6 +177,15 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
+          <configuration>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmh.version}</version>
+              </path>
+            </annotationProcessorPaths>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/src/main/java/org/apache/datasketches/hll/Union.java
+++ b/src/main/java/org/apache/datasketches/hll/Union.java
@@ -505,9 +505,9 @@ public class Union extends BaseHllSketch {
           final byte[] srcArr = ((Hll8Array) src.hllSketchImpl).hllByteArr;
           final byte[] tgtArr = ((Hll8Array) tgt.hllSketchImpl).hllByteArr;
           for (int i = 0; i < srcK; i++) {
-            final byte srcV = srcArr[i];
-            final byte tgtV = tgtArr[i];
-            tgtArr[i] = (byte) Math.max(srcV, tgtV);
+            if (srcArr[i] > tgtArr[i]) {
+              tgtArr[i] = srcArr[i];
+            }
           }
           break;
         }

--- a/src/test/java/org/apache/datasketches/hll/BenchmarkUnion.java
+++ b/src/test/java/org/apache/datasketches/hll/BenchmarkUnion.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.hll;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.datasketches.hll.TgtHllType.HLL_8;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkUnion {
+    private HllSketch sketch;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt =
+                new OptionsBuilder()
+                        .include(BenchmarkUnion.class.getSimpleName())
+                        .forks(1)
+                        .build();
+
+        new Runner(opt).run();
+    }
+
+
+    @Setup
+    public void setup() {
+        sketch = new HllSketch(11, HLL_8);
+        for (int i = 0; i < 29197004; i++) {
+            sketch.update(i);
+        }
+    }
+
+    @Benchmark
+    public void benchHllUnionHLLToHLLMerge() {
+        Union union = new Union(11);
+        for (int i = 0; i < 1_000_000; i++) {
+            union.update(sketch);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR introduce JMH benchmark - happy to remove it and leave that to characterisation if thats an issue.


This also only shows in a particular place that some optimisation can be gained by avoiding a call to Math.max + array mutation with a simple comparaison.

About 8% gain for HLL heap union

Before
```
Benchmark                                       Mode  Cnt    Score    Error  Units
BenchmarkUnion.benchHllUnionHLLToHLLMerge  avgt    5  511.411 ± 12.468  ms/op
```

After
```
Benchmark                                       Mode  Cnt    Score   Error  Units
BenchmarkUnion.benchHllUnionHLLToHLLMerge  avgt    5  471.329 ± 9.712  ms/op
```