### PR TITLE
Add new MemoryStatus interface to Theta.

### DIFF
--- a/src/main/java/org/apache/datasketches/common/MemoryStatus.java
+++ b/src/main/java/org/apache/datasketches/common/MemoryStatus.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.datasketches.common;
 
 import org.apache.datasketches.memory.Memory;

--- a/src/main/java/org/apache/datasketches/common/MemoryStatus.java
+++ b/src/main/java/org/apache/datasketches/common/MemoryStatus.java
@@ -1,0 +1,35 @@
+package org.apache.datasketches.common;
+
+import org.apache.datasketches.memory.Memory;
+
+/**
+ * Methods for inquiring the status of a backing Memory object.
+ */
+public interface MemoryStatus {
+
+  /**
+   * Returns true if this object's internal data is backed by a Memory object,
+   * which may be on-heap or off-heap.
+   * @return true if this object's internal data is backed by a Memory object.
+   */
+  default boolean hasMemory() { return false; }
+
+  /**
+   * Returns true if this object's internal data is backed by direct (off-heap) Memory.
+   * @return true if this object's internal data is backed by direct (off-heap) Memory.
+   */
+  default boolean isDirect() { return false; }
+
+  /**
+   * Returns true if the backing resource of <i>this</i> is identical with the backing resource
+   * of <i>that</i>. The capacities must be the same.  If <i>this</i> is a region,
+   * the region offset must also be the same.
+   *
+   * @param that A different non-null and alive Memory object.
+   * @return true if the backing resource of <i>this</i> is identical with the backing resource
+   * of <i>that</i>.
+   * @throws SketchesArgumentException if <i>that</i> is not alive (already closed).
+   */
+  default boolean isSameResource(final Memory that) { return false; }
+
+}

--- a/src/main/java/org/apache/datasketches/common/MemoryStatus.java
+++ b/src/main/java/org/apache/datasketches/common/MemoryStatus.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.datasketches.common;
 
 import org.apache.datasketches.memory.Memory;

--- a/src/main/java/org/apache/datasketches/theta/AnotBimpl.java
+++ b/src/main/java/org/apache/datasketches/theta/AnotBimpl.java
@@ -26,7 +26,6 @@ import static org.apache.datasketches.thetacommon.HashOperations.hashSearch;
 import java.util.Arrays;
 
 import org.apache.datasketches.common.SketchesArgumentException;
-import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.thetacommon.ThetaUtil;
 
@@ -146,11 +145,6 @@ final class AnotBimpl extends AnotB {
   @Override
   int getRetainedEntries() {
     return curCount_;
-  }
-
-  @Override
-  public boolean isSameResource(final Memory that) {
-    return false;
   }
 
   //restricted

--- a/src/main/java/org/apache/datasketches/theta/ConcurrentHeapThetaBuffer.java
+++ b/src/main/java/org/apache/datasketches/theta/ConcurrentHeapThetaBuffer.java
@@ -26,6 +26,7 @@ import static org.apache.datasketches.theta.UpdateReturnState.RejectedOverTheta;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.datasketches.common.ResizeFactor;
+import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.thetacommon.HashOperations;
 
 /**
@@ -165,6 +166,11 @@ final class ConcurrentHeapThetaBuffer extends HeapQuickSelectSketch {
   @Override
   public boolean isEstimationMode() {
     return shared.isEstimationMode();
+  }
+
+  @Override
+  public boolean isSameResource(final Memory that) {
+    return shared.isSameResource(that);
   }
 
   //End of proxies

--- a/src/main/java/org/apache/datasketches/theta/ConcurrentSharedThetaSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/ConcurrentSharedThetaSketch.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.theta;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.datasketches.common.MemoryStatus;
 import org.apache.datasketches.memory.WritableMemory;
 
 /**
@@ -30,7 +31,7 @@ import org.apache.datasketches.memory.WritableMemory;
  *
  * @author eshcar
  */
-interface ConcurrentSharedThetaSketch {
+interface ConcurrentSharedThetaSketch extends MemoryStatus {
 
   long NOT_SINGLE_HASH = -1L;
   double MIN_ERROR = 0.0000001;
@@ -127,7 +128,7 @@ interface ConcurrentSharedThetaSketch {
   //attempt to access these methods from the local buffer will be diverted to the shared
   //sketch.
 
-  //From Sketch
+  //From Sketch and MemoryStatus
 
   int getCompactBytes();
 
@@ -138,10 +139,6 @@ interface ConcurrentSharedThetaSketch {
   double getLowerBound(int numStdDev);
 
   double getUpperBound(int numStdDev);
-
-  boolean hasMemory();
-
-  boolean isDirect();
 
   boolean isEmpty();
 

--- a/src/main/java/org/apache/datasketches/theta/DirectCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectCompactSketch.java
@@ -109,12 +109,12 @@ class DirectCompactSketch extends CompactSketch {
 
   @Override
   public boolean hasMemory() {
-    return true;
+    return mem_ != null;
   }
 
   @Override
   public boolean isDirect() {
-    return mem_.isDirect();
+    return hasMemory() ? mem_.isDirect() : false;
   }
 
   @Override
@@ -132,7 +132,7 @@ class DirectCompactSketch extends CompactSketch {
 
   @Override
   public boolean isSameResource(final Memory that) {
-    return mem_.isSameResource(that);
+    return hasMemory() ? mem_.isSameResource(that) : false;
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketchR.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketchR.java
@@ -144,12 +144,12 @@ class DirectQuickSelectSketchR extends UpdateSketch {
 
   @Override
   public boolean hasMemory() {
-    return true;
+    return wmem_ != null;
   }
 
   @Override
   public boolean isDirect() {
-    return wmem_.isDirect();
+    return hasMemory() ? wmem_.isDirect() : false;
   }
 
   @Override
@@ -159,7 +159,7 @@ class DirectQuickSelectSketchR extends UpdateSketch {
 
   @Override
   public boolean isSameResource(final Memory that) {
-    return wmem_.isSameResource(that);
+    return hasMemory() ? wmem_.isSameResource(that) : false;
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/EmptyCompactSketch.java
@@ -92,16 +92,6 @@ final class EmptyCompactSketch extends CompactSketch {
   }
 
   @Override
-  public boolean hasMemory() {
-    return false;
-  }
-
-  @Override
-  public boolean isDirect() {
-    return false;
-  }
-
-  @Override
   public boolean isEmpty() {
     return true;
   }

--- a/src/main/java/org/apache/datasketches/theta/HeapCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapCompactSketch.java
@@ -103,16 +103,6 @@ class HeapCompactSketch extends CompactSketch {
   }
 
   @Override
-  public boolean hasMemory() {
-    return false;
-  }
-
-  @Override
-  public boolean isDirect() {
-    return false;
-  }
-
-  @Override
   public boolean isEmpty() {
     return empty_;
   }

--- a/src/main/java/org/apache/datasketches/theta/HeapUpdateSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapUpdateSketch.java
@@ -66,16 +66,6 @@ abstract class HeapUpdateSketch extends UpdateSketch {
     return (preLongs + dataLongs) << 3;
   }
 
-  @Override
-  public boolean isDirect() {
-    return false;
-  }
-
-  @Override
-  public boolean hasMemory() {
-    return false;
-  }
-
   //UpdateSketch
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/IntersectionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/IntersectionImpl.java
@@ -337,13 +337,23 @@ class IntersectionImpl extends Intersection {
   }
 
   @Override
+  public boolean hasMemory() {
+    return wmem_ != null;
+  }
+
+  @Override
   public boolean hasResult() {
-    return wmem_ != null ? wmem_.getInt(RETAINED_ENTRIES_INT) >= 0 : curCount_ >= 0;
+    return hasMemory() ? wmem_.getInt(RETAINED_ENTRIES_INT) >= 0 : curCount_ >= 0;
+  }
+
+  @Override
+  public boolean isDirect() {
+    return hasMemory() ? wmem_.isDirect() : false;
   }
 
   @Override
   public boolean isSameResource(final Memory that) {
-    return wmem_ != null ? wmem_.isSameResource(that) : false;
+    return hasMemory() ? wmem_.isSameResource(that) : false;
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/theta/SetOperation.java
+++ b/src/main/java/org/apache/datasketches/theta/SetOperation.java
@@ -25,6 +25,7 @@ import static org.apache.datasketches.theta.PreambleUtil.FAMILY_BYTE;
 import static org.apache.datasketches.theta.PreambleUtil.SER_VER_BYTE;
 
 import org.apache.datasketches.common.Family;
+import org.apache.datasketches.common.MemoryStatus;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
@@ -35,7 +36,7 @@ import org.apache.datasketches.thetacommon.ThetaUtil;
  *
  * @author Lee Rhodes
  */
-public abstract class SetOperation {
+public abstract class SetOperation implements MemoryStatus {
   static final int CONST_PREAMBLE_LONGS = 3;
 
   SetOperation() {}
@@ -236,20 +237,6 @@ public abstract class SetOperation {
    * @return the Family of this SetOperation
    */
   public abstract Family getFamily();
-
-  /**
-   * Returns true if the backing resource of <i>this</i> is identical with the backing resource
-   * of <i>that</i>. The capacities must be the same.  If <i>this</i> is a region,
-   * the region offset must also be the same.
-   *
-   * <p>Note: Only certain set operators during stateful operations can be serialized.
-   * Only when they are stored into Memory will this be relevant.</p>
-   *
-   * @param that A different non-null and alive object
-   * @return true if the backing resource of <i>this</i> is the same as the backing resource
-   * of <i>that</i>.
-   */
-  public abstract boolean isSameResource(Memory that);
 
   //restricted
 

--- a/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
@@ -344,16 +344,6 @@ final class SingleItemSketch extends CompactSketch {
   }
 
   @Override
-  public boolean hasMemory() {
-    return false;
-  }
-
-  @Override
-  public boolean isDirect() {
-    return false;
-  }
-
-  @Override
   public boolean isEmpty() {
     return false;
   }

--- a/src/main/java/org/apache/datasketches/theta/Sketch.java
+++ b/src/main/java/org/apache/datasketches/theta/Sketch.java
@@ -32,6 +32,7 @@ import static org.apache.datasketches.theta.PreambleUtil.SER_VER_BYTE;
 import static org.apache.datasketches.thetacommon.HashOperations.count;
 
 import org.apache.datasketches.common.Family;
+import org.apache.datasketches.common.MemoryStatus;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
@@ -44,7 +45,7 @@ import org.apache.datasketches.thetacommon.ThetaUtil;
  *
  * @author Lee Rhodes
  */
-public abstract class Sketch {
+public abstract class Sketch implements MemoryStatus {
   static final int DEFAULT_LG_RESIZE_FACTOR = 3;   //Unique to Heap
 
   Sketch() {}
@@ -384,24 +385,10 @@ public abstract class Sketch {
   }
 
   /**
-   * Returns true if this sketch's data structure is backed by Memory or WritableMemory.
-   * @return true if this sketch's data structure is backed by Memory or WritableMemory.
-   */
-  public abstract boolean hasMemory();
-
-  /**
    * Returns true if this sketch is in compact form.
    * @return true if this sketch is in compact form.
    */
   public abstract boolean isCompact();
-
-  /**
-   * Returns true if the this sketch's internal data structure is backed by direct (off-heap)
-   * Memory.
-   * @return true if the this sketch's internal data structure is backed by direct (off-heap)
-   * Memory.
-   */
-  public abstract boolean isDirect();
 
   /**
    * <a href="{@docRoot}/resources/dictionary.html#empty">See Empty</a>
@@ -423,18 +410,6 @@ public abstract class Sketch {
    * @return true if internal cache is ordered
    */
   public abstract boolean isOrdered();
-
-  /**
-   * Returns true if the backing resource of <i>this</i> is identical with the backing resource
-   * of <i>that</i>. The capacities must be the same.  If <i>this</i> is a region,
-   * the region offset must also be the same.
-   * @param that A different non-null object
-   * @return true if the backing resource of <i>this</i> is the same as the backing resource
-   * of <i>that</i>.
-   */
-  public boolean isSameResource(final Memory that) {
-    return false;
-  }
 
   /**
    * Returns a HashIterator that can be used to iterate over the retained hash values of the

--- a/src/main/java/org/apache/datasketches/theta/UnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/UnionImpl.java
@@ -263,9 +263,21 @@ final class UnionImpl extends Union {
   }
 
   @Override
+  public boolean hasMemory() {
+    return gadget_ instanceof DirectQuickSelectSketchR
+        ? gadget_.hasMemory() : false;
+  }
+
+  @Override
+  public boolean isDirect() {
+    return gadget_ instanceof DirectQuickSelectSketchR
+        ? gadget_.isDirect() : false;
+  }
+
+  @Override
   public boolean isSameResource(final Memory that) {
     return gadget_ instanceof DirectQuickSelectSketchR
-        ? gadget_.getMemory().isSameResource(that) : false;
+        ? gadget_.isSameResource(that) : false;
   }
 
   @Override

--- a/src/test/java/org/apache/datasketches/theta/ConcurrentDirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ConcurrentDirectQuickSelectSketchTest.java
@@ -119,7 +119,6 @@ public class ConcurrentDirectQuickSelectSketchTest {
     // That is, this is being run for its side-effect of accessing things.
     // If something is wonky, it will generate an exception and fail the test.
     local2.toString(true, true, 8, true);
-
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/ConcurrentHeapQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ConcurrentHeapQuickSelectSketchTest.java
@@ -114,7 +114,7 @@ public class ConcurrentHeapQuickSelectSketchTest {
     WritableMemory mem = WritableMemory.writableWrap(byteArray);
     mem.putByte(FAMILY_BYTE, (byte) 0); //corrupt the Sketch ID byte
 
-    //try to heapify the corruped mem
+    //try to heapify the corrupted mem
     Sketch.heapify(mem, sl.seed);
   }
 


### PR DESCRIPTION
While going through the Java library, there are three public methods that had to do with the status of the internal Memory object used for a backing store: hasMemory(), isDirect(), and isSameResource().   These methods are only relevant to the sketch classes that need to access and retain the sketch as a Memory object, on or off-heap.  But these three methods were inconsistently applied even to the classes that could use them. Some classes had only one or two of these methods implemented instead of all three.  

Also because these methods in the root classes were implemented as abstract, it required all child dependents that did not need to access and retain the sketch as a Memory object, to implement these three methods as dummy methods that always returned false.  This really clutters up the APIs of these classes and is "crazy-making" when trying to debug memory-related issues.  

I thought it would be a good idea to clean this up.  I have implemented a very simple interface, MemoryStatus, in o.a.ds.common with these three methods implemented as default methods that always return false.  This way the only classes where these methods are relevant need to override these methods. And all the other classes don't need to implement dummy methods at all. 

These methods are widely used across the library, but for this PR I have only implemented the necessary changes to the Theta tree to keep the PR smaller.  Nonetheless there are 14 classes that were impacted, (an additional two classes had only spelling corrections).  A summary of the changes for each file is included with the Files Changed View.
