### PR TITLE
Changed java '1.8' to Java '8'

### DIFF
--- a/.github/workflows/auto-jdk-matrix.yml
+++ b/.github/workflows/auto-jdk-matrix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 1.8 ]
+        jdk: [ 8 ]
 
     env:
       JDK_VERSION: ${{ matrix.jdk }}

--- a/.github/workflows/auto-os-matrix.yml
+++ b/.github/workflows/auto-os-matrix.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        jdk: [ 1.8 ]
+        jdk: [ 8 ]
         os: [ windows-latest, ubuntu-latest, macos-latest ]
         include:
           - os: windows-latest

--- a/.github/workflows/check_cpp_files.yml
+++ b/.github/workflows/check_cpp_files.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '1.8'
+          java-version: '8'
           distribution: 'temurin'
 
       - name: Configure C++ build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           distribution: 'temurin'
           cache: 'maven'
-          java-version: '1.8'
+          java-version: '8'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '1.8'
+          java-version: '8'
           distribution: 'temurin'
 
       - name: Echo Java Version


### PR DESCRIPTION
I didn't realize that the Java_setup workflows do not accept the specification 'java 1.8'. They only accept 'java 8' !!
This 2 character change is required in all 5 workflows.