### PR TITLE
Correct indentation in GHAW auto-check_cpp_files.yml

### DIFF
--- a/.github/workflows/auto-check_cpp_files.yml
+++ b/.github/workflows/auto-check_cpp_files.yml
@@ -13,32 +13,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-	  - name: Checkout C++
+      - name: Checkout C++
         uses: actions/checkout@v4
         with:
           repository: apache/datasketches-cpp
           path: cpp
 
-	  - name: Setup Java
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
-	  - name: Configure C++ build
+      - name: Configure C++ build
         run: cd cpp/build && cmake .. -DGENERATE=true
 
-	  - name: Build C++ unit tests
+      - name: Build C++ unit tests
         run: cd cpp && cmake --build build --config Release
 
-	  - name: Run C++ tests
+      - name: Run C++ tests
         run: cd cpp && cmake --build build --config Release --target test
 
-	  - name: Make dir
+      - name: Make dir
         run: mkdir -p serialization_test_data/cpp_generated_files
 
       - name: Copy files
         run: cp cpp/build/*/test/*_cpp.sk serialization_test_data/cpp_generated_files
 
-	  - name: Run Java tests
+      - name: Run Java tests
         run: mvn test -P check-cpp-files


### PR DESCRIPTION
Some hard tabs somehow got inserted into this workflow -- screwed up the indentation, which is critical for yml files.