### PR TITLE
Add one exclusion to FindBugsExcludeFilter.xml.

### DIFF
--- a/tools/FindBugsExcludeFilter.xml
+++ b/tools/FindBugsExcludeFilter.xml
@@ -41,6 +41,7 @@ under the License.
   <Match>
     <Bug pattern="EI_EXPOSE_REP2"/>
     <Or>
+      <Class name="org.apache.datasketches.quantilescommon.LongsSortedViewIterator"/>
       <Class name="org.apache.datasketches.quantilescommon.FloatsSortedViewIterator"/>
       <Class name="org.apache.datasketches.quantilescommon.DoublesSortedViewIterator"/>
       <Class name="org.apache.datasketches.quantilescommon.GenericSortedViewIterator"/>


### PR DESCRIPTION
Discovered a single SpotBugs EI_EXPOSE_REP2 in the new class `quantilescommon.LongsSortedViewIterator` 
This SB is complaining about internal copying of an array from one class to another. 
       This array is an internal private array and never exposed as public. Without reflection the user would have no access
       to this array.  To force a copy or clone at this point would be very expensive so I deem this relatively harmless.
