### PR TITLE
Add Go cross-serde tests for CPC sketch 

### DIFF
--- a/src/test/java/org/apache/datasketches/common/TestUtil.java
+++ b/src/test/java/org/apache/datasketches/common/TestUtil.java
@@ -47,6 +47,7 @@ public final class TestUtil  {
    */
   public static final String GENERATE_JAVA_FILES = "generate_java_files";
   public static final String CHECK_CPP_FILES = "check_cpp_files";
+  public static final String CHECK_GO_FILES = "check_go_files";
   public static final String CHECK_CPP_HISTORICAL_FILES = "check_cpp_historical_files";
 
   /**
@@ -58,6 +59,11 @@ public final class TestUtil  {
    * The full target Path for C++ serialized sketches to be tested by Java.
    */
   public static final Path cppPath = createPath("serialization_test_data/cpp_generated_files");
+
+  /**
+   * The full target Path for Go serialized sketches to be tested by Java.
+   */
+  public static final Path goPath = createPath("serialization_test_data/go_generated_files");
 
   private static Path createPath(final String projectLocalDir) {
     try {

--- a/src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java
@@ -20,8 +20,10 @@
 package org.apache.datasketches.cpc;
 
 import static org.apache.datasketches.common.TestUtil.CHECK_CPP_FILES;
+import static org.apache.datasketches.common.TestUtil.CHECK_GO_FILES;
 import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
 import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.goPath;
 import static org.apache.datasketches.common.TestUtil.javaPath;
 import static org.testng.Assert.assertEquals;
 
@@ -72,6 +74,19 @@ public class CpcSketchCrossLanguageTest {
     int flavorIdx = 0;
     for (int n: nArr) {
       final byte[] bytes = Files.readAllBytes(cppPath.resolve("cpc_n" + n + "_cpp.sk"));
+      final CpcSketch sketch = CpcSketch.heapify(Memory.wrap(bytes));
+      assertEquals(sketch.getFlavor(), flavorArr[flavorIdx++]);
+      assertEquals(sketch.getEstimate(), n, n * 0.02);
+    }
+  }
+
+  @Test(groups = {CHECK_GO_FILES})
+  public void checkAllFlavorsGo() throws IOException {
+    final int[] nArr = {0, 100, 200, 2000, 20000};
+    final Flavor[] flavorArr = {Flavor.EMPTY, Flavor.SPARSE, Flavor.HYBRID, Flavor.PINNED, Flavor.SLIDING};
+    int flavorIdx = 0;
+    for (int n: nArr) {
+      final byte[] bytes = Files.readAllBytes(goPath.resolve("cpc_n" + n + "_go.sk"));
       final CpcSketch sketch = CpcSketch.heapify(Memory.wrap(bytes));
       assertEquals(sketch.getFlavor(), flavorArr[flavorIdx++]);
       assertEquals(sketch.getEstimate(), n, n * 0.02);


### PR DESCRIPTION
Added cross language deserialization tests for serialized sketches produced by datasketches-go