### PR TITLE
These tests were attempting to

### DIFF
--- a/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DirectQuantilesMemoryRequestTest.java
@@ -48,6 +48,7 @@ public class DirectQuantilesMemoryRequestTest {
     //########## Owning Implementation
     // This part would actually be part of the Memory owning implementation so it is faked here
     WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    WritableMemory wmemCopy = wmem;
     println("Initial mem size: " + wmem.getCapacity());
 
     //########## Receiving Application
@@ -70,6 +71,8 @@ public class DirectQuantilesMemoryRequestTest {
     // so the the wmem reference is invalid. Use the sketch to get the last memory reference.
     WritableMemory lastMem = usk1.getMemory();
     println("Final mem size: " + usk1.getMemory().getCapacity());
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
   }
 
   @Test
@@ -79,6 +82,7 @@ public class DirectQuantilesMemoryRequestTest {
     final int initBytes = (4 + (u / 2)) << 3; // not enough to hold everything
 
     WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    WritableMemory wmemCopy = wmem;
     println("Initial mem size: " + wmem.getCapacity());
     final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build(wmem);
     for (int i = 1; i <= u; i++) {
@@ -88,6 +92,8 @@ public class DirectQuantilesMemoryRequestTest {
     println("curCombBufItemCap: " + currentSpace);
     assertEquals(currentSpace, 2 * k);
     println("last Mem Cap: " + usk1.getMemory().getCapacity());
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
   }
 
   @Test
@@ -97,6 +103,7 @@ public class DirectQuantilesMemoryRequestTest {
     final int initBytes = ((2 * k) + 4) << 3; //just room for BB
 
     WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    WritableMemory wmemCopy = wmem;
     println("Initial mem size: " + wmem.getCapacity());
     final UpdateDoublesSketch usk1 = DoublesSketch.builder().setK(k).build(wmem);
     for (int i = 1; i <= u; i++) {
@@ -108,6 +115,8 @@ public class DirectQuantilesMemoryRequestTest {
     final int newSpace = usk1.getCombinedBufferItemCapacity();
     println("newCombBurItemCap: " + newSpace);
     assertEquals(newCB.length, 3 * k);
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
   }
 
   @Test
@@ -119,6 +128,7 @@ public class DirectQuantilesMemoryRequestTest {
     final Memory origSketchMem = Memory.wrap(usk1.toByteArray());
 
     WritableMemory wmem = WritableMemory.allocateDirect(initBytes, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    WritableMemory wmemCopy = wmem;
     origSketchMem.copyTo(0, wmem, 0, initBytes);
     UpdateDoublesSketch usk2 = DirectUpdateDoublesSketch.wrapInstance(wmem);
     assertTrue(wmem.isSameResource(usk2.getMemory()));
@@ -135,6 +145,8 @@ public class DirectQuantilesMemoryRequestTest {
 
     final int expectedSize = COMBINED_BUFFER + ((2 * k) << 3);
     assertEquals(mem2.getCapacity(), expectedSize);
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/org/apache/datasketches/quantiles/DoublesSketchTest.java
@@ -140,18 +140,22 @@ public class DoublesSketchTest {
   @Test
   public void directSketchShouldMoveOntoHeapEventually() {
     WritableMemory wmem = WritableMemory.allocateDirect(1000, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer());
+    WritableMemory wmemCopy = wmem;
     UpdateDoublesSketch sketch = DoublesSketch.builder().build(wmem);
     Assert.assertTrue(sketch.isSameResource(wmem));
     for (int i = 0; i < 1000; i++) {
       sketch.update(i);
     }
     println(sketch.toString());
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
   }
 
   @Test
   public void directSketchShouldMoveOntoHeapEventually2() {
     int i = 0;
     WritableMemory wmem = WritableMemory.allocateDirect(50, ByteOrder.LITTLE_ENDIAN, new DefaultMemoryRequestServer());
+    WritableMemory wmemCopy = wmem;
     UpdateDoublesSketch sketch = DoublesSketch.builder().build(wmem);
     Assert.assertTrue(sketch.isSameResource(wmem));
     for (; i < 1000; i++) {
@@ -163,6 +167,8 @@ public class DoublesSketchTest {
       }
     }
     assertFalse(wmem.isAlive());
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
@@ -781,13 +781,16 @@ public class DirectQuickSelectSketchTest {
     int u = 2 * k;
     int bytes = Sketches.getMaxUpdateSketchBytes(k);
     WritableMemory wmem = WritableMemory.allocateDirect(bytes/2); //will request more memory
+    WritableMemory wmemCopy = wmem;
     UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
     assertTrue(sketch.isSameResource(wmem));
     for (int i = 0; i < u; i++) { sketch.update(i); }
     Memory mem = sketch.getMemory();
     assertTrue(mem.isAlive());
     assertFalse(mem.isDirect()); //now on heap.
+    assertTrue(wmemCopy.isDirect()); //original copy
     assertFalse(wmem.isAlive()); //wmem closed by MemoryRequestServer
+    assertFalse(wmemCopy.isAlive()); //original copy closed
   }
 
   @Test
@@ -796,6 +799,7 @@ public class DirectQuickSelectSketchTest {
     int u = 2 * k;
     int bytes = Sketches.getMaxUpdateSketchBytes(k);
     WritableMemory wmem = WritableMemory.allocateDirect(bytes/2); //will request more memory
+    WritableMemory wmemCopy = wmem;
     UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
     for (int i = 0; i < u; i++) { sketch.update(i); }
     double est1 = sketch.getEstimate();
@@ -808,6 +812,8 @@ public class DirectQuickSelectSketchTest {
     assertTrue(mem2.isAlive());
     assertFalse(mem2.isDirect()); //now on heap
     assertFalse(wmem.isAlive());  //wmem closed by MemoryRequestServer
+    assertTrue(wmemCopy.isDirect());
+    assertFalse(wmemCopy.isAlive());
     try {
       roSketch.rebuild();
       fail();

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -193,6 +193,7 @@ public class UnionImplTest {
     final int bytes = Sketches.getMaxUpdateSketchBytes(k);
     WritableMemory wmem = WritableMemory.allocateDirect(bytes / 2); //not really used, except as a reference.
     WritableMemory wmem2 = WritableMemory.allocateDirect(bytes / 2); //too small, forces new allocation on heap
+    WritableMemory wmem2Copy = wmem2;
     final UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k).build(wmem);
     assertTrue(sketch.isSameResource(wmem)); //also testing the isSameResource function
 
@@ -206,6 +207,8 @@ public class UnionImplTest {
     assertFalse(union2.isSameResource(wmem2));  //obviously not
     wmem.close(); //empty, but we must close it anyway.
     assertFalse(wmem2.isAlive());//previously closed via the DefaultMemoryRequestServer.
+    assertTrue(wmem2Copy.isDirect());
+    assertFalse(wmem2Copy.isAlive());
   }
 
   @Test


### PR DESCRIPTION
test the ability of the MemoryRequestServer to correctly move a direct sketch onto the heap. But the implementations of the tests were not correct.