### PR TITLE
Fix target directory in workflow back to /site/

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -34,6 +34,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.6.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          folder: target/reports/apidocs
+          folder: target/site/apidocs
           target-folder: docs/${{ github.ref_name }}
           branch: gh-pages


### PR DESCRIPTION
I thought this was working, but now it wants to deploy from /target/site/apidocs, when before it was /target/reports/apidocs!
