### PR TITLE
Java8-11 changes consistent with 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,14 @@ However, if your application also directly relies on the APIs of the *datasketch
 you may need additional JVM arguments.
 Please refer to the [datasketches-memory README](https://github.com/apache/datasketches-memory/blob/master/README.md) for details.
 
-If your application uses Maven, you can also use the *pom.xml* of this component as an example of how to automatically
-configure the JVM arguments for compilation and testing based on the version of the JDK.
+If your application uses Maven, you can also use the *pom.xml* of this component as an example of how to automatically configure the JVM arguments for compilation and testing based on the version of the JDK.
 
 ### Recommended Build Tool
 This DataSketches component is structured as a Maven project and Maven is the recommended Build Tool.
 
-There are two types of tests: normal unit tests and tests run by the strict profile.  
-
 To run normal unit tests:
 
     $ mvn clean test
-
-To run the strict profile tests (only supported in Java 8):
-
-    $ mvn clean test -P strict
 
 To install jars built from the downloaded source:
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,12 @@ under the License.
   </properties>
 
   <dependencies>
-    <!--
     <dependency>
       <groupId>org.apache.datasketches</groupId>
       <artifactId>datasketches-memory</artifactId>
       <version>${datasketches-memory.version}</version>
     </dependency>
-    -->
+
     <!-- Test Scope -->
     <dependency>
       <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,13 +134,13 @@ under the License.
   </properties>
 
   <dependencies>
-    <!-- UNIQUE FOR THIS JAVA COMPONENT -->
+    <!--
     <dependency>
       <groupId>org.apache.datasketches</groupId>
       <artifactId>datasketches-memory</artifactId>
       <version>${datasketches-memory.version}</version>
     </dependency>
-    <!-- END: UNIQUE FOR THIS JAVA COMPONENT -->
+    -->
     <!-- Test Scope -->
     <dependency>
       <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ under the License.
   </developers>
 
   <properties>
-    <datasketches-memory.version>3.0.0-SNAPSHOT</datasketches-memory.version>
+    <datasketches-memory.version>3.0.0</datasketches-memory.version>
 
     <!-- Test -->
     <testng.version>7.5.1</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,6 @@ under the License.
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <version>32</version>
-  </parent>
-
   <groupId>org.apache.datasketches</groupId>
   <artifactId>datasketches-java</artifactId>
   <version>6.1.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@ under the License.
 
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>32</version>
+  </parent>
+
   <groupId>org.apache.datasketches</groupId>
   <artifactId>datasketches-java</artifactId>
   <version>6.1.0-SNAPSHOT</version>
@@ -77,9 +83,7 @@ under the License.
   </developers>
 
   <properties>
-    <!-- UNIQUE FOR THIS JAVA COMPONENT -->
-    <datasketches-memory.version>2.2.0</datasketches-memory.version>
-    <!-- END:UNIQUE FOR THIS JAVA COMPONENT -->
+    <datasketches-memory.version>3.0.0-SNAPSHOT</datasketches-memory.version>
 
     <!-- Test -->
     <testng.version>7.5.1</testng.version>
@@ -89,8 +93,8 @@ under the License.
     <testng.check-cpp-historical-files>check_cpp_historical_files</testng.check-cpp-historical-files>
 
     <!-- System-wide properties -->
-    <maven.version>3.6.3</maven.version> <!-- may override parent, used in enforcer plugin -->
-    <java.version>1.8</java.version>
+    <maven.version>3.6.3</maven.version>
+    <java.version>8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <argLine>-Xmx4g -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8</argLine>
@@ -100,31 +104,31 @@ under the License.
     <project.reporting.outputEncoding>${charset.encoding}</project.reporting.outputEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH-mm-ss'Z'</maven.build.timestamp.format>
 
-    <!-- org.mojohaus plugins: used for checking & updating dependency versions -->
-    <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
-
-    <!--  Maven Plugins -->
-    <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version> <!-- may override parent -->
-    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version> <!-- may override parent -->
-    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version> <!-- may override parent -->
-    <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version> <!-- may override parent -->
-    <maven-gpg-plugin.version>3.2.3</maven-gpg-plugin.version> <!-- may override parent -->
-    <maven-jar-plugin.version>3.4.0</maven-jar-plugin.version> <!-- may override parent -->
-    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version> <!-- may override parent -->
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version> <!-- may override parent -->
-    <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version> <!-- may override parent -->
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version> <!-- may override parent -->
-    <maven-surefire-failsafe-plugins.version>3.2.5</maven-surefire-failsafe-plugins.version><!-- for surefire, failsafe and surefire-report, may override parent-->
-    <!-- Apache Plugins -->
-    <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version> <!-- may override parent -->
-    <!-- org.jacoco Maven Plugins -->
-    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <!-- org.eluder Maven Plugins -->
+    <!--  org.apache.maven plugins -->
+    <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
+    <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+    <maven-gpg-plugin.version>3.2.3</maven-gpg-plugin.version>
+    <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+    <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version>
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <maven-surefire-failsafe-plugins.version>3.2.5</maven-surefire-failsafe-plugins.version> <!-- for surefire, failsafe and surefire-report-->
+    <!-- com.github plugins -->
+    <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>    
+    <!-- org.apache.creadur plugins -->
+    <apache-rat-plugin.version>0.16.1</apache-rat-plugin.version> 
+    <!-- org.eluder maven plugins -->
     <coveralls-repo-token></coveralls-repo-token>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
+    <!-- org.jacoco maven plugins -->
+    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+    <!-- org.mojohaus plugins -->
+    <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
     <!-- other -->
-    <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version> <!-- not used -->
-    <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
+    <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/apache/datasketches/common/Util.java
+++ b/src/main/java/org/apache/datasketches/common/Util.java
@@ -245,7 +245,8 @@ public final class Util {
 
   /**
    * Prepend or postpend the given string with the given character to fill the given field length.
-   * If the given string is equal to or greater than the given field length, it will be returned without modification.
+   * If the given string is equal to or greater than the given field length, it will be returned
+   * without modification.
    * @param s the given string
    * @param fieldLength the desired field length
    * @param padChar the desired pad character

--- a/src/main/java/org/apache/datasketches/theta/Sketch.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketch.java
@@ -292,14 +292,11 @@ public abstract class Sketch {
 
   /**
    * Returns the maximum number of storage bytes required for a CompactSketch with the given
-   * number of actual entries. Note that this assumes the worse case of the sketch in
-   * estimation mode, which requires storing theta and count.
-   * @param numberOfEntries the actual number of entries stored with the CompactSketch.
+   * number of actual entries.
+   * @param numberOfEntries the actual number of retained entries stored in the sketch.
    * @return the maximum number of storage bytes required for a CompactSketch with the given number
-   * of entries.
-   * @deprecated as a public method. Use {@link #getCompactSketchMaxBytes(int) instead}
+   * of retained entries.
    */
-  @Deprecated
   public static int getMaxCompactSketchBytes(final int numberOfEntries) {
     if (numberOfEntries == 0) { return 8; }
     if (numberOfEntries == 1) { return 16; }

--- a/src/main/java/org/apache/datasketches/theta/Sketch.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketch.java
@@ -311,8 +311,8 @@ public abstract class Sketch {
    * nomEntries.
    */
   public static int getCompactSketchMaxBytes(final int lgNomEntries) {
-    return (int)((2 << lgNomEntries) * ThetaUtil.REBUILD_THRESHOLD)
-        + Family.QUICKSELECT.getMaxPreLongs() * Long.BYTES;
+    return (int)((2 << lgNomEntries) * ThetaUtil.REBUILD_THRESHOLD
+        + Family.QUICKSELECT.getMaxPreLongs()) * Long.BYTES;
   }
 
   /**

--- a/src/main/java/org/apache/datasketches/theta/Sketches.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketches.java
@@ -80,15 +80,11 @@ public final class Sketches {
 
   /**
    * Returns the maximum number of storage bytes required for a CompactSketch with the given
-   * number of actual entries. Note that this assumes the worse case of the sketch in
-   * estimation mode, which requires storing theta and count.
-   * @param numberOfEntries the actual number of entries stored with the CompactSketch.
+   * number of actual entries.
+   * @param numberOfEntries the actual number of retained entries stored in the sketch.
    * @return the maximum number of storage bytes required for a CompactSketch with the given number
-   * of entries.
-   * @see Sketch#getMaxCompactSketchBytes(int)
-   * @deprecated as a public method. Use {@link #getCompactSketchMaxBytes(int) instead}
+   * of retained entries.
    */
-  @Deprecated
   public static int getMaxCompactSketchBytes(final int numberOfEntries) {
     return Sketch.getMaxCompactSketchBytes(numberOfEntries);
   }

--- a/src/test/java/org/apache/datasketches/filters/bloomfilter/BloomFilterTest.java
+++ b/src/test/java/org/apache/datasketches/filters/bloomfilter/BloomFilterTest.java
@@ -28,7 +28,6 @@ import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesReadOnlyException;
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
@@ -51,8 +50,7 @@ public class BloomFilterTest {
     assertFalse(bf1.isDirect());
     assertFalse(bf1.isReadOnly());
 
-    try (WritableHandle wh = WritableMemory.allocateDirect(sizeBytes)) {
-      final WritableMemory wmem = wh.getWritable();
+    try (WritableMemory wmem = WritableMemory.allocateDirect(sizeBytes)) {
       final BloomFilter bf2 = new BloomFilter(numBits, numHashes, seed, wmem);
       assertTrue(bf2.isEmpty());
       assertTrue(bf2.hasMemory());

--- a/src/test/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayRTest.java
+++ b/src/test/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayRTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertTrue;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesReadOnlyException;
 import org.apache.datasketches.memory.Memory;
+import org.apache.datasketches.memory.MemoryBoundsException;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
@@ -142,8 +143,8 @@ public class DirectBitArrayRTest {
 
     final Memory mem = bitArrayToMemory(hba);
     DirectBitArrayR dba = DirectBitArrayR.wrap(mem, hba.isEmpty());
-    assertThrows(AssertionError.class, () -> dba.getBit(-10));
-    assertThrows(AssertionError.class, () -> dba.getBit(2048));
+    assertThrows(MemoryBoundsException.class, () -> dba.getBit(-10));
+    assertThrows(MemoryBoundsException.class, () -> dba.getBit(2048));
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayTest.java
+++ b/src/test/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import org.apache.datasketches.common.SketchesArgumentException;
+import org.apache.datasketches.memory.MemoryBoundsException;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
@@ -172,12 +173,12 @@ public class DirectBitArrayTest {
       dba.getAndSetBit(i);
     }
 
-    assertThrows(AssertionError.class, () -> dba.getBit(-10));
-    assertThrows(AssertionError.class, () -> dba.getBit(2048));
-    assertThrows(AssertionError.class, () -> dba.setBit(-20));
-    assertThrows(AssertionError.class, () -> dba.setBit(4096));
-    assertThrows(AssertionError.class, () -> dba.getAndSetBit(-30));
-    assertThrows(AssertionError.class, () -> dba.getAndSetBit(8192));
+    assertThrows(MemoryBoundsException.class, () -> dba.getBit(-10));
+    assertThrows(MemoryBoundsException.class, () -> dba.getBit(2048));
+    assertThrows(MemoryBoundsException.class, () -> dba.setBit(-20));
+    assertThrows(MemoryBoundsException.class, () -> dba.setBit(4096));
+    assertThrows(MemoryBoundsException.class, () -> dba.getAndSetBit(-30));
+    assertThrows(MemoryBoundsException.class, () -> dba.getAndSetBit(8192));
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayTest.java
+++ b/src/test/java/org/apache/datasketches/filters/bloomfilter/DirectBitArrayTest.java
@@ -139,7 +139,7 @@ public class DirectBitArrayTest {
   @Test
   public void countWritableWrappedBitsWhenDirty() {
     // like basicOperationTest but with setBit which does
-    // not neecssarily track numBitsSet_
+    // not necessarily track numBitsSet_
     final HeapBitArray hba = new HeapBitArray(128);
     assertFalse(hba.getAndSetBit(1));
     assertFalse(hba.getAndSetBit(2));

--- a/src/test/java/org/apache/datasketches/hll/DirectAuxHashMapTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectAuxHashMapTest.java
@@ -34,7 +34,6 @@ import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.testng.annotations.Test;
 
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 
 
@@ -50,51 +49,45 @@ public class DirectAuxHashMapTest {
     int n = 8; //put lgConfigK == 4 into HLL mode
     int bytes = HllSketch.getMaxUpdatableSerializationBytes(lgConfigK, tgtHllType);
     HllSketch hllSketch;
-    try (WritableHandle handle = WritableMemory.allocateDirect(bytes,
-            ByteOrder.nativeOrder(), new DefaultMemoryRequestServer())) {
-      WritableMemory wmem = handle.getWritable();
-      hllSketch = new HllSketch(lgConfigK, tgtHllType, wmem);
-      for (int i = 0; i < n; i++) {
-        hllSketch.update(i);
-      }
-      hllSketch.couponUpdate(HllUtil.pair(7, 15)); //mock extreme values
-      hllSketch.couponUpdate(HllUtil.pair(8, 15));
-      hllSketch.couponUpdate(HllUtil.pair(9, 15));
-      //println(hllSketch.toString(true, true, true, true));
-      DirectHllArray dha = (DirectHllArray) hllSketch.hllSketchImpl;
-      assertEquals(dha.getAuxHashMap().getLgAuxArrInts(), 2);
-      assertTrue(hllSketch.isMemory());
-      assertTrue(hllSketch.isOffHeap());
-      assertTrue(hllSketch.isSameResource(wmem));
-
-      //Check heapify
-      byte[] byteArray = hllSketch.toCompactByteArray();
-      HllSketch hllSketch2 = HllSketch.heapify(byteArray);
-      HllArray ha = (HllArray) hllSketch2.hllSketchImpl;
-      assertEquals(ha.getAuxHashMap().getLgAuxArrInts(), 2);
-      assertEquals(ha.getAuxHashMap().getAuxCount(), 3);
-
-      //Check wrap
-      byteArray = hllSketch.toUpdatableByteArray();
-      WritableMemory wmem2 = WritableMemory.writableWrap(byteArray);
-      hllSketch2 = HllSketch.writableWrap(wmem2);
-      //println(hllSketch2.toString(true, true, true, true));
-      DirectHllArray dha2 = (DirectHllArray) hllSketch2.hllSketchImpl;
-      assertEquals(dha2.getAuxHashMap().getLgAuxArrInts(), 2);
-      assertEquals(dha2.getAuxHashMap().getAuxCount(), 3);
-
-      //Check grow to on-heap
-      hllSketch.couponUpdate(HllUtil.pair(10, 15)); //puts it over the edge, must grow
-      //println(hllSketch.toString(true, true, true, true));
-      dha = (DirectHllArray) hllSketch.hllSketchImpl;
-      assertEquals(dha.getAuxHashMap().getLgAuxArrInts(), 3);
-      assertEquals(dha.getAuxHashMap().getAuxCount(), 4);
-      assertTrue(hllSketch.isMemory());
-      assertFalse(hllSketch.isOffHeap());
-      assertFalse(hllSketch.isSameResource(wmem));
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    hllSketch = new HllSketch(lgConfigK, tgtHllType, wmem);
+    for (int i = 0; i < n; i++) {
+      hllSketch.update(i);
     }
+    hllSketch.couponUpdate(HllUtil.pair(7, 15)); //mock extreme values
+    hllSketch.couponUpdate(HllUtil.pair(8, 15));
+    hllSketch.couponUpdate(HllUtil.pair(9, 15));
+    //println(hllSketch.toString(true, true, true, true));
+    DirectHllArray dha = (DirectHllArray) hllSketch.hllSketchImpl;
+    assertEquals(dha.getAuxHashMap().getLgAuxArrInts(), 2);
+    assertTrue(hllSketch.isMemory());
+    assertTrue(hllSketch.isOffHeap());
+    assertTrue(hllSketch.isSameResource(wmem));
+
+    //Check heapify
+    byte[] byteArray = hllSketch.toCompactByteArray();
+    HllSketch hllSketch2 = HllSketch.heapify(byteArray);
+    HllArray ha = (HllArray) hllSketch2.hllSketchImpl;
+    assertEquals(ha.getAuxHashMap().getLgAuxArrInts(), 2);
+    assertEquals(ha.getAuxHashMap().getAuxCount(), 3);
+
+    //Check wrap
+    byteArray = hllSketch.toUpdatableByteArray();
+    WritableMemory wmem2 = WritableMemory.writableWrap(byteArray);
+    hllSketch2 = HllSketch.writableWrap(wmem2);
+    //println(hllSketch2.toString(true, true, true, true));
+    DirectHllArray dha2 = (DirectHllArray) hllSketch2.hllSketchImpl;
+    assertEquals(dha2.getAuxHashMap().getLgAuxArrInts(), 2);
+    assertEquals(dha2.getAuxHashMap().getAuxCount(), 3);
+
+    //Check grow to on-heap
+    hllSketch.couponUpdate(HllUtil.pair(10, 15)); //puts it over the edge, must grow
+    //println(hllSketch.toString(true, true, true, true));
+    dha = (DirectHllArray) hllSketch.hllSketchImpl;
+    assertEquals(dha.getAuxHashMap().getLgAuxArrInts(), 3);
+    assertEquals(dha.getAuxHashMap().getAuxCount(), 4);
+    assertTrue(hllSketch.isMemory());
+    assertFalse(hllSketch.isOffHeap());
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/hll/DirectCouponListTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectCouponListTest.java
@@ -68,27 +68,25 @@ public class DirectCouponListTest {
 
     //println("DIRECT");
     byte[] barr1;
-    WritableMemory wmem = WritableMemory.allocateDirect(bytes); //direct?
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes);
+    hllSketch = new HllSketch(lgConfigK, tgtHllType, wmem);
+    assertTrue(hllSketch.isEmpty());
 
-      hllSketch = new HllSketch(lgConfigK, tgtHllType, wmem);
-      assertTrue(hllSketch.isEmpty());
+    for (int i = 0; i < n; i++) {
+      hllSketch.update(i);
+    }
+    //println(hllSketch.toString(true, true, false, false));
+    assertFalse(hllSketch.isEmpty());
+    assertEquals(hllSketch.getCurMode(), tgtMode);
+    assertTrue(hllSketch.isMemory());
+    assertTrue(hllSketch.isOffHeap());
+    assertTrue(hllSketch.isSameResource(wmem));
 
-      for (int i = 0; i < n; i++) {
-        hllSketch.update(i);
-      }
-      //println(hllSketch.toString(true, true, false, false));
-      assertFalse(hllSketch.isEmpty());
-      assertEquals(hllSketch.getCurMode(), tgtMode);
-      assertTrue(hllSketch.isMemory());
-      assertTrue(hllSketch.isOffHeap());   //
-      assertTrue(hllSketch.isSameResource(wmem));
-
-      //convert direct sketch to byte[]
-      barr1 = (compact) ? hllSketch.toCompactByteArray() : hllSketch.toUpdatableByteArray();
-      //println(PreambleUtil.toString(barr1));
-      hllSketch.reset();
-      assertTrue(hllSketch.isEmpty());
-
+    //convert direct sketch to byte[]
+    barr1 = (compact) ? hllSketch.toCompactByteArray() : hllSketch.toUpdatableByteArray();
+    //println(PreambleUtil.toString(barr1));
+    hllSketch.reset();
+    assertTrue(hllSketch.isEmpty());
 
     //println("HEAP");
     HllSketch hllSketch2 = new HllSketch(lgConfigK, tgtHllType);
@@ -105,9 +103,7 @@ public class DirectCouponListTest {
     assertEquals(barr1.length, barr2.length, barr1.length + ", " + barr2.length);
     //printDiffs(barr1, barr2);
     assertEquals(barr1, barr2);
-    if (wmem.isCloseable()) {
-      wmem.close();
-    }
+    wmem.close();
   }
 
   @SuppressWarnings("unused") //only used when above printlns are enabled.

--- a/src/test/java/org/apache/datasketches/hll/DirectCouponListTest.java
+++ b/src/test/java/org/apache/datasketches/hll/DirectCouponListTest.java
@@ -28,7 +28,6 @@ import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 
 /**
@@ -69,11 +68,8 @@ public class DirectCouponListTest {
 
     //println("DIRECT");
     byte[] barr1;
-    WritableMemory wmem = null;
-    try (WritableHandle hand = WritableMemory.allocateDirect(bytes)) {
-      wmem = hand.getWritable();
-      //byte[] byteArr = new byte[bytes];
-      //WritableMemory wmem = WritableMemory.wrap(byteArr);
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes); //direct?
+
       hllSketch = new HllSketch(lgConfigK, tgtHllType, wmem);
       assertTrue(hllSketch.isEmpty());
 
@@ -84,7 +80,7 @@ public class DirectCouponListTest {
       assertFalse(hllSketch.isEmpty());
       assertEquals(hllSketch.getCurMode(), tgtMode);
       assertTrue(hllSketch.isMemory());
-      assertTrue(hllSketch.isOffHeap());
+      assertTrue(hllSketch.isOffHeap());   //
       assertTrue(hllSketch.isSameResource(wmem));
 
       //convert direct sketch to byte[]
@@ -92,9 +88,7 @@ public class DirectCouponListTest {
       //println(PreambleUtil.toString(barr1));
       hllSketch.reset();
       assertTrue(hllSketch.isEmpty());
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
+
 
     //println("HEAP");
     HllSketch hllSketch2 = new HllSketch(lgConfigK, tgtHllType);
@@ -111,6 +105,9 @@ public class DirectCouponListTest {
     assertEquals(barr1.length, barr2.length, barr1.length + ", " + barr2.length);
     //printDiffs(barr1, barr2);
     assertEquals(barr1, barr2);
+    if (wmem.isCloseable()) {
+      wmem.close();
+    }
   }
 
   @SuppressWarnings("unused") //only used when above printlns are enabled.

--- a/src/test/java/org/apache/datasketches/kll/KllDoublesValidationTest.java
+++ b/src/test/java/org/apache/datasketches/kll/KllDoublesValidationTest.java
@@ -160,7 +160,7 @@ public class KllDoublesValidationTest {
 
   private static int[] makeInputArray(int n, int stride) {
     assert isOdd(stride);
-    int mask = (1 << 23) - 1; // because library items are single-precision floats //TODO ?
+    int mask = (1 << 23) - 1; // because library items are single-precision floats
     int cur = 0;
     int[] arr = new int[n];
     for (int i = 0; i < n; i++) {

--- a/src/test/java/org/apache/datasketches/quantiles/DebugUnionTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DebugUnionTest.java
@@ -26,7 +26,6 @@ import static org.testng.Assert.assertTrue;
 import java.util.HashSet;
 
 import org.testng.annotations.Test;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.quantilescommon.QuantilesDoublesSketchIterator;
 
@@ -61,13 +60,10 @@ public class DebugUnionTest {
     DoublesSketch.setRandom(1); //make deterministic for test
     DoublesUnion dUnion;
     DoublesSketch dSketch;
-    try ( WritableHandle wdh = WritableMemory.allocateDirect(10_000_000) ) {
-      WritableMemory wmem = wdh.getWritable();
+    try ( WritableMemory wmem = WritableMemory.allocateDirect(10_000_000) ) {
       dUnion = DoublesUnion.builder().setMaxK(8).build(wmem);
       for (int s = 0; s < numSketches; s++) { dUnion.union(sketchArr[s]); }
       dSketch = dUnion.getResult(); //result is on heap
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
 
     //iterates and counts errors

--- a/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
@@ -70,7 +70,6 @@ public class DirectQuantilesMemoryRequestTest {
     // so the the wmem reference is invalid. Use the sketch to get the last memory reference.
     WritableMemory lastMem = usk1.getMemory();
     println("Final mem size: " + usk1.getMemory().getCapacity());
-    if (wmem.isAlive()) { System.out.println("Here"); }
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
@@ -70,6 +70,7 @@ public class DirectQuantilesMemoryRequestTest {
     // so the the wmem reference is invalid. Use the sketch to get the last memory reference.
     WritableMemory lastMem = usk1.getMemory();
     println("Final mem size: " + usk1.getMemory().getCapacity());
+    if (wmem.isAlive()) { System.out.println("Here"); }
   }
 
   @Test
@@ -78,9 +79,9 @@ public class DirectQuantilesMemoryRequestTest {
     final int u = 32; // don't need the BB to fill here
     final int initBytes = (4 + (u / 2)) << 3; // not enough to hold everything
 
-    WritableMemory mem1 = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
-    println("Initial mem size: " + mem1.getCapacity());
-    final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build(mem1);
+    WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    println("Initial mem size: " + wmem.getCapacity());
+    final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build(wmem);
     for (int i = 1; i <= u; i++) {
       usk1.update(i);
     }
@@ -96,9 +97,9 @@ public class DirectQuantilesMemoryRequestTest {
     final int u = (2 * k) - 1; //just to fill the BB
     final int initBytes = ((2 * k) + 4) << 3; //just room for BB
 
-    WritableMemory mem1 = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
-    println("Initial mem size: " + mem1.getCapacity());
-    final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build(mem1);
+    WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    println("Initial mem size: " + wmem.getCapacity());
+    final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build(wmem);
     for (int i = 1; i <= u; i++) {
       usk1.update(i);
     }
@@ -118,19 +119,19 @@ public class DirectQuantilesMemoryRequestTest {
     final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build();
     final Memory origSketchMem = Memory.wrap(usk1.toByteArray());
 
-    WritableMemory mem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
-    origSketchMem.copyTo(0, mem, 0, initBytes);
-    UpdateDoublesSketch usk2 = DirectUpdateDoublesSketch.wrapInstance(mem);
-    assertTrue(mem.isSameResource(usk2.getMemory()));
-    assertEquals(mem.getCapacity(), initBytes);
-    assertTrue(mem.isDirect());
+    WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    origSketchMem.copyTo(0, wmem, 0, initBytes);
+    UpdateDoublesSketch usk2 = DirectUpdateDoublesSketch.wrapInstance(wmem);
+    assertTrue(wmem.isSameResource(usk2.getMemory()));
+    assertEquals(wmem.getCapacity(), initBytes);
+    assertTrue(wmem.isDirect());
     assertTrue(usk2.isEmpty());
 
     //update the sketch forcing it to grow on-heap
     for (int i = 1; i <= 5; i++) { usk2.update(i); }
     assertEquals(usk2.getN(), 5);
     WritableMemory mem2 = usk2.getMemory();
-    assertFalse(mem.isAlive()); //
+    assertFalse(wmem.isAlive()); //
     assertFalse(mem2.isDirect()); //should now be on-heap
 
     final int expectedSize = COMBINED_BUFFER + ((2 * k) << 3);
@@ -146,7 +147,7 @@ public class DirectQuantilesMemoryRequestTest {
    * @param s value to print
    */
   static void println(final String s) {
-    System.out.println(s); //disable here
+    //System.out.println(s); //disable here
   }
 
 }

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -162,13 +162,16 @@ public class DoublesSketchTest {
         break;
       }
     }
+    assertFalse(wmem.isAlive());
   }
 
   @Test
   public void checkEmptyDirect() {
     WritableMemory wmem = WritableMemory.allocateDirect(1000);
     UpdateDoublesSketch sketch = DoublesSketch.builder().build(wmem);
-    sketch.toByteArray(); //exercises a specific path
+    byte[] bytes = sketch.toByteArray(); //exercises a specific path
+    byte[] result = {1,3,8,4,-128,0,0,0};
+    assertEquals(bytes, result);
     wmem.close();
   }
 

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -139,9 +139,9 @@ public class DoublesSketchTest {
 
   @Test
   public void directSketchShouldMoveOntoHeapEventually() {
-    WritableMemory mem = WritableMemory.allocateDirect(1000, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
-    UpdateDoublesSketch sketch = DoublesSketch.builder().build(mem);
-    Assert.assertTrue(sketch.isSameResource(mem));
+    WritableMemory wmem = WritableMemory.allocateDirect(1000, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    UpdateDoublesSketch sketch = DoublesSketch.builder().build(wmem);
+    Assert.assertTrue(sketch.isSameResource(wmem));
     for (int i = 0; i < 1000; i++) {
       sketch.update(i);
     }
@@ -151,11 +151,11 @@ public class DoublesSketchTest {
   @Test
   public void directSketchShouldMoveOntoHeapEventually2() {
     int i = 0;
-    WritableMemory mem = WritableMemory.allocateDirect(50, ByteOrder.LITTLE_ENDIAN, new DefaultMemoryRequestServer());
-    UpdateDoublesSketch sketch = DoublesSketch.builder().build(mem);
-    Assert.assertTrue(sketch.isSameResource(mem));
+    WritableMemory wmem = WritableMemory.allocateDirect(50, ByteOrder.LITTLE_ENDIAN, new DefaultMemoryRequestServer());
+    UpdateDoublesSketch sketch = DoublesSketch.builder().build(wmem);
+    Assert.assertTrue(sketch.isSameResource(wmem));
     for (; i < 1000; i++) {
-      if (mem.isAlive()) {
+      if (wmem.isAlive()) {
         sketch.update(i);
       } else {
         println("Sketch Move to Heap at i = " + i);
@@ -166,9 +166,10 @@ public class DoublesSketchTest {
 
   @Test
   public void checkEmptyDirect() {
-    WritableMemory mem = WritableMemory.allocateDirect(1000);
-    UpdateDoublesSketch sketch = DoublesSketch.builder().build(mem);
+    WritableMemory wmem = WritableMemory.allocateDirect(1000);
+    UpdateDoublesSketch sketch = DoublesSketch.builder().build(wmem);
     sketch.toByteArray(); //exercises a specific path
+    wmem.close();
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/PreambleUtilTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/PreambleUtilTest.java
@@ -40,7 +40,6 @@ import static org.testng.Assert.assertEquals;
 import org.testng.annotations.Test;
 
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 
 public class PreambleUtilTest {
@@ -48,8 +47,7 @@ public class PreambleUtilTest {
   @Test
   public void checkInsertsAndExtracts() {
     final int bytes = 32;
-    try (WritableHandle offHeapMemHandler = WritableMemory.allocateDirect(bytes)) {
-      final WritableMemory offHeapMem = offHeapMemHandler.getWritable();
+    try (WritableMemory offHeapMem = WritableMemory.allocateDirect(bytes)) {
       final WritableMemory onHeapMem = WritableMemory.writableWrap(new byte[bytes]);
 
       onHeapMem.clear();
@@ -156,8 +154,6 @@ public class PreambleUtilTest {
       assertEquals(offHD, vD);
       onHeapMem.clear();
       offHeapMem.clear();
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/src/test/java/org/apache/datasketches/theta/CompactSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/CompactSketchTest.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.assertTrue;
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
@@ -78,8 +77,7 @@ public class CompactSketchTest {
     //Prepare Memory for direct
     int bytes = usk.getCompactBytes(); //for Compact
 
-    try (WritableHandle wdh = WritableMemory.allocateDirect(bytes)) {
-      WritableMemory directMem = wdh.getWritable();
+    try (WritableMemory directMem = WritableMemory.allocateDirect(bytes)) {
 
       /**Via CompactSketch.compact**/
       refSk = usk.compact(ordered, directMem);
@@ -90,8 +88,6 @@ public class CompactSketchTest {
       /**Via CompactSketch.compact**/
       testSk = (CompactSketch)Sketch.wrap(directMem);
       checkByRange(refSk, testSk, u, ordered);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
@@ -74,26 +74,18 @@ public class DirectQuickSelectSketchTest {
     }
   }
 
-  @Test//(expectedExceptions = SketchesArgumentException.class)
+  @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkConstructorKtooSmall() {
     int k = 8;
-    try (WritableMemory mem = makeNativeMemory(k)) {
-      UpdateSketch.builder().setNominalEntries(k).build(mem);
-    } catch (final Exception e) {
-      if (e instanceof SketchesArgumentException) {}
-      else { throw new RuntimeException(e); }
-    }
+    WritableMemory mem = makeNativeMemory(k);
+    UpdateSketch.builder().setNominalEntries(k).build(mem);
   }
 
-  @Test//(expectedExceptions = SketchesArgumentException.class)
+  @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkConstructorMemTooSmall() {
     int k = 16;
-    try (WritableMemory mem = makeNativeMemory(k/2)) {
-      UpdateSketch.builder().setNominalEntries(k).build(mem);
-    } catch (final Exception e) {
-      if (e instanceof SketchesArgumentException) {}
-      else { throw new RuntimeException(e); }
-    }
+    WritableMemory mem = makeNativeMemory(k/2);
+    UpdateSketch.builder().setNominalEntries(k).build(mem);
   }
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
@@ -45,7 +45,6 @@ import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesReadOnlyException;
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.HashOperations;
 import org.apache.datasketches.thetacommon.ThetaUtil;
@@ -56,19 +55,15 @@ import org.testng.annotations.Test;
  */
 public class DirectQuickSelectSketchTest {
 
-  @Test//(expectedExceptions = SketchesArgumentException.class)
+  @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkBadSerVer() {
     int k = 512;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
-
       assertTrue(usk.isEmpty());
 
       for (int i = 0; i< k; i++) { usk.update(i); }
-
       assertFalse(usk.isEmpty());
       assertEquals(usk.getEstimate(), k, 0.0);
       assertEquals(sk1.getRetainedEntries(false), k);
@@ -76,17 +71,13 @@ public class DirectQuickSelectSketchTest {
       mem.putByte(SER_VER_BYTE, (byte) 0); //corrupt the SerVer byte
 
       Sketch.wrap(mem);
-    } catch (final Exception e) {
-      if (e instanceof SketchesArgumentException) {}
-      else { throw new RuntimeException(e); }
     }
   }
 
   @Test//(expectedExceptions = SketchesArgumentException.class)
   public void checkConstructorKtooSmall() {
     int k = 8;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch.builder().setNominalEntries(k).build(mem);
     } catch (final Exception e) {
       if (e instanceof SketchesArgumentException) {}
@@ -97,8 +88,7 @@ public class DirectQuickSelectSketchTest {
   @Test//(expectedExceptions = SketchesArgumentException.class)
   public void checkConstructorMemTooSmall() {
     int k = 16;
-    try (WritableHandle h = makeNativeMemory(k/2)) {
-      WritableMemory mem = h.getWritable();
+    try (WritableMemory mem = makeNativeMemory(k/2)) {
       UpdateSketch.builder().setNominalEntries(k).build(mem);
     } catch (final Exception e) {
       if (e instanceof SketchesArgumentException) {}
@@ -124,9 +114,7 @@ public class DirectQuickSelectSketchTest {
     int k = 512;
     int u = 2*k; //thus estimating
 
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch sk1 = UpdateSketch.builder().setNominalEntries(k).build(mem);
       for (int i=0; i<u; i++) { sk1.update(i); }
 
@@ -158,8 +146,6 @@ public class DirectQuickSelectSketchTest {
       assertFalse(sk2.isDirect());
       assertFalse(sk2.hasMemory());
       assertFalse(sk2.isDirty());
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -168,7 +154,6 @@ public class DirectQuickSelectSketchTest {
     int k = 512;
     int maxBytes = (k << 4) + (Family.QUICKSELECT.getMinPreLongs() << 3);
     WritableMemory mem = WritableMemory.writableWrap(new byte[maxBytes]);
-
     UpdateSketch.builder().setNominalEntries(k).build(mem);
 
     mem.putByte(FAMILY_BYTE, (byte) 0); //corrupt the Sketch ID byte
@@ -182,7 +167,6 @@ public class DirectQuickSelectSketchTest {
     int k = 512;
     int maxBytes = (k << 4) + (Family.QUICKSELECT.getMinPreLongs() << 3);
     WritableMemory mem = WritableMemory.writableWrap(new byte[maxBytes]);
-
     UpdateSketch.builder().setNominalEntries(k).build(mem);
 
     mem.putByte(FAMILY_BYTE, (byte) 0); //corrupt the Sketch ID byte
@@ -191,44 +175,33 @@ public class DirectQuickSelectSketchTest {
     DirectQuickSelectSketch.writableWrap(mem, ThetaUtil.DEFAULT_UPDATE_SEED);
   }
 
-  @Test //(expectedExceptions = SketchesArgumentException.class)
+  @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkHeapifySeedConflict() {
     int k = 512;
     long seed1 = 1021;
     long seed2 = ThetaUtil.DEFAULT_UPDATE_SEED;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setSeed(seed1).setNominalEntries(k).build(mem);
       byte[] byteArray = usk.toByteArray();
       Memory srcMem = Memory.wrap(byteArray);
       Sketch.heapify(srcMem, seed2);
-    } catch (final Exception e) {
-      if (e instanceof SketchesArgumentException) {}
-      else { throw new RuntimeException(e); }
     }
   }
 
-  @Test//(expectedExceptions = SketchesArgumentException.class)
+  @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkCorruptLgNomLongs() {
     int k = 16;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch.builder().setNominalEntries(k).build(mem);
       mem.putByte(LG_NOM_LONGS_BYTE, (byte)2); //corrupt
       Sketch.heapify(mem, ThetaUtil.DEFAULT_UPDATE_SEED);
-    } catch (final Exception e) {
-      if (e instanceof SketchesArgumentException) {}
-      else { throw new RuntimeException(e); }
     }
   }
 
   @Test
   public void checkHeapifyByteArrayExact() {
     int k = 512;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
 
       for (int i=0; i< k; i++) { usk.update(i); }
@@ -250,8 +223,6 @@ public class DirectQuickSelectSketchTest {
       // That is, this is being run for its side-effect of accessing things.
       // If something is wonky, it will generate an exception and fail the test.
       usk2.toString(true, true, 8, true);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -259,8 +230,7 @@ public class DirectQuickSelectSketchTest {
   public void checkHeapifyByteArrayEstimating() {
     int k = 4096;
     int u = 2*k;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
 
       for (int i=0; i<u; i++) { usk.update(i); }
@@ -279,8 +249,6 @@ public class DirectQuickSelectSketchTest {
       assertEquals(usk2.isEmpty(), false);
       assertEquals(usk2.isEstimationMode(), true);
       assertEquals(usk2.getClass().getSimpleName(), "HeapQuickSelectSketch");
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -288,9 +256,7 @@ public class DirectQuickSelectSketchTest {
   public void checkWrapMemoryEst() {
     int k = 512;
     int u = 2*k; //thus estimating
-
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch sk1 = UpdateSketch.builder().setNominalEntries(k).build(mem);
       for (int i=0; i<u; i++) { sk1.update(i); }
 
@@ -306,8 +272,6 @@ public class DirectQuickSelectSketchTest {
       assertEquals(sk2.getUpperBound(2), sk1ub);
       assertEquals(sk2.isEmpty(), false);
       assertTrue(sk2.isEstimationMode());
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -315,9 +279,7 @@ public class DirectQuickSelectSketchTest {
   public void checkDQStoCompactForms() {
     int k = 512;
     int u = 4*k; //thus estimating
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
 
@@ -377,17 +339,13 @@ public class DirectQuickSelectSketchTest {
       assertTrue(csk.isEstimationMode());
       assertEquals(csk.getClass().getSimpleName(), "DirectCompactSketch");
       csk.toString(false, true, 0, false);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
   @Test
   public void checkDQStoCompactEmptyForms() {
     int k = 512;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
 
       //empty
@@ -420,9 +378,6 @@ public class DirectQuickSelectSketchTest {
       assertEquals(csk3.isEmpty(), true);
       assertEquals(csk3.isEstimationMode(), false);
       assertEquals(csk3.getClass().getSimpleName(), "DirectCompactSketch");
-    } catch (final Exception e) {
-      //if (e instanceof SketchesArgumentException) {}
-      throw new RuntimeException(e);
     }
   }
 
@@ -431,9 +386,7 @@ public class DirectQuickSelectSketchTest {
     int k = 4096;
     int u = 2*k;
 
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
 
@@ -442,8 +395,6 @@ public class DirectQuickSelectSketchTest {
       for (int i = 0; i< u; i++) { usk.update(i); }
 
       assertTrue(sk1.getRetainedEntries(false) > k);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -452,9 +403,7 @@ public class DirectQuickSelectSketchTest {
     int k = 4096;
     float p = (float)0.5;
 
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setP(p).setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
 
@@ -470,17 +419,13 @@ public class DirectQuickSelectSketchTest {
       assertTrue(ub > est);
       double lb = usk.getLowerBound(1);
       assertTrue(lb < est);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
   @Test
   public void checkErrorBounds() {
     int k = 512;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
 
       //Exact mode
@@ -503,8 +448,6 @@ public class DirectQuickSelectSketchTest {
       ub = usk.getUpperBound(2);
       assertTrue(est <= ub);
       assertTrue(est >= lb);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -514,9 +457,7 @@ public class DirectQuickSelectSketchTest {
     //virgin, p = 1.0
     int k = 1024;
     float p = (float)1.0;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setP(p).setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
 
@@ -545,8 +486,6 @@ public class DirectQuickSelectSketchTest {
       double lb = usk2.getLowerBound(2);
       assertTrue(lb <= est);
       //println("LB: "+lb);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -554,9 +493,7 @@ public class DirectQuickSelectSketchTest {
   public void checkUpperAndLowerBounds() {
     int k = 512;
     int u = 2*k;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
 
       for (int i = 0; i < u; i++ ) { usk.update(i); }
@@ -566,8 +503,6 @@ public class DirectQuickSelectSketchTest {
       double lb = usk.getLowerBound(1);
       assertTrue(ub > est);
       assertTrue(lb < est);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -575,9 +510,7 @@ public class DirectQuickSelectSketchTest {
   public void checkRebuild() {
     int k = 512;
     int u = 4*k;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
 
@@ -595,8 +528,6 @@ public class DirectQuickSelectSketchTest {
       sk1.rebuild();
       assertEquals(sk1.getRetainedEntries(false), k);
       assertEquals(sk1.getRetainedEntries(true), k);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -604,9 +535,7 @@ public class DirectQuickSelectSketchTest {
   public void checkResetAndStartingSubMultiple() {
     int k = 512;
     int u = 4*k;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
 
@@ -626,8 +555,6 @@ public class DirectQuickSelectSketchTest {
 
       assertNotNull(sk1.getMemory());
       assertFalse(sk1.isOrdered());
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -635,9 +562,7 @@ public class DirectQuickSelectSketchTest {
   public void checkExactModeMemoryArr() {
     int k = 4096;
     int u = 4096;
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
       assertTrue(usk.isEmpty());
@@ -646,8 +571,6 @@ public class DirectQuickSelectSketchTest {
 
       assertEquals(usk.getEstimate(), u, 0.0);
       assertEquals(sk1.getRetainedEntries(false), u);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -656,9 +579,7 @@ public class DirectQuickSelectSketchTest {
     int k = 4096;
     int u = 2*k;
 
-    try (WritableHandle h = makeNativeMemory(k)) {
-      WritableMemory mem = h.getWritable();
-
+    try (WritableMemory mem = makeNativeMemory(k)) {
       UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
       assertTrue(usk.isEmpty());
@@ -667,8 +588,6 @@ public class DirectQuickSelectSketchTest {
 
       assertEquals(usk.getEstimate(), u, u*.05);
       assertTrue(sk1.getRetainedEntries(false) > k);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -678,9 +597,8 @@ public class DirectQuickSelectSketchTest {
     int u = 2*k;
     int memCapacity = (k << 4) + (Family.QUICKSELECT.getMinPreLongs() << 3);
 
-    try(WritableHandle memHandler = WritableMemory.allocateDirect(memCapacity)) {
-
-      UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(memHandler.getWritable());
+    try(WritableMemory mem = WritableMemory.allocateDirect(memCapacity)) {
+      UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       DirectQuickSelectSketch sk1 = (DirectQuickSelectSketch)usk; //for internal checks
       assertTrue(usk.isEmpty());
 
@@ -689,8 +607,6 @@ public class DirectQuickSelectSketchTest {
       println(""+est);
       assertEquals(usk.getEstimate(), u, u*.05);
       assertTrue(sk1.getRetainedEntries(false) > k);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -699,8 +615,8 @@ public class DirectQuickSelectSketchTest {
     int k = 4096;
     int u = 2*k;
 
-    try (WritableHandle h = makeNativeMemory(k)) {
-      UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(h.getWritable());
+    try (WritableMemory mem = makeNativeMemory(k)) {
+      UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).build(mem);
       assertTrue(usk.isEmpty());
 
       for (int i = 0; i< u; i++) { usk.update(i); } //force estimation
@@ -726,8 +642,6 @@ public class DirectQuickSelectSketchTest {
 
       assertEquals(count2, count1);
       assertEquals(est2, est1, 0.0);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -868,15 +782,12 @@ public class DirectQuickSelectSketchTest {
     int k = 1 << 12;
     int u = 2 * k;
     int bytes = Sketches.getMaxUpdateSketchBytes(k);
-      try (WritableHandle wdh = WritableMemory.allocateDirect(bytes/2)) { //will request
-      WritableMemory wmem = wdh.getWritable();
-      UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
-      assertTrue(sketch.isSameResource(wmem));
-      for (int i = 0; i < u; i++) { sketch.update(i); }
-      assertFalse(sketch.isSameResource(wmem));
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes/2); //will request
+    UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
+    assertTrue(sketch.isSameResource(wmem));
+    for (int i = 0; i < u; i++) { sketch.update(i); }
+    assertTrue(sketch.getMemory().isAlive());
+    assertFalse(wmem.isAlive());
   }
 
   @Test
@@ -884,34 +795,28 @@ public class DirectQuickSelectSketchTest {
     int k = 1 << 12;
     int u = 2 * k;
     int bytes = Sketches.getMaxUpdateSketchBytes(k);
-    try (WritableHandle wdh = WritableMemory.allocateDirect(bytes/2)) { //will request
-      WritableMemory wmem = wdh.getWritable();
-      UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
-      for (int i = 0; i < u; i++) { sketch.update(i); }
-      double est1 = sketch.getEstimate();
-      byte[] ser = sketch.toByteArray();
-      Memory mem = Memory.wrap(ser);
-      UpdateSketch roSketch = (UpdateSketch) Sketches.wrapSketch(mem);
-      double est2 = roSketch.getEstimate();
-      assertEquals(est2, est1);
-      try {
-        roSketch.rebuild();
-        fail();
-      } catch (SketchesReadOnlyException e) {
-        //expected
-      }
-      try {
-        roSketch.reset();
-        fail();
-      } catch (SketchesReadOnlyException e) {
-        //expected
-      }
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes/2); //will request
+    UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
+    for (int i = 0; i < u; i++) { sketch.update(i); }
+    double est1 = sketch.getEstimate();
+    byte[] ser = sketch.toByteArray();
+    Memory mem = Memory.wrap(ser);
+    UpdateSketch roSketch = (UpdateSketch) Sketches.wrapSketch(mem);
+    double est2 = roSketch.getEstimate();
+    assertEquals(est2, est1);
+    try {
+      roSketch.rebuild();
+      fail();
+    } catch (SketchesReadOnlyException e) {
+      //expected
     }
-
+    try {
+      roSketch.reset();
+      fail();
+    } catch (SketchesReadOnlyException e) {
+      //expected
+    }
   }
-
 
   @Test
   public void printlnTest() {
@@ -929,7 +834,7 @@ public class DirectQuickSelectSketchTest {
     return (k << 4) + (Family.QUICKSELECT.getMinPreLongs() << 3);
   }
 
-  private static WritableHandle makeNativeMemory(int k) {
+  private static WritableMemory makeNativeMemory(int k) {
     return WritableMemory.allocateDirect(getMaxBytes(k));
   }
 

--- a/src/test/java/org/apache/datasketches/theta/HeapifyWrapSerVer1and2Test.java
+++ b/src/test/java/org/apache/datasketches/theta/HeapifyWrapSerVer1and2Test.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
 import org.apache.datasketches.tuple.Util;
@@ -39,29 +38,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = Sketches.heapifyCompactSketch(sv3cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = Sketches.heapifyCompactSketch(cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv2cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = Sketches.heapifyCompactSketch(sv2cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv1cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = Sketches.heapifyCompactSketch(sv1cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
   }
 
   @Test
@@ -69,29 +68,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = Sketches.heapifyCompactSketch(sv3cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = Sketches.heapifyCompactSketch(cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv2cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = Sketches.heapifyCompactSketch(sv2cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv1cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), defaultSeedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = Sketches.heapifyCompactSketch(sv1cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), defaultSeedHash);
   }
 
   @Test
@@ -99,29 +98,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = Sketches.heapifyCompactSketch(sv3cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = Sketches.heapifyCompactSketch(cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv2cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = Sketches.heapifyCompactSketch(sv2cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv1cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = Sketches.heapifyCompactSketch(sv1cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
   }
 
   @Test
@@ -129,29 +128,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = Sketches.heapifyCompactSketch(sv3cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = Sketches.heapifyCompactSketch(cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv2cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = Sketches.heapifyCompactSketch(sv2cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = Sketches.heapifyCompactSketch(sv1cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = Sketches.heapifyCompactSketch(sv1cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
   }
 
   @Test
@@ -159,29 +158,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv3cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = (CompactSketch) Sketches.heapifySketch(cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
   }
 
   @Test
@@ -189,29 +188,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv3cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = (CompactSketch) Sketches.heapifySketch(cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), defaultSeedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), defaultSeedHash);
   }
 
   @Test
@@ -219,29 +218,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv3cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = (CompactSketch) Sketches.heapifySketch(cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
   }
 
   @Test
@@ -249,29 +248,29 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
 
-    CompactSketch sv3csk = sv3usk.compact();
-    Memory sv3cskMem = Memory.wrap(sv3csk.toByteArray());
-    CompactSketch sv3cskResult;
+    CompactSketch csk = usk.compact();
+    Memory cskMem = Memory.wrap(csk.toByteArray());
+    CompactSketch cskResult;
 
-    //SV3 test
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv3cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion3 test
+    cskResult = (CompactSketch) Sketches.heapifySketch(cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV2 test
-    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion2 test
+    Memory sv2cskMem = BackwardConversions.convertSerVer3toSerVer2(csk, seed);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv2cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
 
-    //SV1 test
-    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(sv3csk);
-    sv3cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem, seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
+    //SerialVersion1 test
+    Memory sv1cskMem = BackwardConversions.convertSerVer3toSerVer1(csk);
+    cskResult = (CompactSketch) Sketches.heapifySketch(sv1cskMem, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
   }
 
   @Test
@@ -279,35 +278,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = Sketches.wrapCompactSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = Sketches.wrapCompactSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = Sketches.wrapCompactSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -315,35 +314,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = Sketches.wrapCompactSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = Sketches.wrapCompactSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), defaultSeedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = Sketches.wrapCompactSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), defaultSeedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -351,35 +350,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = Sketches.wrapCompactSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = Sketches.wrapCompactSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {/* ignore */}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = Sketches.wrapCompactSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -387,35 +386,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = Sketches.wrapCompactSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = Sketches.wrapCompactSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = Sketches.wrapCompactSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = Sketches.wrapCompactSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -423,35 +422,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -459,35 +458,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable());
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), defaultSeedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), defaultSeedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -495,35 +494,35 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = ThetaUtil.DEFAULT_UPDATE_SEED;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i=0; i<k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
   @Test
@@ -531,43 +530,42 @@ public class HeapifyWrapSerVer1and2Test {
     final int k = 64;
     final long seed = 128L;
     final short seedHash = Util.computeSeedHash(seed);
-    UpdateSketch sv3usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
-    for (int i=0; i<k; i++) { sv3usk.update(i); }
-    CompactSketch sv3cskResult;
-    WritableHandle wh;
-    CompactSketch sv3csk = sv3usk.compact();
+    UpdateSketch usk = UpdateSketch.builder().setNominalEntries(k).setSeed(seed).build();
+    for (int i = 0; i < k; i++) { usk.update(i); }
+    CompactSketch cskResult;
+    WritableMemory offHeap;
+    CompactSketch csk = usk.compact();
 
-    //SV3 test
-    wh = putOffHeap(Memory.wrap(sv3csk.toByteArray()));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertTrue(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion3 test
+    offHeap = putOffHeap(Memory.wrap(csk.toByteArray()));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertTrue(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV2 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(sv3csk, seed));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion2 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer2(csk, seed));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
 
-    //SV1 test
-    wh = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(sv3csk));
-    sv3cskResult = (CompactSketch) Sketches.wrapSketch(wh.getWritable(), seed);
-    assertEquals(sv3cskResult.getEstimate(), sv3usk.getEstimate());
-    assertEquals(sv3cskResult.getSeedHash(), seedHash);
-    assertFalse(sv3cskResult.isDirect());
-    try { wh.close(); } catch (Exception e) {}
+    //SerialVersion1 test
+    offHeap = putOffHeap(BackwardConversions.convertSerVer3toSerVer1(csk));
+    cskResult = (CompactSketch) Sketches.wrapSketch(offHeap, seed);
+    assertEquals(cskResult.getEstimate(), usk.getEstimate());
+    assertEquals(cskResult.getSeedHash(), seedHash);
+    assertFalse(cskResult.isDirect());
+    try { offHeap.close(); } catch (Exception e) { throw new RuntimeException(e); }
   }
 
-  private static WritableHandle putOffHeap(Memory heapMem) {
+  private static WritableMemory putOffHeap(Memory heapMem) {
     final long cap = heapMem.getCapacity();
-    WritableHandle wh = WritableMemory.allocateDirect(cap);
-    WritableMemory wmem = wh.getWritable();
+    WritableMemory wmem = WritableMemory.allocateDirect(cap);
     heapMem.copyTo(0, wmem, 0, cap);
-    return wh;
+    return wmem;
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/SketchesTest.java
+++ b/src/test/java/org/apache/datasketches/theta/SketchesTest.java
@@ -145,7 +145,8 @@ public class SketchesTest {
     assertEquals(24+(k+1)*8, maxCompSkBytes);
 
     final int compSkMaxBytes = getCompactSketchMaxBytes(lgK); {
-      assertEquals(compSkMaxBytes, ((2 << lgK) * 15) / 16 + (Family.QUICKSELECT.getMaxPreLongs() << 3));
+      int bytes = (int)((2 << lgK) * ThetaUtil.REBUILD_THRESHOLD + Family.QUICKSELECT.getMaxPreLongs()) * Long.BYTES;
+      assertEquals(compSkMaxBytes, bytes);
     }
 
     final int maxSkBytes = getMaxUpdateSketchBytes(k);

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -27,7 +27,6 @@ import static org.testng.Assert.assertTrue;
 
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.Memory;
-import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
 import org.testng.annotations.Test;
@@ -192,24 +191,19 @@ public class UnionImplTest {
     final int k = 1 << 12;
     final int u = 2 * k;
     final int bytes = Sketches.getMaxUpdateSketchBytes(k);
-    try (WritableHandle wh = WritableMemory.allocateDirect(bytes/2);
-        WritableHandle wh2 = WritableMemory.allocateDirect(bytes/2) ) {
-      final WritableMemory wmem = wh.getWritable();
-      final UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
-      assertTrue(sketch.isSameResource(wmem));
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes / 2);
+    WritableMemory wmem2 = WritableMemory.allocateDirect(bytes / 2);
+    final UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
+    assertTrue(sketch.isSameResource(wmem));
 
-      final WritableMemory wmem2 = wh2.getWritable();
-      final Union union = SetOperation.builder().buildUnion(wmem2);
-      assertTrue(union.isSameResource(wmem2));
+    final Union union = SetOperation.builder().buildUnion(wmem2);
+    assertTrue(union.isSameResource(wmem2));
 
-      for (int i = 0; i < u; i++) { union.update(i); }
-      assertFalse(union.isSameResource(wmem));
+    for (int i = 0; i < u; i++) { union.update(i); }
+    assertFalse(union.isSameResource(wmem));
 
-      final Union union2 = SetOperation.builder().buildUnion(); //on-heap union
-      assertFalse(union2.isSameResource(wmem2));  //obviously not
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
-    }
+    final Union union2 = SetOperation.builder().buildUnion(); //on-heap union
+    assertFalse(union2.isSameResource(wmem2));  //obviously not
   }
 
   @Test
@@ -230,15 +224,12 @@ public class UnionImplTest {
     final double est1 = sk.getEstimate();
 
     final int bytes = Sketches.getMaxCompactSketchBytes(sk.getRetainedEntries(true));
-    try (WritableHandle h = WritableMemory.allocateDirect(bytes)) {
-      final WritableMemory wmem = h.getWritable();
+    try (WritableMemory wmem = WritableMemory.allocateDirect(bytes)) {
       final CompactSketch csk = sk.compact(true, wmem); //ordered, direct
       final Union union = Sketches.setOperationBuilder().buildUnion();
       union.union(csk);
       final double est2 = union.getResult().getEstimate();
       assertEquals(est2, est1);
-    } catch (final Exception e) {
-      throw new RuntimeException(e);
     }
   }
 

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -187,14 +187,14 @@ public class UnionImplTest {
   }
 
   @Test
-  public void checkMoveAndResize() {
+  public void checkMoveAndResizeOffHeap() {
     final int k = 1 << 12;
     final int u = 2 * k;
     final int bytes = Sketches.getMaxUpdateSketchBytes(k);
-    WritableMemory wmem = WritableMemory.allocateDirect(bytes / 2);
+    WritableMemory wmem = WritableMemory.allocateDirect(bytes / 2); //too small, forces new allocation on heap
     WritableMemory wmem2 = WritableMemory.allocateDirect(bytes / 2);
     final UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
-    assertTrue(sketch.isSameResource(wmem));
+    assertTrue(sketch.isSameResource(wmem)); //also testing the isSameResource function
 
     final Union union = SetOperation.builder().buildUnion(wmem2);
     assertTrue(union.isSameResource(wmem2));
@@ -205,6 +205,7 @@ public class UnionImplTest {
     final Union union2 = SetOperation.builder().buildUnion(); //on-heap union
     assertFalse(union2.isSameResource(wmem2));  //obviously not
     wmem.close();
+    //note wmem2 has already been closed by the DefaultMemoryRequestServer
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -204,6 +204,7 @@ public class UnionImplTest {
 
     final Union union2 = SetOperation.builder().buildUnion(); //on-heap union
     assertFalse(union2.isSameResource(wmem2));  //obviously not
+    wmem.close();
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/UpdateSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UpdateSketchTest.java
@@ -213,8 +213,8 @@ public class UpdateSketchTest {
     UpdateSketch sk = Sketches.updateSketchBuilder().setLogNominalEntries(lgK).build();
     int n = 1 << (lgK + 1);
     for (int i = 2; i < n; i++) { sk.update(i); }
-    int cbytes = sk.getCompactBytes();
-    byte[] byteArr = sk.toByteArray();
+    int cbytes = sk.getCompactBytes(); //560
+    byte[] byteArr = sk.toByteArray(); //1048
     skwmem = WritableMemory.writableWrap(byteArr);
     cskwmem1 = WritableMemory.allocate(cbytes);
     cskwmem2 = WritableMemory.allocate(cbytes);
@@ -222,8 +222,8 @@ public class UpdateSketchTest {
     csk1 = sk.compact(true, cskwmem1);
     csk2 = CompactOperations.memoryToCompact(skwmem, true, cskwmem2);
     csk3 = CompactOperations.memoryToCompact(cskwmem1, true, cskwmem3);
-    assertTrue(cskwmem1.equals(cskwmem2));
-    assertTrue(cskwmem1.equals(cskwmem3));
+    assertTrue(cskwmem1.equalTo(cskwmem2)); //both 560
+    assertTrue(cskwmem1.equalTo(cskwmem3));
   }
 
   @Test


### PR DESCRIPTION
This PR is targeting a DS-Java 6.1.0 release.  The changes in this PR make the Java repo consistent with the just released Memory 3.0.0.  This ds-java release is still targeted for Java 8 and 11 and will likely be the last release supporting Java 8 and 11.  If all goes as planned, the next release will be DS-Java 7.0.0, which will be targeted at Java 17.

All of the following changes are **_internal_** and do not impact the DS-Java API.

DS-Java changes from Master to branch _java8-11_changes_consistent_with_17_:

**common/Util.java**
* 1 javadoc
  
**theta/Sketch**
* Deprecation removed on getMaxCompactSketchBytes
* bug fix: getCompactSketchMaxBytes(lgK)
  
**theta/Sketches**
* Deprecation removed on getMaxCompactSketchBytes(numEntries), Javadoc improved.
  
**filters/bloomfilter**
* all new code for 6.1.0.  
* changes are to make the calls to Memory compatible with Memory 3.0.0.

**hll/DirectAuxHashMapTest**
* WritableHandle removed

**hll/DirectCouponListTest**
* WritableHandle removed

**kll/KllDoublesValidationTest**
*  code comment change
  
**quantiles/DebugUnionTest**
* WritableHandle removed
  
**quantiles/DirectQuantilesMemoryRequestTest**
* WritableHandle removed

**quantiles/DoublesSketchTest**
* WritableHandle removed
  
**quantiles/PreambleUtilTest**
* WritableHandle removed
  
**theta/CompactSketchTest**
* WritableHandle removed
  
**theta/DirectQuickSelectSketchTest**
* WritableHandle removed

**theta/HeapifyWrapSerVer1and2Test**
* All variable renaming

**theta/SketchesTest**
* bug fix: getCompactSketchMaxBytes

**theta/UnionImplTest**
* WritableHandle removed  

**theta/UpdateSketchTest**
* removed some code comments

**pom.xml**
* updated Memory dependency to 3.0.0
* Removed some comments
* Reorganized the <properties> section
* updated some of the plugin versions

**Readme**
* Fixed the badges
* Removed references to "-P strict"
