### PR TITLE
Fix a memory leak in test.

### DIFF
--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -205,7 +205,7 @@ public class UnionImplTest {
     final Union union2 = SetOperation.builder().buildUnion(); //on-heap union
     assertFalse(union2.isSameResource(wmem2));  //obviously not
     wmem.close(); //empty, but we must close it anyway.
-    //note wmem2 has already been closed by the DefaultMemoryRequestServer.
+    assertFalse(wmem2.isAlive());//previously closed via the DefaultMemoryRequestServer.
   }
 
   @Test


### PR DESCRIPTION
This was a memory leak in the tests.  It only shows up when the tests run long enough and generate enough garbage for the garbage collector to activate and call finalize.  It only showed up when running all the tests for the java library.  Running individual tests it will not show up. I would see the warning after all the tests have run, but, of course, the warning message doesn't provide any clues about where the culprit  is, it can't!  It was kind of a cat-and-mouse game to find it, but I finally figured out a way to track it down.  

This leak has been there a while, but it was only in the test code. So no real harm done.  Release 6.1.0 is coming soon, I think it is safe to release it then. 

