### PR TITLE
Setup java action

### DIFF
--- a/.github/workflows/check_cpp_files.yml
+++ b/.github/workflows/check_cpp_files.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           repository: apache/datasketches-cpp
           path: cpp
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
       - name: Configure C++ build
         run: cd cpp/build && cmake .. -DGENERATE=true
       - name: Build C++ unit tests

--- a/.github/workflows/check_cpp_files.yml
+++ b/.github/workflows/check_cpp_files.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout C++
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: apache/datasketches-cpp
           path: cpp


### PR DESCRIPTION
This is to fix the failing serde compatibility action, that used the default Java setup in ubuntu-latest, which seems to have moved to  Ubuntu 24.04 LTS with Java 17 by default