### PR TITLE
FFM Phase 4

### DIFF
--- a/src/main/java/org/apache/datasketches/common/ArrayOfItemsSerDe2.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfItemsSerDe2.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.common;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+/**
+ * Base class for serializing and deserializing custom types.
+ * @param <T> Type of item
+ *
+ * @author Alexander Saydakov
+ */
+public abstract class ArrayOfItemsSerDe2<T> {
+
+  /**
+   * Serialize a single unserialized item to a byte array.
+   *
+   * @param item the item to be serialized
+   * @return serialized representation of the given item
+   */
+  public abstract byte[] serializeToByteArray(T item);
+
+  /**
+   * Serialize an array of unserialized items to a byte array of contiguous serialized items.
+   *
+   * @param items array of items to be serialized
+   * @return contiguous, serialized representation of the given array of unserialized items
+   */
+  public abstract byte[] serializeToByteArray(T[] items);
+
+  /**
+   * Deserialize a contiguous sequence of serialized items from the given MemorySegment
+   * starting at a MemorySegment offset of zero and extending numItems.
+   *
+   * @param seg MemorySegment containing a contiguous sequence of serialized items
+   * @param numItems number of items in the contiguous serialized sequence.
+   * @return array of deserialized items
+   * @see #deserializeFromMemorySegment(MemorySegment, long, int)
+   */
+  public T[] deserializeFromMemorySegment(final MemorySegment seg, final int numItems) {
+    return deserializeFromMemorySegment(seg, 0, numItems);
+  }
+
+  /**
+   * Deserialize a contiguous sequence of serialized items from the given MemorySegment
+   * starting at the given MemorySegment <i>offsetBytes</i> and extending numItems.
+   *
+   * @param seg MemorySegment containing a contiguous sequence of serialized items
+   * @param offsetBytes the starting offset in the given MemorySegment.
+   * @param numItems number of items in the contiguous serialized sequence.
+   * @return array of deserialized items
+   */
+  public abstract T[] deserializeFromMemorySegment(MemorySegment seg, long offsetBytes, int numItems);
+
+  /**
+   * Returns the serialized size in bytes of a single unserialized item.
+   * @param item a specific item
+   * @return the serialized size in bytes of a single unserialized item.
+   */
+  public abstract int sizeOf(T item);
+
+  /**
+   * Returns the serialized size in bytes of the array of items.
+   * @param items an array of items.
+   * @return the serialized size in bytes of the array of items.
+   */
+  public int sizeOf(final T[] items) {
+    Objects.requireNonNull(items, "Items must not be null");
+    int totalBytes = 0;
+    for (int i = 0; i < items.length; i++) {
+      totalBytes += sizeOf(items[i]);
+    }
+    return totalBytes;
+  }
+
+  /**
+   * Returns the serialized size in bytes of the number of contiguous serialized items in MemorySegment.
+   * The capacity of the given MemorySegment can be much larger that the required size of the items.
+   * @param seg the given MemorySegment.
+   * @param offsetBytes the starting offset in the given MemorySegment.
+   * @param numItems the number of serialized items contained in the MemorySegment
+   * @return the serialized size in bytes of the given number of items.
+   */
+  public abstract int sizeOf(MemorySegment seg, long offsetBytes, int numItems);
+
+  /**
+   * Returns a human readable string of an item.
+   * @param item a specific item
+   * @return a human readable string of an item.
+   */
+  public abstract String toString(T item);
+
+  /**
+   * Returns the concrete class of type T
+   * @return the concrete class of type T
+   */
+  public abstract Class<T> getClassOfT();
+}

--- a/src/main/java/org/apache/datasketches/common/ArrayOfLongsSerDe2.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfLongsSerDe2.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.common;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static org.apache.datasketches.common.ByteArrayUtil.putLongLE;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+/**
+ * Methods of serializing and deserializing arrays of Long.
+ *
+ * @author Alexander Saydakov
+ */
+public class ArrayOfLongsSerDe2 extends ArrayOfItemsSerDe2<Long> {
+
+  @Override
+  public byte[] serializeToByteArray(final Long item) {
+    Objects.requireNonNull(item, "Item must not be null");
+    final byte[] byteArr = new byte[Long.BYTES];
+    putLongLE(byteArr, 0, item.longValue());
+    return byteArr;
+  }
+
+  @Override
+  public byte[] serializeToByteArray(final Long[] items) {
+    Objects.requireNonNull(items, "Items must not be null");
+    if (items.length == 0) { return new byte[0]; }
+    final byte[] bytes = new byte[Long.BYTES * items.length];
+    final MemorySegment seg = MemorySegment.ofArray(bytes);
+    long offset = 0;
+    for (int i = 0; i < items.length; i++) {
+      seg.set(JAVA_LONG_UNALIGNED, offset, items[i]);
+      offset += Long.BYTES;
+    }
+    return bytes;
+  }
+
+  @Override
+  public Long[] deserializeFromMemorySegment(final MemorySegment seg, final int numItems) {
+    return deserializeFromMemorySegment(seg, 0, numItems);
+  }
+
+  @Override
+  public Long[] deserializeFromMemorySegment(final MemorySegment seg, final long offsetBytes, final int numItems) {
+    Objects.requireNonNull(seg, "MemorySegment must not be null");
+    if (numItems <= 0) { return new Long[0]; }
+    long offset = offsetBytes;
+    Util.checkBounds(offset, Long.BYTES * (long)numItems, seg.byteSize());
+    final Long[] array = new Long[numItems];
+    for (int i = 0; i < numItems; i++) {
+      array[i] = seg.get(JAVA_LONG_UNALIGNED, offset);
+      offset += Long.BYTES;
+    }
+    return array;
+  }
+
+  @Override
+  public int sizeOf(final Long item) {
+    Objects.requireNonNull(item, "Item must not be null");
+    return Long.BYTES;
+  }
+
+  @Override //override because this is simpler
+  public int sizeOf(final Long[] items) {
+    Objects.requireNonNull(items, "Items must not be null");
+    return items.length * Long.BYTES;
+  }
+
+  @Override
+  public int sizeOf(final MemorySegment seg, final long offsetBytes, final int numItems) {
+    Objects.requireNonNull(seg, "MemorySegment must not be null");
+    return numItems * Long.BYTES;
+  }
+
+  @Override
+  public String toString(final Long item) {
+    if (item == null) { return "null"; }
+    return item.toString();
+  }
+
+  @Override
+  public Class<Long> getClassOfT() { return Long.class; }
+}

--- a/src/main/java/org/apache/datasketches/common/ArrayOfStringsSerDe2.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfStringsSerDe2.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.common;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static org.apache.datasketches.common.ByteArrayUtil.copyBytes;
+import static org.apache.datasketches.common.ByteArrayUtil.putIntLE;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Methods of serializing and deserializing arrays of String.
+ * This class serializes strings in UTF-8 format, which is more compact compared to
+ * {@link ArrayOfUtf16StringsSerDe}. In an extreme case when all strings are in ASCII,
+ * this method is 2 times more compact, but it takes more time to encode and decode
+ * by a factor of 1.5 to 2.
+ *
+ * <p>The serialization
+ *
+ * @author Alexander Saydakov
+ */
+public class ArrayOfStringsSerDe2 extends ArrayOfItemsSerDe2<String> {
+
+  @Override
+  public byte[] serializeToByteArray(final String item) {
+    Objects.requireNonNull(item, "Item must not be null");
+    if (item.isEmpty()) { return new byte[] { 0, 0, 0, 0 }; }
+    final byte[] utf8ByteArr = item.getBytes(StandardCharsets.UTF_8);
+    final int numBytes = utf8ByteArr.length;
+    final byte[] out = new byte[numBytes + Integer.BYTES];
+    copyBytes(utf8ByteArr, 0, out, 4, numBytes);
+    putIntLE(out, 0, numBytes);
+    return out;
+  }
+
+  @Override
+  public byte[] serializeToByteArray(final String[] items) {
+    Objects.requireNonNull(items, "Items must not be null");
+    if (items.length == 0) { return new byte[0]; }
+    int totalBytes = 0;
+    final int numItems = items.length;
+    final byte[][] serialized2DArray = new byte[numItems][];
+    for (int i = 0; i < numItems; i++) {
+      serialized2DArray[i] = items[i].getBytes(StandardCharsets.UTF_8);
+      totalBytes += serialized2DArray[i].length + Integer.BYTES;
+    }
+    final byte[] bytesOut = new byte[totalBytes];
+    int offset = 0;
+    for (int i = 0; i < numItems; i++) {
+      final int utf8len = serialized2DArray[i].length;
+      putIntLE(bytesOut, offset, utf8len);
+      offset += Integer.BYTES;
+      copyBytes(serialized2DArray[i], 0, bytesOut, offset, utf8len);
+      offset += utf8len;
+    }
+    return bytesOut;
+  }
+
+  @Override
+  public String[] deserializeFromMemorySegment(final MemorySegment seg, final int numItems) {
+    return deserializeFromMemorySegment(seg, 0, numItems);
+  }
+
+  @Override
+  public String[] deserializeFromMemorySegment(final MemorySegment seg, final long offsetBytes, final int numItems) {
+    Objects.requireNonNull(seg, "MemorySegment must not be null");
+    if (numItems <= 0) { return new String[0]; }
+    final String[] array = new String[numItems];
+    long offset = offsetBytes;
+    for (int i = 0; i < numItems; i++) {
+      Util.checkBounds(offset, Integer.BYTES, seg.byteSize());
+      final int strLength = seg.get(JAVA_INT_UNALIGNED, offset);
+      offset += Integer.BYTES;
+      final byte[] utf8Bytes = new byte[strLength];
+      Util.checkBounds(offset, strLength, seg.byteSize());
+      MemorySegment.copy(seg, JAVA_BYTE, offset, utf8Bytes, 0, strLength);
+      offset += strLength;
+      array[i] = new String(utf8Bytes, StandardCharsets.UTF_8);
+    }
+    return array;
+  }
+
+  @Override
+  public int sizeOf(final String item) {
+    Objects.requireNonNull(item, "Item must not be null");
+    if (item.isEmpty()) { return Integer.BYTES; }
+    return item.getBytes(StandardCharsets.UTF_8).length + Integer.BYTES;
+  }
+
+  @Override
+  public int sizeOf(final MemorySegment seg, final long offsetBytes, final int numItems) {
+    Objects.requireNonNull(seg, "MemorySegment must not be null");
+    if (numItems <= 0) { return 0; }
+    long offset = offsetBytes;
+    final long segCap = seg.byteSize();
+    for (int i = 0; i < numItems; i++) {
+      Util.checkBounds(offset, Integer.BYTES, segCap);
+      final int itemLenBytes = seg.get(JAVA_INT_UNALIGNED, offset);
+      offset += Integer.BYTES;
+      Util.checkBounds(offset, itemLenBytes, segCap);
+      offset += itemLenBytes;
+    }
+    return (int)(offset - offsetBytes);
+  }
+
+  @Override
+  public String toString(final String item) {
+    if (item == null) { return "null"; }
+    return item;
+  }
+
+  @Override
+  public Class<String> getClassOfT() { return String.class; }
+}

--- a/src/main/java/org/apache/datasketches/common/ArrayOfUtf16StringsSerDe2.java
+++ b/src/main/java/org/apache/datasketches/common/ArrayOfUtf16StringsSerDe2.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.common;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static org.apache.datasketches.common.ByteArrayUtil.copyBytes;
+import static org.apache.datasketches.common.ByteArrayUtil.putIntLE;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Methods of serializing and deserializing arrays of String.
+ * This class serializes strings using internal Java representation as char[], where each char
+ * is a 16-bit code. The result is larger than one from {@link ArrayOfStringsSerDe}.
+ * In an extreme case when all strings are in ASCII, the size is doubled. However it takes
+ * less time to serialize and deserialize by a factor of 1.5 to 2.
+ *
+ * @author Alexander Saydakov
+ */
+public class ArrayOfUtf16StringsSerDe2 extends ArrayOfItemsSerDe2<String> {
+
+  @Override
+  public byte[] serializeToByteArray(final String item) {
+    Objects.requireNonNull(item, "Item must not be null");
+    final byte[] utf16ByteArr = item.getBytes(StandardCharsets.UTF_16); //includes BOM
+    final int numBytes = utf16ByteArr.length;
+    final byte[] out = new byte[numBytes + Integer.BYTES];
+    copyBytes(utf16ByteArr, 0, out, 4, numBytes);
+    putIntLE(out, 0, numBytes);
+    return out;
+  }
+
+  @Override
+  public byte[] serializeToByteArray(final String[] items) {
+    Objects.requireNonNull(items, "Items must not be null");
+    int totalBytes = 0;
+    final int numItems = items.length;
+    final byte[][] serialized2DArray = new byte[numItems][];
+    for (int i = 0; i < numItems; i++) {
+      serialized2DArray[i] = items[i].getBytes(StandardCharsets.UTF_16);
+      totalBytes += serialized2DArray[i].length + Integer.BYTES;
+    }
+    final byte[] bytesOut = new byte[totalBytes];
+    int offset = 0;
+    for (int i = 0; i < numItems; i++) {
+      final int utf8len = serialized2DArray[i].length;
+      putIntLE(bytesOut, offset, utf8len);
+      offset += Integer.BYTES;
+      copyBytes(serialized2DArray[i], 0, bytesOut, offset, utf8len);
+      offset += utf8len;
+    }
+    return bytesOut;
+  }
+
+  @Override
+  public String[] deserializeFromMemorySegment(final MemorySegment seg, final int numItems) {
+    return deserializeFromMemorySegment(seg, 0, numItems);
+  }
+
+  @Override
+  public String[] deserializeFromMemorySegment(final MemorySegment seg, final long offsetBytes, final int numItems) {
+    Objects.requireNonNull(seg, "MemorySegment must not be null");
+    if (numItems <= 0) { return new String[0]; }
+    final String[] array = new String[numItems];
+    long offset = offsetBytes;
+    for (int i = 0; i < numItems; i++) {
+      Util.checkBounds(offset, Integer.BYTES, seg.byteSize());
+      final int strLength = seg.get(JAVA_INT_UNALIGNED, offset);
+      offset += Integer.BYTES;
+      final byte[] utf16Bytes = new byte[strLength];
+      Util.checkBounds(offset, strLength, seg.byteSize());
+      MemorySegment.copy(seg, JAVA_BYTE, offset, utf16Bytes, 0, strLength);
+      offset += strLength;
+      array[i] = new String(utf16Bytes, StandardCharsets.UTF_16);
+    }
+    return array;
+  }
+
+  @Override
+  public int sizeOf(final String item) {
+    Objects.requireNonNull(item, "Item must not be null");
+    return item.getBytes(StandardCharsets.UTF_16).length + Integer.BYTES;
+  }
+
+  @Override
+  public int sizeOf(final MemorySegment seg, final long offsetBytes, final int numItems) {
+    Objects.requireNonNull(seg, "MemorySegment must not be null");
+    long offset = offsetBytes;
+    final long segCap = seg.byteSize();
+    for (int i = 0; i < numItems; i++) {
+      Util.checkBounds(offset, Integer.BYTES, segCap);
+      final int itemLenBytes = seg.get(JAVA_INT_UNALIGNED, offset);
+      offset += Integer.BYTES;
+      Util.checkBounds(offset, itemLenBytes, segCap);
+      offset += itemLenBytes;
+    }
+    return (int)(offset - offsetBytes);
+  }
+
+  @Override
+  public String toString(final String item) {
+    if (item == null) { return "null"; }
+    return item;
+  }
+
+  @Override
+  public Class<String> getClassOfT() { return String.class; }
+}

--- a/src/main/java/org/apache/datasketches/common/Util.java
+++ b/src/main/java/org/apache/datasketches/common/Util.java
@@ -427,7 +427,7 @@ public final class Util {
   /**
    * This is a long integer equivalent to <i>Math.ceil(n / (double)(1 << k))</i>
    * where: <i>0 &lt; k &le; 6</i> and <i>n</i> is a non-negative long.
-   * These limits are not checked for speed.
+   * These limits are not checked for speed reasons.
    * @param n the input dividend as a positive long greater than zero.
    * @param k the input divisor exponent of 2 as a positive integer where 0 &lt; k &le; 6.
    * @return the long integer equivalent to <i>Math.ceil(n / 2^k)</i>.

--- a/src/main/java/org/apache/datasketches/frequencies2/ErrorType.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/ErrorType.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+/**
+ * Specifies one of two types of error regions of the statistical classification Confusion Matrix
+ * that can be excluded from a returned sample of Frequent Items.
+ */
+public enum ErrorType {
+
+  /**
+   * No <i>Type I</i> error samples will be included in the sample set,
+   * which means all <i>Truly Negative</i> samples will be excluded from the sample set.
+   * However, there may be <i>Type II</i> error samples (<i>False Negatives</i>)
+   * that should have been included that were not.
+   * This is a subset of the NO_FALSE_NEGATIVES ErrorType.
+   */
+  NO_FALSE_POSITIVES,
+
+  /**
+   * No <i>Type II</i> error samples will be excluded from the sample set,
+   * which means all <i>Truly Positive</i> samples will be included in the sample set.
+   * However, there may be <i>Type I</i> error samples (<i>False Positives</i>)
+   * that were included that should not have been.
+   */
+  NO_FALSE_NEGATIVES
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/ItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/ItemsSketch.java
@@ -1,0 +1,747 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.common.Util.checkBounds;
+import static org.apache.datasketches.common.Util.exactLog2OfInt;
+import static org.apache.datasketches.common.Util.isPowerOf2;
+import static org.apache.datasketches.frequencies2.PreambleUtil.EMPTY_FLAG_MASK;
+import static org.apache.datasketches.frequencies2.PreambleUtil.SER_VER;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractActiveItems;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractFamilyID;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractFlags;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractLgCurMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractLgMaxMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractPreLongs;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractSerVer;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertActiveItems;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertFamilyID;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertFlags;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertLgCurMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertLgMaxMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertPreLongs;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertSerVer;
+import static org.apache.datasketches.frequencies2.Util.LG_MIN_MAP_SIZE;
+import static org.apache.datasketches.frequencies2.Util.SAMPLE_SIZE;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Objects;
+
+import org.apache.datasketches.common.ArrayOfItemsSerDe2;
+import org.apache.datasketches.common.Family;
+import org.apache.datasketches.common.SketchesArgumentException;
+import org.apache.datasketches.common.SketchesStateException;
+
+/**
+ * This sketch is useful for tracking approximate frequencies of items of type <i>&lt;T&gt;</i>
+ * with optional associated counts (<i>&lt;T&gt;</i> item, <i>long</i> count) that are members of a
+ * multiset of such items. The true frequency of an item is defined to be the sum of associated
+ * counts.
+ *
+ * <p>This implementation provides the following capabilities:</p>
+ * <ul>
+ * <li>Estimate the frequency of an item.</li>
+ * <li>Return upper and lower bounds of any item, such that the true frequency is always
+ * between the upper and lower bounds.</li>
+ * <li>Return a global maximum error that holds for all items in the stream.</li>
+ * <li>Return an array of frequent items that qualify either a NO_FALSE_POSITIVES or a
+ * NO_FALSE_NEGATIVES error type.</li>
+ * <li>Merge itself with another sketch object created from this class.</li>
+ * <li>Serialize/Deserialize to/from a byte array.</li>
+ * </ul>
+ *
+ * <p><b>Space Usage</b></p>
+ *
+ * <p>The sketch is initialized with a <i>maxMapSize</i> that specifies the maximum physical
+ * length of the internal hash map of the form (<i>&lt;T&gt;</i> item, <i>long</i> count).
+ * The <i>maxMapSize</i> must be a power of 2.</p>
+ *
+ * <p>The hash map starts at a very small size (8 entries), and grows as needed up to the
+ * specified <i>maxMapSize</i>.</p>
+ *
+ * <p>Excluding external space required for the item objects, the internal memory space usage of
+ * this sketch is 18 * <i>mapSize</i> bytes (assuming 8 bytes for each Java reference), plus a small
+ * constant number of additional bytes. The internal memory space usage of this sketch will never
+ * exceed 18 * <i>maxMapSize</i> bytes, plus a small constant number of additional bytes.</p>
+ *
+ * <p><b>Maximum Capacity of the Sketch</b></p>
+ *
+ * <p>The LOAD_FACTOR for the hash map is internally set at 75%,
+ * which means at any time the map capacity of (item, count) pairs is <i>mapCap</i> = 0.75 *
+ * <i>mapSize</i>.
+ * The maximum capacity of (item, count) pairs of the sketch is <i>maxMapCap</i> = 0.75 *
+ * <i>maxMapSize</i>.</p>
+ *
+ * <p><b>Updating the sketch with (item, count) pairs</b></p>
+ *
+ * <p>If the item is found in the hash map, the mapped count field (the "counter") is
+ * incremented by the incoming count, otherwise, a new counter "(item, count) pair" is
+ * created. If the number of tracked counters reaches the maximum capacity of the hash map
+ * the sketch decrements all of the counters (by an approximately computed median), and
+ * removes any non-positive counters.</p>
+ *
+ * <p><b>Accuracy</b></p>
+ *
+ * <p>If fewer than 0.75 * <i>maxMapSize</i> different items are inserted into the sketch the
+ * estimated frequencies returned by the sketch will be exact.</p>
+ *
+ * <p>The logic of the frequent items sketch is such that the stored counts and true counts are
+ * never too different.
+ * More specifically, for any <i>item</i>, the sketch can return an estimate of the
+ * true frequency of <i>item</i>, along with upper and lower bounds on the frequency
+ * (that hold deterministically).</p>
+ *
+ * <p>For this implementation and for a specific active <i>item</i>, it is guaranteed that
+ * the true frequency will be between the Upper Bound (UB) and the Lower Bound (LB) computed for
+ * that <i>item</i>.  Specifically, <i>(UB- LB) &le; W * epsilon</i>, where <i>W</i> denotes the
+ * sum of all item counts, and <i>epsilon = 3.5/M</i>, where <i>M</i> is the <i>maxMapSize</i>.</p>
+ *
+ * <p>This is a worst case guarantee that applies to arbitrary inputs.<sup>1</sup>
+ * For inputs typically seen in practice <i>(UB-LB)</i> is usually much smaller.
+ * </p>
+ *
+ * <p><b>Background</b></p>
+ *
+ * <p>This code implements a variant of what is commonly known as the "Misra-Gries
+ * algorithm". Variants of it were discovered and rediscovered and redesigned several times
+ * over the years:</p>
+ * <ul><li>"Finding repeated elements", Misra, Gries, 1982</li>
+ * <li>"Frequency estimation of Internet packet streams with limited space" Demaine,
+ * Lopez-Ortiz, Munro, 2002</li>
+ * <li>"A simple algorithm for finding frequent elements in streams and bags" Karp, Shenker,
+ * Papadimitriou, 2003</li>
+ * <li>"Efficient Computation of Frequent and Top-k Elements in Data Streams" Metwally,
+ * Agrawal, Abbadi, 2006</li>
+ * </ul>
+ *
+ * <sup>1</sup> For speed we do employ some randomization that introduces a small probability that
+ * our proof of the worst-case bound might not apply to a given run. However, we have ensured
+ * that this probability is extremely small. For example, if the stream causes one table purge
+ * (rebuild), our proof of the worst case bound applies with probability at least 1 - 1E-14.
+ * If the stream causes 1E9 purges, our proof applies with probability at least 1 - 1E-5.
+ *
+ * @param <T> The type of item to be tracked by this sketch
+ *
+ * @author Justin Thaler
+ * @author Alexander Saydakov
+ */
+public class ItemsSketch<T> {
+
+  /**
+   * Log2 Maximum length of the arrays internal to the hash map supported by the data
+   * structure.
+   */
+  private int lgMaxMapSize;
+
+  /**
+   * The current number of counters supported by the hash map.
+   */
+  private int curMapCap; //the threshold to purge
+
+  /**
+   * Tracks the total of decremented counts.
+   */
+  private long offset;
+
+  /**
+   * The sum of all frequencies of the stream so far.
+   */
+  private long streamWeight = 0;
+
+  /**
+   * The maximum number of samples used to compute approximate median of counters when doing
+   * decrement
+   */
+  private int sampleSize;
+
+  /**
+   * Hash map mapping stored items to approximate counts
+   */
+  private ReversePurgeItemHashMap<T> hashMap;
+
+  /**
+   * Construct this sketch with the parameter maxMapSize and the default initialMapSize (8).
+   *
+   * @param maxMapSize Determines the physical size of the internal hash map managed by this
+   * sketch and must be a power of 2. The maximum capacity of this internal hash map is
+   * 0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are
+   * functions of maxMapSize.
+   */
+  public ItemsSketch(final int maxMapSize) {
+    this(exactLog2OfInt(maxMapSize, "maxMapSize"), LG_MIN_MAP_SIZE);
+  }
+
+  /**
+   * Construct this sketch with parameter lgMaxMapSize and lgCurMapSize. This internal
+   * constructor is used when deserializing the sketch.
+   *
+   * @param lgMaxMapSize Log2 of the physical size of the internal hash map managed by this
+   * sketch. The maximum capacity of this internal hash map is 0.75 times 2^lgMaxMapSize.
+   * Both the ultimate accuracy and size of this sketch are functions of lgMaxMapSize.
+   *
+   * @param lgCurMapSize Log2 of the starting (current) physical size of the internal hash
+   * map managed by this sketch.
+   */
+  ItemsSketch(final int lgMaxMapSize, final int lgCurMapSize) {
+    //set initial size of hash map
+    this.lgMaxMapSize = Math.max(lgMaxMapSize, LG_MIN_MAP_SIZE);
+    final int lgCurMapSz = Math.max(lgCurMapSize, LG_MIN_MAP_SIZE);
+    hashMap = new ReversePurgeItemHashMap<>(1 << lgCurMapSz);
+    curMapCap = hashMap.getCapacity();
+    final int maxMapCap =
+        (int) ((1 << lgMaxMapSize) * ReversePurgeItemHashMap.getLoadFactor());
+    offset = 0;
+    sampleSize = Math.min(SAMPLE_SIZE, maxMapCap);
+  }
+
+  /**
+   * Returns a sketch instance of this class from the given srcMem,
+   * which must be a MemorySegment representation of this sketch class.
+   *
+   * @param <T> The type of item that this sketch will track
+   * @param srcSeg a MemorySegment representation of a sketch of this class.
+   * @param serDe an instance of ArrayOfItemsSerDe
+   * @return a sketch instance of this class.
+   */
+  public static <T> ItemsSketch<T> getInstance(final MemorySegment srcSeg,
+      final ArrayOfItemsSerDe2<T> serDe) {
+    Objects.requireNonNull(srcSeg, "srcMem must not be null.");
+    Objects.requireNonNull(serDe, "serDe must not be null.");
+
+    final long pre0 = PreambleUtil.checkPreambleSize(srcSeg); //make sure preamble will fit
+    final int maxPreLongs = Family.FREQUENCY.getMaxPreLongs();
+
+    final int preLongs = extractPreLongs(pre0);         //Byte 0
+    final int serVer = extractSerVer(pre0);             //Byte 1
+    final int familyID = extractFamilyID(pre0);         //Byte 2
+    final int lgMaxMapSize = extractLgMaxMapSize(pre0); //Byte 3
+    final int lgCurMapSize = extractLgCurMapSize(pre0); //Byte 4
+    final boolean empty = (extractFlags(pre0) & EMPTY_FLAG_MASK) != 0; //Byte 5
+
+    // Checks
+    final boolean preLongsEq1 = (preLongs == 1);        //Byte 0
+    final boolean preLongsEqMax = (preLongs == maxPreLongs);
+    if (!preLongsEq1 && !preLongsEqMax) {
+      throw new SketchesArgumentException(
+          "Possible Corruption: PreLongs must be 1 or " + maxPreLongs + ": " + preLongs);
+    }
+    if (serVer != SER_VER) {                            //Byte 1
+      throw new SketchesArgumentException(
+          "Possible Corruption: Ser Ver must be " + SER_VER + ": " + serVer);
+    }
+    final int actFamID = Family.FREQUENCY.getID();      //Byte 2
+    if (familyID != actFamID) {
+      throw new SketchesArgumentException(
+          "Possible Corruption: FamilyID must be " + actFamID + ": " + familyID);
+    }
+    if (empty ^ preLongsEq1) {                          //Byte 5 and Byte 0
+      throw new SketchesArgumentException(
+          "Possible Corruption: (PreLongs == 1) ^ Empty == True.");
+    }
+
+    if (empty) {
+      return new ItemsSketch<>(lgMaxMapSize, LG_MIN_MAP_SIZE);
+    }
+    //get full preamble
+    final long[] preArr = new long[preLongs];
+    MemorySegment.copy(srcSeg, JAVA_LONG_UNALIGNED, 0, preArr, 0, preLongs);
+
+    final ItemsSketch<T> fis = new ItemsSketch<>(lgMaxMapSize, lgCurMapSize);
+    fis.streamWeight = 0; //update after
+    fis.offset = preArr[3];
+
+    final int preBytes = preLongs << 3;
+    final int activeItems = extractActiveItems(preArr[1]);
+
+    //Get countArray
+    final long[] countArray = new long[activeItems];
+    final int reqBytes = preBytes + (activeItems * Long.BYTES); //count Arr only
+    checkBounds(0, reqBytes, srcSeg.byteSize()); //check MemorySegment capacity
+    MemorySegment.copy(srcSeg, JAVA_LONG_UNALIGNED, preBytes, countArray, 0, activeItems);
+
+    //Get itemArray
+    final int itemsOffset = preBytes + (Long.BYTES * activeItems);
+    final T[] itemArray = serDe.deserializeFromMemorySegment(srcSeg.asSlice(itemsOffset), 0, activeItems);
+    //update the sketch
+    for (int i = 0; i < activeItems; i++) {
+      fis.update(itemArray[i], countArray[i]);
+    }
+    fis.streamWeight = preArr[2]; //override streamWeight due to updating
+    return fis;
+  }
+
+  /**
+   * Returns the estimated <i>a priori</i> error given the maxMapSize for the sketch and the
+   * estimatedTotalStreamWeight.
+   * @param maxMapSize the planned map size to be used when constructing this sketch.
+   * @param estimatedTotalStreamWeight the estimated total stream weight.
+   * @return the estimated <i>a priori</i> error.
+   */
+  public static double getAprioriError(final int maxMapSize, final long estimatedTotalStreamWeight) {
+    return getEpsilon(maxMapSize) * estimatedTotalStreamWeight;
+  }
+
+  /**
+   * Returns the current number of counters the sketch is configured to support.
+   *
+   * @return the current number of counters the sketch is configured to support.
+   */
+  public int getCurrentMapCapacity() {
+    return curMapCap;
+  }
+
+  /**
+   * Returns epsilon used to compute <i>a priori</i> error.
+   * This is just the value <i>3.5 / maxMapSize</i>.
+   * @param maxMapSize the planned map size to be used when constructing this sketch.
+   * @return epsilon used to compute <i>a priori</i> error.
+   */
+  public static double getEpsilon(final int maxMapSize) {
+    if (!isPowerOf2(maxMapSize)) {
+      throw new SketchesArgumentException("maxMapSize is not a power of 2.");
+    }
+    return 3.5 / maxMapSize;
+  }
+
+  /**
+   * Gets the estimate of the frequency of the given item.
+   * Note: The true frequency of a item would be the sum of the counts as a result of the
+   * two update functions.
+   *
+   * @param item the given item
+   * @return the estimate of the frequency of the given item
+   */
+  public long getEstimate(final T item) {
+    // If item is tracked:
+    // Estimate = itemCount + offset; Otherwise it is 0.
+    final long itemCount = hashMap.get(item);
+    return (itemCount > 0) ? itemCount + offset : 0;
+  }
+
+  /**
+   * Gets the guaranteed lower bound frequency of the given item, which can never be
+   * negative.
+   *
+   * @param item the given item.
+   * @return the guaranteed lower bound frequency of the given item. That is, a number which
+   * is guaranteed to be no larger than the real frequency.
+   */
+  public long getLowerBound(final T item) {
+    //LB = itemCount or 0
+    return hashMap.get(item);
+  }
+
+  /**
+   * Returns an array of Rows that include frequent items, estimates, upper and lower bounds
+   * given a threshold and an ErrorCondition. If the threshold is lower than getMaximumError(),
+   * then getMaximumError() will be used instead.
+   *
+   * <p>The method first examines all active items in the sketch (items that have a counter).
+   *
+   * <p>If <i>ErrorType = NO_FALSE_NEGATIVES</i>, this will include an item in the result
+   * list if getUpperBound(item) &gt; threshold.
+   * There will be no false negatives, i.e., no Type II error.
+   * There may be items in the set with true frequencies less than the threshold
+   * (false positives).</p>
+   *
+   * <p>If <i>ErrorType = NO_FALSE_POSITIVES</i>, this will include an item in the result
+   * list if getLowerBound(item) &gt; threshold.
+   * There will be no false positives, i.e., no Type I error.
+   * There may be items omitted from the set with true frequencies greater than the
+   * threshold (false negatives).</p>
+   *
+   * @param threshold to include items in the result list
+   * @param errorType determines whether no false positives or no false negatives are
+   * desired.
+   * @return an array of frequent items
+   */
+  public Row<T>[] getFrequentItems(final long threshold, final ErrorType errorType) {
+    return sortItems(threshold > getMaximumError() ? threshold : getMaximumError(), errorType);
+  }
+
+  /**
+   * Returns an array of Rows that include frequent items, estimates, upper and lower bounds
+   * given an ErrorCondition and the default threshold.
+   * This is the same as getFrequentItems(getMaximumError(), errorType)
+   *
+   * @param errorType determines whether no false positives or no false negatives are
+   * desired.
+   * @return an array of frequent items
+   */
+  public Row<T>[] getFrequentItems(final ErrorType errorType) {
+    return sortItems(getMaximumError(), errorType);
+  }
+
+  /**
+   * Returns an upper bound on the maximum error of getEstimate(item) for any item.
+   * @return An upper bound on the maximum error of getEstimate(item) for any item.
+   * This is equivalent to the maximum distance between the upper bound and the lower bound
+   * for any item.
+   */
+  public long getMaximumError() {
+    return offset;
+  }
+
+  /**
+   * Returns the maximum number of counters the sketch is configured to support.
+   *
+   * @return the maximum number of counters the sketch is configured to support.
+   */
+  public int getMaximumMapCapacity() {
+    return (int) ((1 << lgMaxMapSize) * ReversePurgeLongHashMap.getLoadFactor());
+  }
+
+  /**
+   * Returns the number of active items in the sketch.
+   * @return the number of active items in the sketch.
+   */
+  public int getNumActiveItems() {
+    return hashMap.getNumActive();
+  }
+
+  /**
+   * Returns the sum of the frequencies in the stream seen so far by the sketch
+   *
+   * @return the sum of the frequencies in the stream seen so far by the sketch
+   */
+  public long getStreamLength() {
+    return streamWeight;
+  }
+
+  /**
+   * Gets the guaranteed upper bound frequency of the given item.
+   *
+   * @param item the given item
+   * @return the guaranteed upper bound frequency of the given item. That is, a number which
+   * is guaranteed to be no smaller than the real frequency.
+   */
+  public long getUpperBound(final T item) {
+    // UB = itemCount + offset
+    return hashMap.get(item) + offset;
+  }
+
+  /**
+   * Returns true if this sketch is empty
+   *
+   * @return true if this sketch is empty
+   */
+  public boolean isEmpty() {
+    return getNumActiveItems() == 0;
+  }
+
+  /**
+   * This function merges the other sketch into this one.
+   * The other sketch may be of a different size.
+   *
+   * @param other sketch of this class
+   * @return a sketch whose estimates are within the guarantees of the
+   * largest error tolerance of the two merged sketches.
+   */
+  public ItemsSketch<T> merge(final ItemsSketch<T> other) {
+    if ((other == null) || other.isEmpty()) { return this; }
+
+    final long streamLen = streamWeight + other.streamWeight; //capture before merge
+
+    final ReversePurgeItemHashMap.Iterator<T> iter = other.hashMap.iterator();
+    while (iter.next()) { //this may add to offset during rebuilds
+      this.update(iter.getKey(), iter.getValue());
+    }
+    offset += other.offset;
+    streamWeight = streamLen; //corrected streamWeight
+    return this;
+  }
+
+  /**
+   * Resets this sketch to a virgin state.
+   */
+  public void reset() {
+    hashMap = new ReversePurgeItemHashMap<>(1 << LG_MIN_MAP_SIZE);
+    curMapCap = hashMap.getCapacity();
+    offset = 0;
+    streamWeight = 0;
+  }
+
+  //Serialization
+
+  /**
+   * Returns a byte array representation of this sketch
+   * @param serDe an instance of ArrayOfItemsSerDe
+   * @return a byte array representation of this sketch
+   */
+  public byte[] toByteArray(final ArrayOfItemsSerDe2<T> serDe) {
+    final int preLongs;
+    final int outBytes;
+    final boolean empty = isEmpty();
+    final int activeItems = getNumActiveItems();
+    byte[] bytes = null;
+    if (empty) {
+      preLongs = 1;
+      outBytes = 8;
+    } else {
+      preLongs = Family.FREQUENCY.getMaxPreLongs();
+      bytes = serDe.serializeToByteArray(hashMap.getActiveKeys());
+      outBytes = ((preLongs + activeItems) << 3) + bytes.length;
+    }
+    final byte[] outArr = new byte[outBytes];
+    final MemorySegment seg = MemorySegment.ofArray(outArr);
+
+    // build first preLong empty or not
+    long pre0 = 0L;
+    pre0 = insertPreLongs(preLongs, pre0);                  //Byte 0
+    pre0 = insertSerVer(SER_VER, pre0);                     //Byte 1
+    pre0 = insertFamilyID(Family.FREQUENCY.getID(), pre0);  //Byte 2
+    pre0 = insertLgMaxMapSize(lgMaxMapSize, pre0);          //Byte 3
+    pre0 = insertLgCurMapSize(hashMap.getLgLength(), pre0); //Byte 4
+    pre0 = empty ? insertFlags(EMPTY_FLAG_MASK, pre0) : insertFlags(0, pre0); //Byte 5
+
+    if (empty) {
+      seg.set(JAVA_LONG_UNALIGNED, 0, pre0);
+    } else {
+      final long pre = 0;
+      final long[] preArr = new long[preLongs];
+      preArr[0] = pre0;
+      preArr[1] = insertActiveItems(activeItems, pre);
+      preArr[2] = streamWeight;
+      preArr[3] = offset;
+      MemorySegment.copy(preArr, 0, seg, JAVA_LONG_UNALIGNED, 0, preLongs);
+
+      final int preBytes = preLongs << 3;
+      MemorySegment.copy(hashMap.getActiveValues(), 0, seg, JAVA_LONG_UNALIGNED, preBytes, activeItems);
+      MemorySegment.copy(bytes, 0, seg, JAVA_BYTE, preBytes + (this.getNumActiveItems() << 3), bytes.length);
+    }
+    return outArr;
+  }
+
+  /**
+   * Returns a human readable summary of this sketch.
+   * @return a human readable summary of this sketch.
+   */
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("FrequentItemsSketch<T>:").append(LS);
+    sb.append("  Stream Length    : " + streamWeight).append(LS);
+    sb.append("  Max Error Offset : " + offset).append(LS);
+    sb.append(hashMap.toString());
+    return sb.toString();
+  }
+
+  /**
+   * Returns a human readable string of the preamble of a byte array image of a ItemsSketch.
+   * @param byteArr the given byte array
+   * @return a human readable string of the preamble of a byte array image of a ItemsSketch.
+   */
+  public static String toString(final byte[] byteArr) {
+    return toString(MemorySegment.ofArray(byteArr));
+  }
+
+  /**
+   * Returns a human readable string of the preamble of a MemorySegment image of a ItemsSketch.
+   * @param seg the given MemorySegment object
+   * @return a human readable string of the preamble of a MemorySegment image of a ItemsSketch.
+   */
+  public static String toString(final MemorySegment seg) {
+    return PreambleUtil.preambleToString(seg);
+  }
+
+  /**
+   * Update this sketch with an item and a frequency count of one.
+   * @param item for which the frequency should be increased.
+   */
+  public void update(final T item) {
+    update(item, 1);
+  }
+
+  /**
+   * Update this sketch with an item and a positive frequency count.
+   * @param item for which the frequency should be increased. The sketch uses
+   * hashCode() and equals() methods of the type T.
+   * @param count the amount by which the frequency of the item should be increased.
+   * A count of zero is a no-op, and a negative count will throw an exception.
+   */
+  public void update(final T item, final long count) {
+    if ((item == null) || (count == 0)) {
+      return;
+    }
+    if (count < 0) {
+      throw new SketchesArgumentException("Count may not be negative");
+    }
+    streamWeight += count;
+    hashMap.adjustOrPutValue(item, count);
+
+    if (getNumActiveItems() > curMapCap) { //over the threshold, we need to do something
+      if (hashMap.getLgLength() < lgMaxMapSize) { //below tgt size, we can grow
+        hashMap.resize(2 * hashMap.getLength());
+        curMapCap = hashMap.getCapacity();
+      } else { //At tgt size, must purge
+        offset += hashMap.purge(sampleSize);
+        if (getNumActiveItems() > getMaximumMapCapacity()) {
+          throw new SketchesStateException("Purge did not reduce active items.");
+        }
+      }
+    }
+  }
+
+  /**
+   * Row class that defines the return values from a getFrequentItems query.
+   * @param <T> type of item
+   */
+  public static class Row<T> implements Comparable<Row<T>> {
+    final T item;
+    final long est;
+    final long ub;
+    final long lb;
+    private static final String FMT =  "  %12d%12d%12d %s";
+    private static final String HFMT = "  %12s%12s%12s %s";
+
+    Row(final T item, final long estimate, final long ub, final long lb) {
+      this.item = item;
+      est = estimate;
+      this.ub = ub;
+      this.lb = lb;
+    }
+
+    /**
+     * Returns an item of type T
+     * @return item of type T
+     */
+    public T getItem() { return item; }
+
+    /**
+     * Returns the estimate
+     * @return the estimate
+     */
+    public long getEstimate() { return est; }
+
+    /**
+     * Returns the upper bound
+     * @return the upper bound
+     */
+    public long getUpperBound() { return ub; }
+
+    /**
+     * Returns the lower bound
+     * @return return the lower bound
+     */
+    public long getLowerBound() { return lb; }
+
+    /**
+     * Returns the descriptive row header
+     * @return the descriptive row header
+     */
+    public static String getRowHeader() {
+      return String.format(HFMT,"Est", "UB", "LB", "Item");
+    }
+
+    @Override
+    public String toString() {
+      return String.format(FMT,  est, ub, lb, item.toString());
+    }
+
+    /**
+     * This compareTo is strictly limited to the Row.getEstimate() value and does not imply any
+     * ordering whatsoever to the other elements of the row: item and upper and lower bounds.
+     * Defined this way, this compareTo will be consistent with hashCode() and equals(Object).
+     * @param that the other row to compare to.
+     * @return a negative integer, zero, or a positive integer as this.getEstimate() is less than,
+     * equal to, or greater than that.getEstimate().
+     */
+    @Override
+    public int compareTo(final Row<T> that) {
+      return (est < that.est) ? -1 : (est > that.est) ? 1 : 0;
+    }
+
+    /**
+     * This hashCode is computed only from the Row.getEstimate() value.
+     * Defined this way, this hashCode will be consistent with equals(Object):<br>
+     * If (x.equals(y)) implies: x.hashCode() == y.hashCode().<br>
+     * If (!x.equals(y)) does NOT imply: x.hashCode() != y.hashCode().
+     * @return the hashCode computed from getEstimate().
+     */
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      final int result = 1;
+      return (prime * result) + (int) (est ^ (est >>> 32));
+    }
+
+    /**
+     * This equals is computed only from the Row.getEstimate() value and does not imply equality
+     * of the other items within the row: item and upper and lower bounds.
+     * Defined this way, this equals will be consistent with compareTo(Row).
+     * @param obj the other row to determine equality with.
+     * @return true if this.getEstimate() equals ((Row&lt;T&gt;)obj).getEstimate().
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) { return true; }
+      if ( (obj == null) || !(obj instanceof Row)) { return false; }
+      final Row<T> that = (Row<T>) obj;
+      if (est != that.est) { return false; }
+      return true;
+    }
+
+  } //End of class Row<T>
+
+  @SuppressWarnings("unchecked")
+  Row<T>[] sortItems(final long threshold, final ErrorType errorType) {
+    final ArrayList<Row<T>> rowList = new ArrayList<>();
+    final ReversePurgeItemHashMap.Iterator<T> iter = hashMap.iterator();
+    if (errorType == ErrorType.NO_FALSE_NEGATIVES) {
+      while (iter.next()) {
+        final long est = getEstimate(iter.getKey());
+        final long ub = getUpperBound(iter.getKey());
+        final long lb = getLowerBound(iter.getKey());
+        if (ub >= threshold) {
+          final Row<T> row = new Row<>(iter.getKey(), est, ub, lb);
+          rowList.add(row);
+        }
+      }
+    } else { //NO_FALSE_POSITIVES
+      while (iter.next()) {
+        final long est = getEstimate(iter.getKey());
+        final long ub = getUpperBound(iter.getKey());
+        final long lb = getLowerBound(iter.getKey());
+        if (lb >= threshold) {
+          final Row<T> row = new Row<>(iter.getKey(), est, ub, lb);
+          rowList.add(row);
+        }
+      }
+    }
+
+    // descending order
+    rowList.sort(new Comparator<Row<T>>() {
+      @Override
+      public int compare(final Row<T> r1, final Row<T> r2) {
+        return r2.compareTo(r1);
+      }
+    });
+
+    return rowList.toArray((Row<T>[]) Array.newInstance(Row.class, rowList.size()));
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/LongsSketch.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/LongsSketch.java
@@ -1,0 +1,832 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.common.Util.checkBounds;
+import static org.apache.datasketches.common.Util.exactLog2OfInt;
+import static org.apache.datasketches.common.Util.isPowerOf2;
+import static org.apache.datasketches.frequencies2.PreambleUtil.EMPTY_FLAG_MASK;
+import static org.apache.datasketches.frequencies2.PreambleUtil.SER_VER;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractActiveItems;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractFamilyID;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractFlags;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractLgCurMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractLgMaxMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractPreLongs;
+import static org.apache.datasketches.frequencies2.PreambleUtil.extractSerVer;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertActiveItems;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertFamilyID;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertFlags;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertLgCurMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertLgMaxMapSize;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertPreLongs;
+import static org.apache.datasketches.frequencies2.PreambleUtil.insertSerVer;
+import static org.apache.datasketches.frequencies2.Util.LG_MIN_MAP_SIZE;
+import static org.apache.datasketches.frequencies2.Util.SAMPLE_SIZE;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Objects;
+
+import org.apache.datasketches.common.Family;
+import org.apache.datasketches.common.SketchesArgumentException;
+import org.apache.datasketches.common.SketchesStateException;
+import org.apache.datasketches.common.SuppressFBWarnings;
+
+/**
+ * This sketch is useful for tracking approximate frequencies of <i>long</i> items with optional
+ * associated counts (<i>long</i> item, <i>long</i> count) that are members of a multiset of
+ * such items. The true frequency of an item is defined to be the sum of associated counts.
+ *
+ * <p>This implementation provides the following capabilities:</p>
+ * <ul>
+ * <li>Estimate the frequency of an item.</li>
+ * <li>Return upper and lower bounds of any item, such that the true frequency is always
+ * between the upper and lower bounds.</li>
+ * <li>Return a global maximum error that holds for all items in the stream.</li>
+ * <li>Return an array of frequent items that qualify either a NO_FALSE_POSITIVES or a
+ * NO_FALSE_NEGATIVES error type.</li>
+ * <li>Merge itself with another sketch object created from this class.</li>
+ * <li>Serialize/Deserialize to/from a String or byte array.</li>
+ * </ul>
+ *
+ * <p><b>Space Usage</b></p>
+ *
+ * <p>The sketch is initialized with a <i>maxMapSize</i> that specifies the maximum physical
+ * length of the internal hash map of the form (<i>long</i> item, <i>long</i> count).
+ * The <i>maxMapSize</i> must be a power of 2.</p>
+ *
+ * <p>The hash map starts at a very small size (8 entries), and grows as needed up to the
+ * specified <i>maxMapSize</i>.</p>
+ *
+ * <p>At any moment the internal memory space usage of this sketch is 18 * <i>mapSize</i> bytes,
+ * plus a small constant number of additional bytes. The maximum internal memory space usage of
+ * this sketch will never exceed 18 * <i>maxMapSize</i> bytes, plus a small constant number of
+ * additional bytes.</p>
+ *
+ * <p><b>Maximum Capacity of the Sketch</b></p>
+ *
+ * <p>The LOAD_FACTOR for the hash map is internally set at 75%,
+ * which means at any time the map capacity of (item, count) pairs is <i>mapCap</i> =
+ * 0.75 * <i>mapSize</i>.
+ * The maximum capacity of (item, count) pairs of the sketch is <i>maxMapCap</i> =
+ * 0.75 * <i>maxMapSize</i>.</p>
+ *
+ * <p><b>Updating the sketch with (item, count) pairs</b></p>
+ *
+ * <p>If the item is found in the hash map, the mapped count field (the "counter") is
+ * incremented by the incoming count, otherwise, a new counter "(item, count) pair" is
+ * created. If the number of tracked counters reaches the maximum capacity of the hash map
+ * the sketch decrements all of the counters (by an approximately computed median), and
+ * removes any non-positive counters.</p>
+ *
+ * <p><b>Accuracy</b></p>
+ *
+ * <p>If fewer than 0.75 * <i>maxMapSize</i> different items are inserted into the sketch the
+ * estimated frequencies returned by the sketch will be exact.</p>
+ *
+ * <p>The logic of the frequent items sketch is such that the stored counts and true counts are
+ * never too different.
+ * More specifically, for any <i>item</i>, the sketch can return an estimate of the
+ * true frequency of <i>item</i>, along with upper and lower bounds on the frequency
+ * (that hold deterministically).</p>
+ *
+ * <p>For this implementation and for a specific active <i>item</i>, it is guaranteed that
+ * the true frequency will be between the Upper Bound (UB) and the Lower Bound (LB) computed for
+ * that <i>item</i>.  Specifically, <i>(UB- LB) &le; W * epsilon</i>, where <i>W</i> denotes the
+ * sum of all item counts, and <i>epsilon = 3.5/M</i>, where <i>M</i> is the <i>maxMapSize</i>.</p>
+ *
+ * <p>This is a worst case guarantee that applies to arbitrary inputs.<sup>1</sup>
+ * For inputs typically seen in practice <i>(UB-LB)</i> is usually much smaller.
+ * </p>
+ *
+ * <p><b>Background</b></p>
+ *
+ * <p>This code implements a variant of what is commonly known as the "Misra-Gries
+ * algorithm". Variants of it were discovered and rediscovered and redesigned several times
+ * over the years:</p>
+ * <ul><li>"Finding repeated elements", Misra, Gries, 1982</li>
+ * <li>"Frequency estimation of Internet packet streams with limited space" Demaine,
+ * Lopez-Ortiz, Munro, 2002</li>
+ * <li>"A simple algorithm for finding frequent elements in streams and bags" Karp, Shenker,
+ * Papadimitriou, 2003</li>
+ * <li>"Efficient Computation of Frequent and Top-k Elements in Data Streams" Metwally,
+ * Agrawal, Abbadi, 2006</li>
+ * </ul>
+ *
+ * <sup>1</sup> For speed we do employ some randomization that introduces a small probability that
+ * our proof of the worst-case bound might not apply to a given run.  However, we have ensured
+ * that this probability is extremely small. For example, if the stream causes one table purge
+ * (rebuild), our proof of the worst case bound applies with probability at least 1 - 1E-14.
+ * If the stream causes 1E9 purges, our proof applies with probability at least 1 - 1E-5.
+ *
+ * @author Justin Thaler
+ * @author Lee Rhodes
+ */
+@SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC_ANON", justification = "Harmless, fix later")
+public class LongsSketch {
+
+  private static final int STR_PREAMBLE_TOKENS = 6;
+
+  /**
+   * Log2 Maximum length of the arrays internal to the hash map supported by the data
+   * structure.
+   */
+  private final int lgMaxMapSize;
+
+  /**
+   * The current number of counters supported by the hash map.
+   */
+  private int curMapCap; //the threshold to purge
+
+  /**
+   * Tracks the total of decremented counts.
+   */
+  private long offset;
+
+  /**
+   * The sum of all frequencies of the stream so far.
+   */
+  private long streamWeight = 0;
+
+  /**
+   * The maximum number of samples used to compute approximate median of counters when doing
+   * decrement
+   */
+  private final int sampleSize;
+
+  /**
+   * Hash map mapping stored items to approximate counts
+   */
+  private ReversePurgeLongHashMap hashMap;
+
+  /**
+   * Construct this sketch with the parameter maxMapSize and the default initialMapSize (8).
+   *
+   * @param maxMapSize Determines the physical size of the internal hash map managed by this
+   * sketch and must be a power of 2.  The maximum capacity of this internal hash map is
+   * 0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are a
+   * function of maxMapSize.
+   */
+  public LongsSketch(final int maxMapSize) {
+    this(exactLog2OfInt(maxMapSize, "maxMapSize"), LG_MIN_MAP_SIZE);
+  }
+
+  /**
+   * Construct this sketch with parameter lgMapMapSize and lgCurMapSize. This internal
+   * constructor is used when deserializing the sketch.
+   *
+   * @param lgMaxMapSize Log2 of the physical size of the internal hash map managed by this
+   * sketch. The maximum capacity of this internal hash map is 0.75 times 2^lgMaxMapSize.
+   * Both the ultimate accuracy and size of this sketch are a function of lgMaxMapSize.
+   *
+   * @param lgCurMapSize Log2 of the starting (current) physical size of the internal hash
+   * map managed by this sketch.
+   */
+  LongsSketch(final int lgMaxMapSize, final int lgCurMapSize) {
+    //set initial size of hash map
+    this.lgMaxMapSize = Math.max(lgMaxMapSize, LG_MIN_MAP_SIZE);
+    final int lgCurMapSz = Math.max(lgCurMapSize, LG_MIN_MAP_SIZE);
+    hashMap = new ReversePurgeLongHashMap(1 << lgCurMapSz);
+    curMapCap = hashMap.getCapacity();
+    final int maxMapCap =
+        (int) ((1 << lgMaxMapSize) * ReversePurgeLongHashMap.getLoadFactor());
+    offset = 0;
+    sampleSize = Math.min(SAMPLE_SIZE, maxMapCap);
+  }
+
+  /**
+   * Returns a sketch instance of this class from the given srcSeg,
+   * which must be a MemorySegment representation of this sketch class.
+   *
+   * @param srcSeg a MemorySegment representation of a sketch of this class.
+   * @return a sketch instance of this class.
+   */
+  public static LongsSketch getInstance(final MemorySegment srcSeg) {
+    Objects.requireNonNull(srcSeg, "Source MemorySegment must not be null.");
+    final long pre0 = PreambleUtil.checkPreambleSize(srcSeg); //check MemorySegment capacity
+    final int maxPreLongs = Family.FREQUENCY.getMaxPreLongs();
+
+    final int preLongs = extractPreLongs(pre0);         //Byte 0
+    final int serVer = extractSerVer(pre0);             //Byte 1
+    final int familyID = extractFamilyID(pre0);         //Byte 2
+    final int lgMaxMapSize = extractLgMaxMapSize(pre0); //Byte 3
+    final int lgCurMapSize = extractLgCurMapSize(pre0); //Byte 4
+    final boolean empty = (extractFlags(pre0) & EMPTY_FLAG_MASK) != 0; //Byte 5
+
+    // Checks
+    final boolean preLongsEq1 = (preLongs == 1);        //Byte 0
+    final boolean preLongsEqMax = (preLongs == maxPreLongs);
+    if (!preLongsEq1 && !preLongsEqMax) {
+      throw new SketchesArgumentException(
+          "Possible Corruption: PreLongs must be 1 or " + maxPreLongs + ": " + preLongs);
+    }
+    if (serVer != SER_VER) {                            //Byte 1
+      throw new SketchesArgumentException(
+          "Possible Corruption: Ser Ver must be " + SER_VER + ": " + serVer);
+    }
+    final int actFamID = Family.FREQUENCY.getID();      //Byte 2
+    if (familyID != actFamID) {
+      throw new SketchesArgumentException(
+          "Possible Corruption: FamilyID must be " + actFamID + ": " + familyID);
+    }
+    if (empty ^ preLongsEq1) {                          //Byte 5 and Byte 0
+      throw new SketchesArgumentException(
+          "Possible Corruption: (PreLongs == 1) ^ Empty == True.");
+    }
+
+    if (empty) {
+      return new LongsSketch(lgMaxMapSize, LG_MIN_MAP_SIZE);
+    }
+    //get full preamble
+    final long[] preArr = new long[preLongs];
+    MemorySegment.copy(srcSeg, JAVA_LONG_UNALIGNED, 0, preArr, 0, preLongs);
+
+    final LongsSketch fls = new LongsSketch(lgMaxMapSize, lgCurMapSize);
+    fls.streamWeight = 0; //update after
+    fls.offset = preArr[3];
+
+    final int preBytes = preLongs << 3;
+    final int activeItems = extractActiveItems(preArr[1]);
+
+    //Get countArray
+    final long[] countArray = new long[activeItems];
+    final int reqBytes = preBytes + (2 * activeItems * Long.BYTES); //count Arr + Items Arr
+    checkBounds(0, reqBytes, srcSeg.byteSize()); //check MemorySegment capacity
+    MemorySegment.copy(srcSeg, JAVA_LONG_UNALIGNED, preBytes, countArray, 0, activeItems);
+
+    //Get itemArray
+    final int itemsOffset = preBytes + (Long.BYTES * activeItems);
+    final long[] itemArray = new long[activeItems];
+    MemorySegment.copy(srcSeg, JAVA_LONG_UNALIGNED, itemsOffset, itemArray, 0, activeItems);
+    //update the sketch
+    for (int i = 0; i < activeItems; i++) {
+      fls.update(itemArray[i], countArray[i]);
+    }
+    fls.streamWeight = preArr[2]; //override streamWeight due to updating
+    return fls;
+  }
+
+  /**
+   * Returns a sketch instance of this class from the given String,
+   * which must be a String representation of this sketch class.
+   *
+   * @param string a String representation of a sketch of this class.
+   * @return a sketch instance of this class.
+   */
+  public static LongsSketch getInstance(final String string) {
+    Objects.requireNonNull(string, "string must not be null.");
+    final String[] tokens = string.split(",");
+    if (tokens.length < (STR_PREAMBLE_TOKENS + 2)) {
+      throw new SketchesArgumentException(
+          "String not long enough: " + tokens.length);
+    }
+    final int serVer  = Integer.parseInt(tokens[0]);
+    final int famID   = Integer.parseInt(tokens[1]);
+    final int lgMax   = Integer.parseInt(tokens[2]);
+    final int flags   = Integer.parseInt(tokens[3]);
+    final long streamWt = Long.parseLong(tokens[4]);
+    final long offset       = Long.parseLong(tokens[5]); //error offset
+    //should always get at least the next 2 from the map
+    final int numActive = Integer.parseInt(tokens[6]);
+    final int lgCur = Integer.numberOfTrailingZeros(Integer.parseInt(tokens[7]));
+
+    //checks
+    if (serVer != SER_VER) {
+      throw new SketchesArgumentException("Possible Corruption: Bad SerVer: " + serVer);
+    }
+    Family.FREQUENCY.checkFamilyID(famID);
+    final boolean empty = flags > 0;
+    if (!empty && (numActive == 0)) {
+      throw new SketchesArgumentException(
+          "Possible Corruption: !Empty && NumActive=0;  strLen: " + numActive);
+    }
+    final int numTokens = tokens.length;
+    if ((2 * numActive) != (numTokens - STR_PREAMBLE_TOKENS - 2)) {
+      throw new SketchesArgumentException(
+          "Possible Corruption: Incorrect # of tokens: " + numTokens
+            + ", numActive: " + numActive);
+    }
+
+    final LongsSketch sketch = new LongsSketch(lgMax, lgCur);
+    sketch.streamWeight = streamWt;
+    sketch.offset = offset;
+    sketch.hashMap = deserializeFromStringArray(tokens);
+    return sketch;
+  }
+
+  /**
+   * Returns the estimated <i>a priori</i> error given the maxMapSize for the sketch and the
+   * estimatedTotalStreamWeight.
+   * @param maxMapSize the planned map size to be used when constructing this sketch.
+   * @param estimatedTotalStreamWeight the estimated total stream weight.
+   * @return the estimated <i>a priori</i> error.
+   */
+  public static double getAprioriError(final int maxMapSize, final long estimatedTotalStreamWeight) {
+    return getEpsilon(maxMapSize) * estimatedTotalStreamWeight;
+  }
+
+  /**
+   * Returns the current number of counters the sketch is configured to support.
+   *
+   * @return the current number of counters the sketch is configured to support.
+   */
+  public int getCurrentMapCapacity() {
+    return curMapCap;
+  }
+
+  /**
+   * Returns epsilon used to compute <i>a priori</i> error.
+   * This is just the value <i>3.5 / maxMapSize</i>.
+   * @param maxMapSize the planned map size to be used when constructing this sketch.
+   * @return epsilon used to compute <i>a priori</i> error.
+   */
+  public static double getEpsilon(final int maxMapSize) {
+    if (!isPowerOf2(maxMapSize)) {
+      throw new SketchesArgumentException("maxMapSize is not a power of 2.");
+    }
+    return 3.5 / maxMapSize;
+  }
+
+  /**
+   * Gets the estimate of the frequency of the given item.
+   * Note: The true frequency of a item would be the sum of the counts as a result of the
+   * two update functions.
+   *
+   * @param item the given item
+   * @return the estimate of the frequency of the given item
+   */
+  public long getEstimate(final long item) {
+    // If item is tracked:
+    // Estimate = itemCount + offset; Otherwise it is 0.
+    final long itemCount = hashMap.get(item);
+    return (itemCount > 0) ? itemCount + offset : 0;
+  }
+
+  /**
+   * Gets the guaranteed lower bound frequency of the given item, which can never be
+   * negative.
+   *
+   * @param item the given item.
+   * @return the guaranteed lower bound frequency of the given item. That is, a number which
+   * is guaranteed to be no larger than the real frequency.
+   */
+  public long getLowerBound(final long item) {
+    //LB = itemCount or 0
+    return hashMap.get(item);
+  }
+
+  /**
+   * Returns an array of Rows that include frequent items, estimates, upper and lower bounds
+   * given a threshold and an ErrorCondition. If the threshold is lower than getMaximumError(),
+   * then getMaximumError() will be used instead.
+   *
+   * <p>The method first examines all active items in the sketch (items that have a counter).
+   *
+   * <p>If <i>ErrorType = NO_FALSE_NEGATIVES</i>, this will include an item in the result
+   * list if getUpperBound(item) &gt; threshold.
+   * There will be no false negatives, i.e., no Type II error.
+   * There may be items in the set with true frequencies less than the threshold
+   * (false positives).</p>
+   *
+   * <p>If <i>ErrorType = NO_FALSE_POSITIVES</i>, this will include an item in the result
+   * list if getLowerBound(item) &gt; threshold.
+   * There will be no false positives, i.e., no Type I error.
+   * There may be items omitted from the set with true frequencies greater than the
+   * threshold (false negatives). This is a subset of the NO_FALSE_NEGATIVES case.</p>
+   *
+   * @param threshold to include items in the result list
+   * @param errorType determines whether no false positives or no false negatives are
+   * desired.
+   * @return an array of frequent items
+   */
+  public Row[] getFrequentItems(final long threshold, final ErrorType errorType) {
+    return sortItems(threshold > getMaximumError() ? threshold : getMaximumError(), errorType);
+  }
+
+  /**
+   * Returns an array of Rows that include frequent items, estimates, upper and lower bounds
+   * given an ErrorCondition and the default threshold.
+   * This is the same as getFrequentItems(getMaximumError(), errorType)
+   *
+   * @param errorType determines whether no false positives or no false negatives are
+   * desired.
+   * @return an array of frequent items
+   */
+  public Row[] getFrequentItems(final ErrorType errorType) {
+    return sortItems(getMaximumError(), errorType);
+  }
+
+  /**
+   * Returns an upper bound on the maximum error of getEstimate(item) for any item.
+   * @return An upper bound on the maximum error of getEstimate(item) for any item.
+   * This is equivalent to the maximum distance between the upper bound and the lower bound
+   * for any item.
+   */
+  public long getMaximumError() {
+    return offset;
+  }
+
+  /**
+   * Returns the maximum number of counters the sketch is configured to support.
+   *
+   * @return the maximum number of counters the sketch is configured to support.
+   */
+  public int getMaximumMapCapacity() {
+    return (int) ((1 << lgMaxMapSize) * ReversePurgeLongHashMap.getLoadFactor());
+  }
+
+  /**
+   * Returns the number of active items in the sketch.
+   * @return the number of active items in the sketch.
+   */
+  public int getNumActiveItems() {
+    return hashMap.getNumActive();
+  }
+
+  /**
+   * Returns the number of bytes required to store this sketch as an array of bytes.
+   *
+   * @return the number of bytes required to store this sketch as an array of bytes.
+   */
+  public int getStorageBytes() {
+    if (isEmpty()) { return 8; }
+    return (4 * 8) + (16 * getNumActiveItems());
+  }
+
+  /**
+   * Returns the sum of the frequencies (weights or counts) in the stream seen so far by the sketch
+   *
+   * @return the sum of the frequencies in the stream seen so far by the sketch
+   */
+  public long getStreamLength() {
+    return streamWeight;
+  }
+
+  /**
+   * Gets the guaranteed upper bound frequency of the given item.
+   *
+   * @param item the given item
+   * @return the guaranteed upper bound frequency of the given item. That is, a number which
+   * is guaranteed to be no smaller than the real frequency.
+   */
+  public long getUpperBound(final long item) {
+    // UB = itemCount + offset
+    return hashMap.get(item) + offset;
+  }
+
+  /**
+   * Returns true if this sketch is empty
+   *
+   * @return true if this sketch is empty
+   */
+  public boolean isEmpty() {
+    return getNumActiveItems() == 0;
+  }
+
+  /**
+   * This function merges the other sketch into this one.
+   * The other sketch may be of a different size.
+   *
+   * @param other sketch of this class
+   * @return a sketch whose estimates are within the guarantees of the
+   * largest error tolerance of the two merged sketches.
+   */
+  public LongsSketch merge(final LongsSketch other) {
+    if ((other == null) || other.isEmpty()) { return this; }
+
+    final long streamWt = streamWeight + other.streamWeight; //capture before merge
+
+    final ReversePurgeLongHashMap.Iterator iter = other.hashMap.iterator();
+    while (iter.next()) { //this may add to offset during rebuilds
+      this.update(iter.getKey(), iter.getValue());
+    }
+    offset += other.offset;
+    streamWeight = streamWt; //corrected streamWeight
+    return this;
+  }
+
+  /**
+   * Resets this sketch to a virgin state.
+   */
+  public void reset() {
+    hashMap = new ReversePurgeLongHashMap(1 << LG_MIN_MAP_SIZE);
+    curMapCap = hashMap.getCapacity();
+    offset = 0;
+    streamWeight = 0;
+  }
+
+  //Serialization
+
+  /**
+   * Returns a String representation of this sketch
+   *
+   * @return a String representation of this sketch
+   */
+  public String serializeToString() {
+    final StringBuilder sb = new StringBuilder();
+    //start the string with parameters of the sketch
+    final int serVer = SER_VER;                 //0
+    final int famID = Family.FREQUENCY.getID(); //1
+    final int lgMaxMapSz = lgMaxMapSize;        //2
+    final int flags = (hashMap.getNumActive() == 0) ? EMPTY_FLAG_MASK : 0; //3
+    final String fmt = "%d,%d,%d,%d,%d,%d,";
+    final String s =
+        String.format(fmt, serVer, famID, lgMaxMapSz, flags, streamWeight, offset);
+    sb.append(s);
+    sb.append(hashMap.serializeToString()); //numActive, curMaplen, key[i], value[i], ...
+    // maxMapCap, sample size are deterministic functions of maxMapSize,
+    //  so we don't need them in the serialization
+    return sb.toString();
+  }
+
+  /**
+   * Returns a byte array representation of this sketch
+   * @return a byte array representation of this sketch
+   */
+  public byte[] toByteArray() {
+    final int preLongs, outBytes;
+    final boolean empty = isEmpty();
+    final int activeItems = getNumActiveItems();
+    if (empty) {
+      preLongs = 1;
+      outBytes = 8;
+    } else {
+      preLongs = Family.FREQUENCY.getMaxPreLongs(); //4
+      outBytes = (preLongs + (2 * activeItems)) << 3; //2 because both keys and values are longs
+    }
+    final byte[] outArr = new byte[outBytes];
+    final MemorySegment seg = MemorySegment.ofArray(outArr);
+
+    // build first preLong empty or not
+    long pre0 = 0L;
+    pre0 = insertPreLongs(preLongs, pre0);                  //Byte 0
+    pre0 = insertSerVer(SER_VER, pre0);                     //Byte 1
+    pre0 = insertFamilyID(Family.FREQUENCY.getID(), pre0);  //Byte 2
+    pre0 = insertLgMaxMapSize(lgMaxMapSize, pre0);          //Byte 3
+    pre0 = insertLgCurMapSize(hashMap.getLgLength(), pre0); //Byte 4
+    pre0 = (empty) ? insertFlags(EMPTY_FLAG_MASK, pre0) : insertFlags(0, pre0); //Byte 5
+
+    if (empty) {
+      seg.set(JAVA_LONG_UNALIGNED, 0, pre0);
+    } else {
+      final long pre = 0;
+      final long[] preArr = new long[preLongs];
+      preArr[0] = pre0;
+      preArr[1] = insertActiveItems(activeItems, pre);
+      preArr[2] = streamWeight;
+      preArr[3] = offset;
+      MemorySegment.copy(preArr, 0, seg, JAVA_LONG_UNALIGNED, 0, preLongs);
+
+      final int preBytes = preLongs << 3;
+      MemorySegment.copy(hashMap.getActiveValues(), 0, seg, JAVA_LONG_UNALIGNED, preBytes, activeItems);
+      MemorySegment.copy(hashMap.getActiveKeys(), 0, seg, JAVA_LONG_UNALIGNED, preBytes + (activeItems << 3), activeItems);
+    }
+    return outArr;
+  }
+
+  /**
+   * Returns a human readable summary of this sketch.
+   * @return a human readable summary of this sketch.
+   */
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("FrequentLongsSketch:").append(LS);
+    sb.append("  Stream Length    : " + streamWeight).append(LS);
+    sb.append("  Max Error Offset : " + offset).append(LS);
+    sb.append(hashMap.toString());
+    return sb.toString();
+  }
+
+  /**
+   * Returns a human readable string of the preamble of a byte array image of a LongsSketch.
+   * @param byteArr the given byte array
+   * @return a human readable string of the preamble of a byte array image of a LongsSketch.
+   */
+  public static String toString(final byte[] byteArr) {
+    return toString(MemorySegment.ofArray(byteArr));
+  }
+
+  /**
+   * Returns a human readable string of the preamble of a MemorySegment image of a LongsSketch.
+   * @param seg the given MemorySegment object
+   * @return  a human readable string of the preamble of a MemorySegment image of a LongsSketch.
+   */
+  public static String toString(final MemorySegment seg) {
+    return PreambleUtil.preambleToString(seg);
+  }
+
+  /**
+   * Update this sketch with an item and a frequency count of one.
+   * @param item for which the frequency should be increased.
+   */
+  public void update(final long item) {
+    update(item, 1);
+  }
+
+  /**
+   * Update this sketch with a item and a positive frequency count (or weight).
+   * @param item for which the frequency should be increased. The item can be any long value
+   * and is only used by the sketch to determine uniqueness.
+   * @param count the amount by which the frequency of the item should be increased.
+   * An count of zero is a no-op, and a negative count will throw an exception.
+   */
+  public void update(final long item, final long count) {
+    if (count == 0) { return; }
+    if (count < 0) {
+      throw new SketchesArgumentException("Count may not be negative");
+    }
+    streamWeight += count;
+    hashMap.adjustOrPutValue(item, count);
+
+    if (getNumActiveItems() > curMapCap) { //over the threshold, we need to do something
+      if (hashMap.getLgLength() < lgMaxMapSize) { //below tgt size, we can grow
+        hashMap.resize(2 * hashMap.getLength());
+        curMapCap = hashMap.getCapacity();
+      } else { //At tgt size, must purge
+        offset += hashMap.purge(sampleSize);
+        if (getNumActiveItems() > getMaximumMapCapacity()) {
+          throw new SketchesStateException("Purge did not reduce active items.");
+        }
+      }
+    }
+  }
+
+  /**
+   * Row class that defines the return values from a getFrequentItems query.
+   */
+  public static class Row implements Comparable<Row> {
+    final long item;
+    final long est;
+    final long ub;
+    final long lb;
+    private static final String fmt =  ("  %20d%20d%20d %d");
+    private static final String hfmt = ("  %20s%20s%20s %s");
+
+    Row(final long item, final long estimate, final long ub, final long lb) {
+      this.item = item;
+      est = estimate;
+      this.ub = ub;
+      this.lb = lb;
+    }
+
+    /**
+     * Returns item of type long
+     * @return item of type long
+     */
+    public long getItem() { return item; }
+
+    /**
+     * Returns the estimate
+     * @return the estimate
+     */
+    public long getEstimate() { return est; }
+
+    /**
+     * Returns the upper bound
+     * @return the upper bound
+     */
+    public long getUpperBound() { return ub; }
+
+    /**
+     * Returns the lower bound
+     * @return return the lower bound
+     */
+    public long getLowerBound() { return lb; }
+
+    /**
+     * Returns the descriptive row header
+     * @return the descriptive row header
+     */
+    public static String getRowHeader() {
+      return String.format(hfmt,"Est", "UB", "LB", "Item");
+    }
+
+    @Override
+    public String toString() {
+      return String.format(fmt, est, ub, lb, item);
+    }
+
+    /**
+     * This compareTo is strictly limited to the Row.getEstimate() value and does not imply any
+     * ordering whatsoever to the other elements of the row: item and upper and lower bounds.
+     * Defined this way, this compareTo will be consistent with hashCode() and equals(Object).
+     * @param that the other row to compare to.
+     * @return a negative integer, zero, or a positive integer as this.getEstimate() is less than,
+     * equal to, or greater than that.getEstimate().
+     */
+    @Override
+    public int compareTo(final Row that) {
+      return (est < that.est) ? -1 : (est > that.est) ? 1 : 0;
+    }
+
+    /**
+     * This hashCode is computed only from the Row.getEstimate() value.
+     * Defined this way, this hashCode will be consistent with equals(Object):<br>
+     * If (x.equals(y)) implies: x.hashCode() == y.hashCode().<br>
+     * If (!x.equals(y)) does NOT imply: x.hashCode() != y.hashCode().
+     * @return the hashCode computed from getEstimate().
+     */
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      final int result = 1;
+      return (prime * result) + (int) (est ^ (est >>> 32));
+    }
+
+    /**
+     * This equals is computed only from the Row.getEstimate() value and does not imply equality
+     * of the other items within the row: item and upper and lower bounds.
+     * Defined this way, this equals will be consistent with compareTo(Row).
+     * @param obj the other row to determine equality with.
+     * @return true if this.getEstimate() equals ((Row)obj).getEstimate().
+     */
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) { return true; }
+      if ( (obj == null) || !(obj instanceof Row)) { return false; }
+      final Row that = (Row) obj;
+      if (est != that.est) { return false; }
+      return true;
+    }
+
+  } // End of class Row
+
+  Row[] sortItems(final long threshold, final ErrorType errorType) {
+    final ArrayList<Row> rowList = new ArrayList<>();
+    final ReversePurgeLongHashMap.Iterator iter = hashMap.iterator();
+    if (errorType == ErrorType.NO_FALSE_NEGATIVES) {
+      while (iter.next()) {
+        final long est = getEstimate(iter.getKey());
+        final long ub = getUpperBound(iter.getKey());
+        final long lb = getLowerBound(iter.getKey());
+        if (ub >= threshold) {
+          final Row row = new Row(iter.getKey(), est, ub, lb);
+          rowList.add(row);
+        }
+      }
+    } else { //NO_FALSE_POSITIVES
+      while (iter.next()) {
+        final long est = getEstimate(iter.getKey());
+        final long ub = getUpperBound(iter.getKey());
+        final long lb = getLowerBound(iter.getKey());
+        if (lb >= threshold) {
+          final Row row = new Row(iter.getKey(), est, ub, lb);
+          rowList.add(row);
+        }
+      }
+    }
+
+    // descending order
+    rowList.sort(new Comparator<Row>() {
+      @Override
+      public int compare(final Row r1, final Row r2) {
+        return r2.compareTo(r1);
+      }
+    });
+
+    return rowList.toArray(new Row[rowList.size()]);
+  }
+
+  /**
+   * Deserializes an array of String tokens into a hash map object of this class.
+   *
+   * @param tokens the given array of Strings tokens.
+   * @return a hash map object of this class
+   */
+  static ReversePurgeLongHashMap deserializeFromStringArray(final String[] tokens) {
+    final int ignore = STR_PREAMBLE_TOKENS;
+    final int numActive = Integer.parseInt(tokens[ignore]);
+    final int length = Integer.parseInt(tokens[ignore + 1]);
+    final ReversePurgeLongHashMap hashMap = new ReversePurgeLongHashMap(length);
+    int j = 2 + ignore;
+    for (int i = 0; i < numActive; i++) {
+      final long key = Long.parseLong(tokens[j++]);
+      final long value = Long.parseLong(tokens[j++]);
+      hashMap.adjustOrPutValue(key, value);
+    }
+    return hashMap;
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/PreambleUtil.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.common.Util.zeroPad;
+
+import java.lang.foreign.MemorySegment;
+
+import org.apache.datasketches.common.Family;
+import org.apache.datasketches.common.SketchesArgumentException;
+
+// @formatter:off
+
+/**
+ * This class defines the preamble data structure and provides basic utilities for some of the key
+ * fields.
+ *
+ * <p>The intent of the design of this class was to isolate the detailed knowledge of the bit and byte
+ * layout of the serialized form of the sketches derived from the Sketch class into one place. This
+ * allows the possibility of the introduction of different serialization schemes with minimal impact
+ * on the rest of the library.</p>
+ *
+ * <p>MAP: Low significance bytes of this <i>long</i> data structure are on the right. However, the
+ * multi-byte integers (<i>int</i> and <i>long</i>) are stored in native byte order. The <i>byte</i>
+ * values are treated as unsigned.</p>
+ *
+ * <p>An empty FrequentItems only requires 8 bytes. All others require 32 bytes of preamble.</p>
+ *
+ * <pre>
+ *  * Long || Start Byte Adr:
+ * Adr:
+ *      ||    7     |    6   |    5   |    4   |    3   |    2   |    1   |     0          |
+ *  0   ||------ unused -----|-Flags--|-LgCur--| LgMax  | FamID  | SerVer | PreambleLongs  |
+ *      ||    15    |   14   |   13   |   12   |   11   |   10   |    9   |     8          |
+ *  1   ||------------(unused)-----------------|--------ActiveItems------------------------|
+ *      ||    23    |   22   |   21   |   20   |   19   |   18   |   17   |    16          |
+ *  2   ||-----------------------------------streamLength----------------------------------|
+ *      ||    31    |   30   |   29   |   28   |   27   |   26   |   25   |    24          |
+ *  3   ||---------------------------------offset------------------------------------------|
+ *      ||    39    |   38   |   37   |   36   |   35   |   34   |   33   |    32          |
+ *  5   ||----------start of values buffer, followed by keys buffer------------------------|
+ * </pre>
+ *
+ * @author Lee Rhodes
+ */
+final class PreambleUtil {
+
+  private PreambleUtil() {}
+
+  // ###### DO NOT MESS WITH THIS FROM HERE ...
+  // Preamble byte Addresses
+  static final int PREAMBLE_LONGS_BYTE       = 0; // either 1 or 4
+  static final int SER_VER_BYTE              = 1;
+  static final int FAMILY_BYTE               = 2;
+  static final int LG_MAX_MAP_SIZE_BYTE      = 3;
+  static final int LG_CUR_MAP_SIZE_BYTE      = 4;
+  static final int FLAGS_BYTE                = 5;
+  static final int SER_DE_ID_SHORT           = 6;  // to 7
+  static final int ACTIVE_ITEMS_INT          = 8;  // to 11 : 0 to 4 in pre1
+  static final int STREAMLENGTH_LONG         = 16; // to 23 : pre2
+  static final int OFFSET_LONG               = 24; // to 31 : pre3
+
+  // flag bit masks
+  // due to a mistake different bits were used in C++ and Java to indicate empty sketch
+  // therefore both are set and checked for compatibility with historical binary format
+  static final int EMPTY_FLAG_MASK = 5;
+
+  // Specific values for this implementation
+  static final int SER_VER = 1;
+
+  /**
+   * Returns a human readable string summary of the preamble state of the given MemorySegment.
+   * Note: other than making sure that the given MemorySegment size is large
+   * enough for just the preamble, this does not do much value checking of the contents of the
+   * preamble as this is primarily a tool for debugging the preamble visually.
+   *
+   * @param srcSeg the given MemorySegment
+   * @return the summary preamble string.
+   */
+  public static String preambleToString(final MemorySegment srcSeg) {
+    final long pre0 = checkPreambleSize(srcSeg); //make sure we can get the assumed preamble
+    final int preLongs = extractPreLongs(pre0);   //byte 0
+    final int serVer = extractSerVer(pre0);       //byte 1
+    final Family family = Family.idToFamily(extractFamilyID(pre0)); //byte 2
+    final int lgMaxMapSize = extractLgMaxMapSize(pre0); //byte 3
+    final int lgCurMapSize = extractLgCurMapSize(pre0); //byte 4
+    final int flags = extractFlags(pre0);         //byte 5
+
+    final String flagsStr = zeroPad(Integer.toBinaryString(flags), 8) + ", " + (flags);
+    final boolean empty = (flags & EMPTY_FLAG_MASK) > 0;
+    final int maxMapSize = 1 << lgMaxMapSize;
+    final int curMapSize = 1 << lgCurMapSize;
+    final int maxPreLongs = Family.FREQUENCY.getMaxPreLongs();
+
+    //Assumed if preLongs == 1
+    int activeItems = 0;
+    long streamLength = 0;
+    long offset = 0;
+
+    //Assumed if preLongs == maxPreLongs
+
+    if (preLongs == maxPreLongs) {
+      //get full preamble
+      final long[] preArr = new long[preLongs];
+      MemorySegment.copy(srcSeg, JAVA_LONG_UNALIGNED, 0, preArr, 0, preLongs);
+      activeItems =  extractActiveItems(preArr[1]);
+      streamLength = preArr[2];
+      offset = preArr[3];
+    }
+
+    final StringBuilder sb = new StringBuilder();
+    sb.append(LS)
+      .append("### FREQUENCY SKETCH PREAMBLE SUMMARY:").append(LS)
+      .append("Byte  0: Preamble Longs       : ").append(preLongs).append(LS)
+      .append("Byte  1: Serialization Version: ").append(serVer).append(LS)
+      .append("Byte  2: Family               : ").append(family.toString()).append(LS)
+      .append("Byte  3: MaxMapSize           : ").append(maxMapSize).append(LS)
+      .append("Byte  4: CurMapSize           : ").append(curMapSize).append(LS)
+      .append("Byte  5: Flags Field          : ").append(flagsStr).append(LS)
+      .append("  EMPTY                       : ").append(empty).append(LS);
+
+    if (preLongs == 1) {
+      sb.append(" --ABSENT, ASSUMED:").append(LS);
+    } else { //preLongs == maxPreLongs
+      sb.append("Bytes 8-11 : ActiveItems      : ").append(activeItems).append(LS);
+      sb.append("Bytes 16-23: StreamLength     : ").append(streamLength).append(LS)
+        .append("Bytes 24-31: Offset           : ").append(offset).append(LS);
+    }
+
+    sb.append(  "Preamble Bytes                : ").append(preLongs * 8).append(LS);
+    sb.append(  "TOTAL Sketch Bytes            : ").append((preLongs + (activeItems * 2)) << 3)
+      .append(LS)
+      .append("### END FREQUENCY SKETCH PREAMBLE SUMMARY").append(LS);
+    return sb.toString();
+  }
+
+  // @formatter:on
+
+  static int extractPreLongs(final long pre0) { //Byte 0
+    final long mask = 0X3FL; //Lower 6 bits
+    return (int) (pre0 & mask);
+  }
+
+  static int extractSerVer(final long pre0) { //Byte 1
+    final int shift = SER_VER_BYTE << 3;
+    final long mask = 0XFFL;
+    return (int) ((pre0 >>> shift) & mask);
+  }
+
+  static int extractFamilyID(final long pre0) { //Byte 2
+    final int shift = FAMILY_BYTE << 3;
+    final long mask = 0XFFL;
+    return (int) ((pre0 >>> shift) & mask);
+  }
+
+  static int extractLgMaxMapSize(final long pre0) { //Byte 3
+    final int shift = LG_MAX_MAP_SIZE_BYTE << 3;
+    final long mask = 0XFFL;
+    return (int) ((pre0 >>> shift) & mask);
+  }
+
+  static int extractLgCurMapSize(final long pre0) { //Byte 4
+    final int shift = LG_CUR_MAP_SIZE_BYTE << 3;
+    final long mask = 0XFFL;
+    return (int) ((pre0 >>> shift) & mask);
+  }
+
+  static int extractFlags(final long pre0) { //Byte 5
+    final int shift = FLAGS_BYTE << 3;
+    final long mask = 0XFFL;
+    return (int) ((pre0 >>> shift) & mask);
+  }
+
+  static int extractActiveItems(final long pre1) { //Bytes 8 to 11
+    final long mask = 0XFFFFFFFFL;
+    return (int) (pre1 & mask) ;
+  }
+
+  static long insertPreLongs(final int preLongs, final long pre0) { //Byte 0
+    final long mask = 0X3FL; //Lower 6 bits
+    return (preLongs & mask) | (~mask & pre0);
+  }
+
+  static long insertSerVer(final int serVer, final long pre0) { //Byte 1
+    final int shift = SER_VER_BYTE << 3;
+    final long mask = 0XFFL;
+    return ((serVer & mask) << shift) | (~(mask << shift) & pre0);
+  }
+
+  static long insertFamilyID(final int familyID, final long pre0) { //Byte 2
+    final int shift = FAMILY_BYTE << 3;
+    final long mask = 0XFFL;
+    return ((familyID & mask) << shift) | (~(mask << shift) & pre0);
+  }
+
+  static long insertLgMaxMapSize(final int lgMaxMapSize, final long pre0) { //Byte 3
+    final int shift = LG_MAX_MAP_SIZE_BYTE << 3;
+    final long mask = 0XFFL;
+    return ((lgMaxMapSize & mask) << shift) | (~(mask << shift) & pre0);
+  }
+
+  static long insertLgCurMapSize(final int lgCurMapSize, final long pre0) { //Byte 4
+    final int shift = LG_CUR_MAP_SIZE_BYTE << 3;
+    final long mask = 0XFFL;
+    return ((lgCurMapSize & mask) << shift) | (~(mask << shift) & pre0);
+  }
+
+  static long insertFlags(final int flags, final long pre0) { //Byte 5
+    final int shift = FLAGS_BYTE << 3;
+    final long mask = 0XFFL;
+    return ((flags & mask) << shift) | (~(mask << shift) & pre0);
+  }
+
+  static long insertActiveItems(final int activeItems, final long pre1) { //Bytes 8 to 11
+    final long mask = 0XFFFFFFFFL;
+    return (activeItems & mask) | (~mask & pre1);
+  }
+
+  /**
+   * Checks MemorySegment for capacity to hold the preamble and returns the first 8 bytes.
+   * @param seg the given MemorySegment
+   * @return the first 8 bytes of preamble as a long.
+   */
+  static long checkPreambleSize(final MemorySegment seg) {
+    final long cap = seg.byteSize();
+    if (cap < 8) { throwNotBigEnough(cap, 8); }
+    final long pre0 = seg.get(JAVA_LONG_UNALIGNED, 0);
+    final int preLongs = (int) (pre0 & 0X3FL); //lower 6 bits
+    final int required = Math.max(preLongs << 3, 8);
+    if (cap < required) { throwNotBigEnough(cap, required); }
+    return pre0;
+  }
+
+  private static void throwNotBigEnough(final long cap, final int required) {
+    throw new SketchesArgumentException(
+        "Possible Corruption: "
+            + "Size of byte array or Memory not large enough for Preamble: Size: " + cap
+            + ", Required: " + required);
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/ReversePurgeItemHashMap.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/ReversePurgeItemHashMap.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.common.Util.exactLog2OfInt;
+import static org.apache.datasketches.frequencies2.Util.hash;
+
+import java.lang.reflect.Array;
+
+import org.apache.datasketches.common.QuickSelect;
+
+/**
+ * Implements a linear-probing based hash map of (key, value) pairs and is distinguished by a
+ * "reverse" purge operation that removes all keys in the map whose associated values are &le; 0
+ * and is performed in reverse, starting at the "back" of the array and moving toward the front.
+ *
+ * @param <T> The type of item to be tracked by this sketch
+ *
+ * @author Edo Liberty
+ * @author Justin Thaler
+ * @author Alexander Saydakov
+ */
+class ReversePurgeItemHashMap<T> {
+  private static final double LOAD_FACTOR = 0.75;
+  private static final int DRIFT_LIMIT = 1024; //used only in stress testing
+  private int lgLength;
+  protected int loadThreshold;
+  protected Object[] keys;
+  protected long[] values;
+  protected short[] states;
+  protected int numActive = 0;
+
+  /**
+   * Constructor will create arrays of length mapSize, which must be a power of two.
+   * This restriction was made to ensure fast hashing.
+   * The protected variable this.loadThreshold is then set to the largest value that
+   * will not overload the hash table.
+   *
+   * @param mapSize This determines the number of cells in the arrays underlying the
+   * HashMap implementation and must be a power of 2.
+   * The hash table will be expected to store LOAD_FACTOR * mapSize (key, value) pairs.
+   */
+  ReversePurgeItemHashMap(final int mapSize) {
+    lgLength = exactLog2OfInt(mapSize, "mapSize");
+    loadThreshold = (int) (mapSize * LOAD_FACTOR);
+    keys = new Object[mapSize];
+    values = new long[mapSize];
+    states = new short[mapSize];
+  }
+
+  /**
+   * @param probe location in the hash table array
+   * @return true if the cell in the array contains an active key
+   */
+  boolean isActive(final int probe) {
+    return states[probe] > 0;
+  }
+
+  /**
+   * Gets the current value with the given key
+   * @param key the given key
+   * @return the positive value the key corresponds to or zero if the key is not found in the
+   * hash map.
+   */
+  long get(final T key) {
+    if (key == null) { return 0; }
+    final int probe = hashProbe(key);
+    if (states[probe] > 0) {
+      assert keys[probe].equals(key);
+      return values[probe];
+    }
+    return 0;
+  }
+
+  /**
+   * Increments the value mapped to the key if the key is present in the map. Otherwise,
+   * the key is inserted with the adjustAmount.
+   *
+   * @param key the key of the value to increment
+   * @param adjustAmount the amount by which to increment the value
+   */
+  void adjustOrPutValue(final T key, final long adjustAmount) {
+    final int arrayMask = keys.length - 1;
+    int probe = (int) hash(key.hashCode()) & arrayMask;
+    int drift = 1;
+    while ((states[probe] != 0) && !keys[probe].equals(key)) {
+      probe = (probe + 1) & arrayMask;
+      drift++;
+      //only used for theoretical analysis
+      assert drift < DRIFT_LIMIT : "drift: " + drift + " >= DRIFT_LIMIT";
+    }
+
+    if (states[probe] == 0) {
+      // adding the key to the table the value
+      assert numActive <= loadThreshold
+        : "numActive: " + numActive + " > loadThreshold: " + loadThreshold;
+      keys[probe] = key;
+      values[probe] = adjustAmount;
+      states[probe] = (short) drift;
+      numActive++;
+    } else {
+      // adjusting the value of an existing key
+      assert keys[probe].equals(key);
+      values[probe] += adjustAmount;
+    }
+  }
+
+  /**
+   * Processes the map arrays and retains only keys with positive counts.
+   */
+  void keepOnlyPositiveCounts() {
+    // Starting from the back, find the first empty cell,
+    //  which establishes the high end of a cluster.
+    int firstProbe = states.length - 1;
+    while (states[firstProbe] > 0) {
+      firstProbe--;
+    }
+    // firstProbe keeps track of this point.
+    // When we find the next non-empty cell, we know we are at the high end of a cluster
+    // Work towards the front; delete any non-positive entries.
+    for (int probe = firstProbe; probe-- > 0;) {
+      if ((states[probe] > 0) && (values[probe] <= 0)) {
+        hashDelete(probe); //does the work of deletion and moving higher items towards the front.
+        numActive--;
+      }
+    }
+    //now work on the first cluster that was skipped.
+    for (int probe = states.length; probe-- > firstProbe;) {
+      if ((states[probe] > 0) && (values[probe] <= 0)) {
+        hashDelete(probe);
+        numActive--;
+      }
+    }
+  }
+
+  /**
+   * @param adjustAmount value by which to shift all values. Only keys corresponding to positive
+   * values are retained.
+   */
+  void adjustAllValuesBy(final long adjustAmount) {
+    for (int i = values.length; i-- > 0;) {
+      values[i] += adjustAmount;
+    }
+  }
+
+  /**
+   * @return an array containing the active keys in the hash map.
+   */
+  @SuppressWarnings("unchecked")
+  T[] getActiveKeys() {
+    if (numActive == 0) { return null; }
+    T[] returnedKeys = null;
+    int j = 0;
+    for (int i = 0; i < keys.length; i++) {
+      if (isActive(i)) {
+        if (returnedKeys == null) {
+          returnedKeys = (T[]) Array.newInstance(keys[i].getClass(), numActive);
+        }
+        returnedKeys[j] = (T) keys[i];
+        j++;
+      }
+    }
+    assert j == numActive : "j: " + j + " != numActive: " + numActive;
+    return returnedKeys;
+  }
+
+  /**
+   * @return an array containing the values corresponding to the active keys in the hash
+   */
+  long[] getActiveValues() {
+    if (numActive == 0) { return null; }
+    final long[] returnedValues = new long[numActive];
+    int j = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (isActive(i)) {
+        returnedValues[j] = values[i];
+        j++;
+      }
+    }
+    assert j == numActive;
+    return returnedValues;
+  }
+
+  // assume newSize is power of 2
+  @SuppressWarnings("unchecked")
+  void resize(final int newSize) {
+    final Object[] oldKeys = keys;
+    final long[] oldValues = values;
+    final short[] oldStates = states;
+    keys = new Object[newSize];
+    values = new long[newSize];
+    states = new short[newSize];
+    loadThreshold = (int) (newSize * LOAD_FACTOR);
+    lgLength = Integer.numberOfTrailingZeros(newSize);
+    numActive = 0;
+    for (int i = 0; i < oldKeys.length; i++) {
+      if (oldStates[i] > 0) {
+        adjustOrPutValue((T) oldKeys[i], oldValues[i]);
+      }
+    }
+  }
+
+  /**
+   * @return length of hash table internal arrays
+   */
+  int getLength() {
+    return keys.length;
+  }
+
+  int getLgLength() {
+    return lgLength;
+  }
+
+  /**
+   * @return capacity of hash table internal arrays (i.e., max number of keys that can be stored)
+   */
+  int getCapacity() {
+    return loadThreshold;
+  }
+
+  /**
+   * @return number of populated keys
+   */
+  int getNumActive() {
+    return numActive;
+  }
+
+  /**
+   * Returns the hash table as a human readable string.
+   */
+  @Override
+  public String toString() {
+    final String fmt  = "  %12d:%11d%12d %s";
+    final String hfmt = "  %12s:%11s%12s %s";
+    final StringBuilder sb = new StringBuilder();
+    sb.append("ReversePurgeItemHashMap").append(LS);
+    sb.append(String.format(hfmt, "Index","States","Values","Keys")).append(LS);
+
+    for (int i = 0; i < keys.length; i++) {
+      if (states[i] <= 0) { continue; }
+      sb.append(String.format(fmt, i, states[i], values[i], keys[i].toString()));
+      sb.append(LS);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * @return the load factor of the hash table, i.e, the ratio between the capacity and the array
+   * length
+   */
+  static double getLoadFactor() {
+    return LOAD_FACTOR;
+  }
+
+  /**
+   * This function is called when a key is processed that is not currently assigned a counter, and
+   * all the counters are in use. This function estimates the median of the counters in the sketch
+   * via sampling, decrements all counts by this estimate, throws out all counters that are no
+   * longer positive, and increments offset accordingly.
+   * @param sampleSize number of samples
+   * @return the median value
+   */
+  long purge(final int sampleSize) {
+    final int limit = Math.min(sampleSize, getNumActive());
+
+    int numSamples = 0;
+    int i = 0;
+    final long[] samples = new long[limit];
+
+    while (numSamples < limit) {
+      if (isActive(i)) {
+        samples[numSamples] = values[i];
+        numSamples++;
+      }
+      i++;
+    }
+
+    final long val = QuickSelect.select(samples, 0, numSamples - 1, limit / 2);
+    adjustAllValuesBy(-1 * val);
+    keepOnlyPositiveCounts();
+    return val;
+  }
+
+  private void hashDelete(int deleteProbe) {
+    // Looks ahead in the table to search for another
+    // item to move to this location
+    // if none are found, the status is changed
+    states[deleteProbe] = 0; //mark as empty
+    int drift = 1;
+    final int arrayMask = keys.length - 1;
+    int probe = (deleteProbe + drift) & arrayMask; //map length must be a power of 2
+    // advance until you find a free location replacing locations as needed
+    while (states[probe] != 0) {
+      if (states[probe] > drift) {
+        // move current element
+        keys[deleteProbe] = keys[probe];
+        values[deleteProbe] = values[probe];
+        states[deleteProbe] = (short) (states[probe] - drift);
+        // marking this location as deleted
+        states[probe] = 0;
+        drift = 0;
+        deleteProbe = probe;
+      }
+      probe = (probe + 1) & arrayMask;
+      drift++;
+      //only used for theoretical analysis
+      assert drift < DRIFT_LIMIT : "drift: " + drift + " >= DRIFT_LIMIT";
+    }
+  }
+
+  private int hashProbe(final T key) {
+    final int arrayMask = keys.length - 1;
+    int probe = (int) hash(key.hashCode()) & arrayMask;
+    while ((states[probe] > 0) && !keys[probe].equals(key)) {
+      probe = (probe + 1) & arrayMask;
+    }
+    return probe;
+  }
+
+  Iterator<T> iterator() {
+    return new Iterator<>(keys, values, states, numActive);
+  }
+
+  // This iterator uses strides based on golden ratio to avoid clustering during merge
+  static class Iterator<T> {
+    private static final double GOLDEN_RATIO_RECIPROCAL = (Math.sqrt(5) - 1) / 2;
+
+    private final Object[] keys_;
+    private final long[] values_;
+    private final short[] states_;
+    private final int numActive_;
+    private final int stride_;
+    private final int mask_;
+    private int i_;
+    private int count_;
+
+    Iterator(final Object[] keys, final long[] values, final short[] states, final int numActive) {
+      keys_ = keys;
+      values_ = values;
+      states_ = states;
+      numActive_ = numActive;
+      stride_ = (int) (keys.length * GOLDEN_RATIO_RECIPROCAL) | 1;
+      mask_ = keys.length - 1;
+      i_ = -stride_;
+      count_ = 0;
+    }
+
+    boolean next() {
+      i_ = (i_ + stride_) & mask_;
+      while (count_ < numActive_) {
+        if (states_[i_] > 0) {
+          count_++;
+          return true;
+        }
+        i_ = (i_ + stride_) & mask_;
+      }
+      return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    T getKey() {
+      return (T) keys_[i_];
+    }
+
+    long getValue() {
+      return values_[i_];
+    }
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/ReversePurgeLongHashMap.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/ReversePurgeLongHashMap.java
@@ -1,0 +1,418 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.common.Util.exactLog2OfInt;
+import static org.apache.datasketches.common.Util.INVERSE_GOLDEN;
+import static org.apache.datasketches.frequencies2.Util.hash;
+
+import org.apache.datasketches.common.QuickSelect;
+import org.apache.datasketches.common.SketchesArgumentException;
+
+/**
+ * Implements a linear-probing based hash map of (key, value) pairs and is distinguished by a
+ * "reverse" purge operation that removes all keys in the map whose associated values are &le; 0
+ * and is performed in reverse, starting at the "back" of the array and moving toward the front.
+ *
+ * @author Edo Liberty
+ * @author Justin Thaler
+ * @author Lee Rhodes
+ */
+class ReversePurgeLongHashMap {
+  private static final double LOAD_FACTOR = 0.75;
+  private static final int DRIFT_LIMIT = 1024; //used only in stress testing
+  private int lgLength;
+  private int loadThreshold;
+  private long[] keys;
+  private long[] values;
+  private short[] states;
+  private int numActive = 0;
+
+  /**
+   * Constructor will create arrays of length mapSize, which must be a power of two.
+   * This restriction was made to ensure fast hashing.
+   * The protected variable this.loadThreshold is then set to the largest value that
+   * will not overload the hash table.
+   *
+   * @param mapSize This determines the number of cells in the arrays underlying the
+   * HashMap implementation and must be a power of 2.
+   * The hash table will be expected to store LOAD_FACTOR * mapSize (key, value) pairs.
+   */
+  ReversePurgeLongHashMap(final int mapSize) {
+    lgLength = exactLog2OfInt(mapSize, "mapSize");
+    loadThreshold = (int) (mapSize * LOAD_FACTOR);
+    keys = new long[mapSize];
+    values = new long[mapSize];
+    states = new short[mapSize];
+  }
+
+  /**
+   * Returns an instance of this class from the given String,
+   * which must be a String representation of this class.
+   *
+   * @param string a String representation of this class.
+   * @return an instance of this class.
+   */
+  static ReversePurgeLongHashMap getInstance(final String string) {
+    final String[] tokens = string.split(",");
+    if (tokens.length < 2) {
+      throw new SketchesArgumentException(
+          "String not long enough to specify length and capacity.");
+    }
+    final int numActive = Integer.parseInt(tokens[0]);
+    final int length = Integer.parseInt(tokens[1]);
+    final ReversePurgeLongHashMap table = new ReversePurgeLongHashMap(length);
+    int j = 2;
+    for (int i = 0; i < numActive; i++) {
+      final long key = Long.parseLong(tokens[j++]);
+      final long value = Long.parseLong(tokens[j++]);
+      table.adjustOrPutValue(key, value);
+    }
+    return table;
+  }
+
+  //Serialization
+
+  /**
+   * Returns a String representation of this hash map.
+   *
+   * @return a String representation of this hash map.
+   */
+  String serializeToString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(String.format("%d,%d,", numActive, keys.length));
+
+    for (int i = 0; i < keys.length; i++) {
+      if (states[i] != 0) {
+        sb.append(String.format("%d,%d,", keys[i], values[i]));
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
+   * @param probe location in the hash table array
+   * @return true if the cell in the array contains an active key
+   */
+  boolean isActive(final int probe) {
+    return (states[probe] > 0);
+  }
+
+  /**
+   * Gets the current value with the given key
+   * @param key the given key
+   * @return the positive value the key corresponds to or zero if the key is not found in the
+   * hash map.
+   */
+  long get(final long key) {
+    final int probe = hashProbe(key);
+    if (states[probe] > 0) {
+      assert (keys[probe] == key);
+      return values[probe];
+    }
+    return 0;
+  }
+
+  /**
+   * Increments the value mapped to the key if the key is present in the map. Otherwise,
+   * the key is inserted with the putAmount.
+   *
+   * @param key the key of the value to increment
+   * @param adjustAmount the amount by which to increment the value
+   */
+  void adjustOrPutValue(final long key, final long adjustAmount) {
+    final int arrayMask = keys.length - 1;
+    int probe = (int) hash(key) & arrayMask;
+    int drift = 1;
+    while ((states[probe] != 0) && (keys[probe] != key)) {
+      probe = (probe + 1) & arrayMask;
+      drift++;
+      //only used for theoretical analysis
+      assert (drift < DRIFT_LIMIT) : "drift: " + drift + " >= DRIFT_LIMIT";
+    }
+    //found either an empty slot or the key
+    if (states[probe] == 0) { //found empty slot
+      // adding the key and value to the table
+      assert (numActive <= loadThreshold)
+        : "numActive: " + numActive + " > loadThreshold : " + loadThreshold;
+      keys[probe] = key;
+      values[probe] = adjustAmount;
+      states[probe] = (short) drift; //how far off we are
+      numActive++;
+    } else { //found the key, adjust the value
+      assert (keys[probe] == key);
+      values[probe] += adjustAmount;
+    }
+  }
+
+  /**
+   * Processes the map arrays and retains only keys with positive counts.
+   */
+  void keepOnlyPositiveCounts() {
+    // Starting from the back, find the first empty cell, which marks a boundary between clusters.
+    int firstProbe = keys.length - 1;
+    while (states[firstProbe] > 0) {
+      firstProbe--;
+    }
+
+    //Work towards the front; delete any non-positive entries.
+    for (int probe = firstProbe; probe-- > 0; ) {
+      // When we find the next non-empty cell, we know we are at the high end of a cluster,
+      //  which is tracked by firstProbe.
+      if ((states[probe] > 0) && (values[probe] <= 0)) {
+        hashDelete(probe); //does the work of deletion and moving higher items towards the front.
+        numActive--;
+      }
+    }
+    //now work on the first cluster that was skipped.
+    for (int probe = keys.length; probe-- > firstProbe;) {
+      if ((states[probe] > 0) && (values[probe] <= 0)) {
+        hashDelete(probe);
+        numActive--;
+      }
+    }
+  }
+
+  /**
+   * @param adjustAmount value by which to shift all values. Only keys corresponding to positive
+   * values are retained.
+   */
+  void adjustAllValuesBy(final long adjustAmount) {
+    for (int i = keys.length; i-- > 0; ) {
+      values[i] += adjustAmount;
+    }
+  }
+
+  /**
+   * @return an array containing the active keys in the hash map.
+   */
+  long[] getActiveKeys() {
+    if (numActive == 0) { return null; }
+    final long[] returnedKeys = new long[numActive];
+    int j = 0;
+    for (int i = 0; i < keys.length; i++) {
+      if (isActive(i)) {
+        returnedKeys[j] = keys[i];
+        j++;
+      }
+    }
+    assert (j == numActive) : "j: " + j + " != numActive: " + numActive;
+    return returnedKeys;
+  }
+
+  /**
+   * @return an array containing the values corresponding. to the active keys in the hash
+   */
+  long[] getActiveValues() {
+    if (numActive == 0) { return null; }
+    final long[] returnedValues = new long[numActive];
+    int j = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (isActive(i)) {
+        returnedValues[j] = values[i];
+        j++;
+      }
+    }
+    assert (j == numActive);
+    return returnedValues;
+  }
+
+  // assume newSize is power of 2
+  void resize(final int newSize) {
+    final long[] oldKeys = keys;
+    final long[] oldValues = values;
+    final short[] oldStates = states;
+    keys = new long[newSize];
+    values = new long[newSize];
+    states = new short[newSize];
+    loadThreshold = (int) (newSize * LOAD_FACTOR);
+    lgLength = Integer.numberOfTrailingZeros(newSize);
+    numActive = 0;
+    for (int i = 0; i < oldKeys.length; i++) {
+      if (oldStates[i] > 0) {
+        adjustOrPutValue(oldKeys[i], oldValues[i]);
+      }
+    }
+  }
+
+  /**
+   * @return length of hash table internal arrays
+   */
+  int getLength() {
+    return keys.length;
+  }
+
+  int getLgLength() {
+    return lgLength;
+  }
+
+  /**
+   * @return capacity of hash table internal arrays (i.e., max number of keys that can be stored)
+   */
+  int getCapacity() {
+    return loadThreshold;
+  }
+
+  /**
+   * @return number of populated keys
+   */
+  int getNumActive() {
+    return numActive;
+  }
+
+  /**
+   * Returns the hash table as a human readable string.
+   */
+  @Override
+  public String toString() {
+    final String fmt  = "  %12d:%11d%20d %d";
+    final String hfmt = "  %12s:%11s%20s %s";
+    final StringBuilder sb = new StringBuilder();
+    sb.append("ReversePurgeLongHashMap:").append(LS);
+    sb.append(String.format(hfmt, "Index","States","Values","Keys")).append(LS);
+
+    for (int i = 0; i < keys.length; i++) {
+      if (states[i] <= 0) { continue; }
+      sb.append(String.format(fmt, i, states[i], values[i], keys[i])).append(LS);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * @return the load factor of the hash table, i.e, the ratio between the capacity and the array
+   * length
+   */
+  static double getLoadFactor() {
+    return LOAD_FACTOR;
+  }
+
+  /**
+   * This function is called when a key is processed that is not currently assigned a counter, and
+   * all the counters are in use. This function estimates the median of the counters in the sketch
+   * via sampling, decrements all counts by this estimate, throws out all counters that are no
+   * longer positive, and increments offset accordingly.
+   * @param sampleSize number of samples
+   * @return the median value
+   */
+  long purge(final int sampleSize) {
+    final int limit = Math.min(sampleSize, getNumActive());
+
+    int numSamples = 0;
+    int i = 0;
+    final long[] samples = new long[limit];
+
+    while (numSamples < limit) {
+      if (isActive(i)) {
+        samples[numSamples] = values[i];
+        numSamples++;
+      }
+      i++;
+    }
+
+    final long val = QuickSelect.select(samples, 0, numSamples - 1, limit / 2);
+    adjustAllValuesBy(-1 * val);
+    keepOnlyPositiveCounts();
+    return val;
+  }
+
+  private void hashDelete(int deleteProbe) {
+    // Looks ahead in the table to search for another item to move to this location.
+    // If none are found, the status is changed
+    states[deleteProbe] = 0; //mark as empty
+    int drift = 1;
+    final int arrayMask = keys.length - 1;
+    int probe = (deleteProbe + drift) & arrayMask; //map length must be a power of 2
+    // advance until you find a free location replacing locations as needed
+    while (states[probe] != 0) {
+      if (states[probe] > drift) {
+        // move current element
+        keys[deleteProbe] = keys[probe];
+        values[deleteProbe] = values[probe];
+        states[deleteProbe] = (short) (states[probe] - drift);
+        // marking the current probe location as deleted
+        states[probe] = 0;
+        drift = 0;
+        deleteProbe = probe;
+      }
+      probe = (probe + 1) & arrayMask;
+      drift++;
+      //only used for theoretical analysis
+      assert (drift < DRIFT_LIMIT) : "drift: " + drift + " >= DRIFT_LIMIT";
+    }
+  }
+
+  private int hashProbe(final long key) {
+    final int arrayMask = keys.length - 1;
+    int probe = (int) hash(key) & arrayMask;
+    while ((states[probe] > 0) && (keys[probe] != key)) {
+      probe = (probe + 1) & arrayMask;
+    }
+    return probe;
+  }
+
+  Iterator iterator() {
+    return new Iterator(keys, values, states, numActive);
+  }
+
+  // This iterator uses strides based on golden ratio to avoid clustering during merge
+  static class Iterator {
+    private final long[] keys_;
+    private final long[] values_;
+    private final short[] states_;
+    private final int numActive_;
+    private final int stride_;
+    private final int mask_;
+    private int i_;
+    private int count_;
+
+    Iterator(final long[] keys, final long[] values, final short[] states, final int numActive) {
+      keys_ = keys;
+      values_ = values;
+      states_ = states;
+      numActive_ = numActive;
+      stride_ = (int) (keys.length * INVERSE_GOLDEN) | 1;
+      mask_ = keys.length - 1;
+      i_ = -stride_;
+      count_ = 0;
+    }
+
+    boolean next() {
+      i_ = (i_ + stride_) & mask_;
+      while (count_ < numActive_) {
+        if (states_[i_] > 0) {
+          count_++;
+          return true;
+        }
+        i_ = (i_ + stride_) & mask_;
+      }
+      return false;
+    }
+
+    long getKey() {
+      return keys_[i_];
+    }
+
+    long getValue() {
+      return values_[i_];
+    }
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/Util.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/Util.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+final class Util {
+
+  private Util() {}
+
+  /**
+   * The following constant controls the size of the initial data structure for the 
+   * frequencies sketches and its value is somewhat arbitrary.
+   */
+  static final int LG_MIN_MAP_SIZE = 3;
+
+  /**
+   * This constant is large enough so that computing the median of SAMPLE_SIZE
+   * randomly selected entries from a list of numbers and outputting
+   * the empirical median will give a constant-factor approximation to the 
+   * true median with high probability.
+   */
+  static final int SAMPLE_SIZE = 1024;
+
+  /**
+   * @param key to be hashed
+   * @return an index into the hash table This hash function is taken from the internals of 
+   * Austin Appleby's MurmurHash3 algorithm. It is also used by the Trove for Java libraries.
+   */
+  static long hash(long key) {
+    key ^= key >>> 33;
+    key *= 0xff51afd7ed558ccdL;
+    key ^= key >>> 33;
+    key *= 0xc4ceb9fe1a85ec53L;
+    key ^= key >>> 33;
+    return key;
+  }
+
+}

--- a/src/main/java/org/apache/datasketches/frequencies2/package-info.java
+++ b/src/main/java/org/apache/datasketches/frequencies2/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;

--- a/src/main/java/org/apache/datasketches/theta/CompactSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/CompactSketch.java
@@ -105,7 +105,7 @@ public abstract class CompactSketch extends Sketch {
     final int familyID = extractFamilyID(srcSeg);
     final Family family = idToFamily(familyID);
     if (family != Family.COMPACT) {
-      throw new IllegalArgumentException("Corrupted: " + family + " is not Compact!");
+      throw new SketchesArgumentException("Corrupted: " + family + " is not Compact!");
     }
     if (serVer == 4) {
        return heapifyV4(srcSeg, seed, enforceSeed);
@@ -186,7 +186,7 @@ public abstract class CompactSketch extends Sketch {
     final int familyID = extractFamilyID(srcSeg);
     final Family family = Family.idToFamily(familyID);
     if (family != Family.COMPACT) {
-      throw new IllegalArgumentException("Corrupted: " + family + " is not Compact!");
+      throw new SketchesArgumentException("Corrupted: " + family + " is not Compact!");
     }
     final short seedHash = Util.computeSeedHash(seed);
 
@@ -285,7 +285,7 @@ public abstract class CompactSketch extends Sketch {
     final int familyId = bytes[PreambleUtil.FAMILY_BYTE];
     final Family family = Family.idToFamily(familyId);
     if (family != Family.COMPACT) {
-      throw new IllegalArgumentException("Corrupted: " + family + " is not Compact!");
+      throw new SketchesArgumentException("Corrupted: " + family + " is not Compact!");
     }
     final short seedHash = Util.computeSeedHash(seed);
     if (serVer == 4) {

--- a/src/test/java/org/apache/datasketches/frequencies2/DistTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/DistTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import org.testng.Assert;
+//import org.testng.annotations.Test;
+
+public class DistTest {
+
+  /**
+   * @param prob the probability of success for the geometric distribution.
+   * @return a random number generated from the geometric distribution.
+   */
+  public static long randomGeometricDist(double prob) {
+    assert ((prob > 0.0) && (prob < 1.0));
+    return 1 + (long) (Math.log(Math.random()) / Math.log(1.0 - prob));
+  }
+
+  public static double zeta(long n, double theta) {
+    // the zeta function, used by the below zipf function
+    // (this is not often called from outside this library)
+    // ... but have made it public now to speed things up
+    long i;
+    double ans = 0.0;
+
+    for (i = 1; i <= n; i++) {
+      ans += Math.pow(1.0 / i, theta);
+    }
+    return (ans);
+  }
+
+  // This draws values from the zipf distribution
+  // n is range, theta is skewness parameter
+  // theta = 0 gives uniform distribution,
+  // theta > 1 gives highly skewed distribution.
+  public static long zipf(double theta, long n, double zetan) {
+    double alpha;
+    double eta;
+    double u;
+    double uz;
+    double val;
+
+    // randinit must be called before entering this procedure for
+    // the first time since it uses the random generators
+
+    alpha = 1. / (1. - theta);
+    eta = (1. - Math.pow(2. / n, 1. - theta)) / (1. - (zeta(2, theta) / zetan));
+
+    u = 0.0;
+    while (u == 0.0) {
+      u = Math.random();
+    }
+    uz = u * zetan;
+    if (uz < 1.) {
+      val = 1;
+    } else if (uz < (1. + Math.pow(0.5, theta))) {
+      val = 2;
+    } else {
+      val = 1 + (n * Math.pow(((eta * u) - eta) + 1., alpha));
+    }
+
+    return (long) val;
+  }
+
+  //@Test
+  public static void testRandomGeometricDist() {
+    long maxItem = 0L;
+    double prob = .1;
+    for (int i = 0; i < 100; i++) {
+      long item = randomGeometricDist(prob);
+      if (item > maxItem) {
+        maxItem = item;
+      }
+      // If you succeed with probability p the probability
+      // of failing 20/p times is smaller than 1/2^20.
+      Assert.assertTrue(maxItem < (20.0 / prob));
+    }
+  }
+
+}

--- a/src/test/java/org/apache/datasketches/frequencies2/FrequentItemsSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/FrequentItemsSketchCrossLanguageTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static org.apache.datasketches.common.TestUtil.CHECK_CPP_FILES;
+import static org.apache.datasketches.common.TestUtil.GENERATE_JAVA_FILES;
+import static org.apache.datasketches.common.TestUtil.cppPath;
+import static org.apache.datasketches.common.TestUtil.javaPath;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.foreign.MemorySegment;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.apache.datasketches.common.ArrayOfStringsSerDe2;
+import org.testng.annotations.Test;
+
+/**
+ * Serialize binary sketches to be tested by C++ code.
+ * Test deserialization of binary sketches serialized by C++ code.
+ */
+public class FrequentItemsSketchCrossLanguageTest {
+
+  @Test(groups = {GENERATE_JAVA_FILES})
+  public void generateBinariesForCompatibilityTestingLongsSketch() throws IOException {
+    final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
+    for (final int n: nArr) {
+      final LongsSketch sk = new LongsSketch(64);
+      for (int i = 1; i <= n; i++) {
+        sk.update(i);
+      }
+      assertTrue(n == 0 ? sk.isEmpty() : !sk.isEmpty());
+      if (n > 10) { assertTrue(sk.getMaximumError() > 0); }
+      else { assertEquals(sk.getMaximumError(), 0); }
+      Files.newOutputStream(javaPath.resolve("frequent_long_n" + n + "_java.sk")).write(sk.toByteArray());
+    }
+  }
+
+  @Test(groups = {GENERATE_JAVA_FILES})
+  public void generateBinariesForCompatibilityTestingStringsSketch() throws IOException {
+    final int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
+    for (final int n: nArr) {
+      final ItemsSketch<String> sk = new ItemsSketch<>(64);
+      for (int i = 1; i <= n; i++) {
+        sk.update(Integer.toString(i));
+      }
+      assertTrue(n == 0 ? sk.isEmpty() : !sk.isEmpty());
+      if (n > 10) { assertTrue(sk.getMaximumError() > 0); }
+      else { assertEquals(sk.getMaximumError(), 0); }
+      Files.newOutputStream(javaPath.resolve("frequent_string_n" + n + "_java.sk"))
+        .write(sk.toByteArray(new ArrayOfStringsSerDe2()));
+    }
+  }
+
+  @Test(groups = {GENERATE_JAVA_FILES})
+  public void generateBinariesForCompatibilityTestingStringsSketchAscii() throws IOException {
+    final ItemsSketch<String> sk = new ItemsSketch<>(64);
+    sk.update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1);
+    sk.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 2);
+    sk.update("ccccccccccccccccccccccccccccc", 3);
+    sk.update("ddddddddddddddddddddddddddddd", 4);
+    Files.newOutputStream(javaPath.resolve("frequent_string_ascii_java.sk"))
+      .write(sk.toByteArray(new ArrayOfStringsSerDe2()));
+  }
+
+  @Test(groups = {GENERATE_JAVA_FILES})
+  public void generateBinariesForCompatibilityTestingStringsSketchUtf8() throws IOException {
+    final ItemsSketch<String> sk = new ItemsSketch<>(64);
+    sk.update("абвгд", 1);
+    sk.update("еёжзи", 2);
+    sk.update("йклмн", 3);
+    sk.update("опрст", 4);
+    sk.update("уфхцч", 5);
+    sk.update("шщъыь", 6);
+    sk.update("эюя", 7);
+    Files.newOutputStream(javaPath.resolve("frequent_string_utf8_java.sk"))
+      .write(sk.toByteArray(new ArrayOfStringsSerDe2()));
+  }
+
+  @Test(groups = {CHECK_CPP_FILES})
+  public void longs() throws IOException {
+    final int[] nArr = {0, 1, 10, 100, 1000, 10000, 100000, 1000000};
+    for (final int n: nArr) {
+      final byte[] bytes = Files.readAllBytes(cppPath.resolve("frequent_long_n" + n + "_cpp.sk"));
+      final LongsSketch sketch = LongsSketch.getInstance(MemorySegment.ofArray(bytes));
+      assertTrue(n == 0 ? sketch.isEmpty() : !sketch.isEmpty());
+      if (n > 10) {
+        assertTrue(sketch.getMaximumError() > 0);
+      } else {
+        assertEquals(sketch.getMaximumError(), 0);
+      }
+      assertEquals(sketch.getStreamLength(), n);
+    }
+  }
+
+  @Test(groups = {CHECK_CPP_FILES})
+  public void strings() throws IOException {
+    final int[] nArr = {0, 1, 10, 100, 1000, 10000, 100000, 1000000};
+    for (final int n: nArr) {
+      final byte[] bytes = Files.readAllBytes(cppPath.resolve("frequent_string_n" + n + "_cpp.sk"));
+      final ItemsSketch<String> sketch = ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfStringsSerDe2());
+      assertTrue(n == 0 ? sketch.isEmpty() : !sketch.isEmpty());
+      if (n > 10) {
+        assertTrue(sketch.getMaximumError() > 0);
+      } else {
+        assertEquals(sketch.getMaximumError(), 0);
+      }
+      assertEquals(sketch.getStreamLength(), n);
+    }
+  }
+
+  @Test(groups = {CHECK_CPP_FILES})
+  public void stringsAscii() throws IOException {
+    final byte[] bytes = Files.readAllBytes(cppPath.resolve("frequent_string_ascii_cpp.sk"));
+    final ItemsSketch<String> sketch = ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfStringsSerDe2());
+    assertFalse(sketch.isEmpty());
+    assertEquals(sketch.getMaximumError(), 0);
+    assertEquals(sketch.getStreamLength(), 10);
+    assertEquals(sketch.getEstimate("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 1);
+    assertEquals(sketch.getEstimate("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), 2);
+    assertEquals(sketch.getEstimate("ccccccccccccccccccccccccccccc"), 3);
+    assertEquals(sketch.getEstimate("ddddddddddddddddddddddddddddd"), 4);
+  }
+
+  @Test(groups = {CHECK_CPP_FILES})
+  public void stringsUtf8() throws IOException {
+    final byte[] bytes = Files.readAllBytes(cppPath.resolve("frequent_string_utf8_cpp.sk"));
+    final ItemsSketch<String> sketch = ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfStringsSerDe2());
+    assertFalse(sketch.isEmpty());
+    assertEquals(sketch.getMaximumError(), 0);
+    assertEquals(sketch.getStreamLength(), 28);
+    assertEquals(sketch.getEstimate("абвгд"), 1);
+    assertEquals(sketch.getEstimate("еёжзи"), 2);
+    assertEquals(sketch.getEstimate("йклмн"), 3);
+    assertEquals(sketch.getEstimate("опрст"), 4);
+    assertEquals(sketch.getEstimate("уфхцч"), 5);
+    assertEquals(sketch.getEstimate("шщъыь"), 6);
+    assertEquals(sketch.getEstimate("эюя"), 7);
+  }
+
+}

--- a/src/test/java/org/apache/datasketches/frequencies2/HashMapStressTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/HashMapStressTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import org.apache.datasketches.hash.MurmurHash3;
+//import org.testng.annotations.Test;
+
+public class HashMapStressTest {
+
+  //@Test
+  public static void stress() {
+    println("ReversePurgeLongHashMap Stress Test");
+    printf("%12s%15s%n", "Capacity", "TimePerAdjust");
+    for (int capacity = 2 << 5; capacity < (2 << 24); capacity *= 2) {
+      int n = 10000000;
+
+      long[] keys = new long[n];
+      long[] values = new long[n];
+
+      for (int i = 0; i < n; i++) {
+        keys[i] = murmur(i);
+        values[i] = (i < (capacity / 2)) ? n : 1;
+      }
+
+      ReversePurgeLongHashMap hashmap = new ReversePurgeLongHashMap(capacity);
+      long timePerAdjust = timeOneHashMap(hashmap, keys, values, (int) (.75 * capacity));
+      printf("%12d%15d%n", capacity, timePerAdjust);
+    }
+  }
+
+  private static long timeOneHashMap(ReversePurgeLongHashMap hashMap, long[] keys, long[] values,
+      int sizeToShift) {
+    final long startTime = System.nanoTime();
+    int n = keys.length;
+    assert (n == values.length);
+    for (int i = 0; i < n; i++) {
+      hashMap.adjustOrPutValue(keys[i], values[i]);
+      if (hashMap.getNumActive() == sizeToShift) {
+        hashMap.adjustAllValuesBy(-1);
+        hashMap.keepOnlyPositiveCounts();
+      }
+    }
+    final long endTime = System.nanoTime();
+    return (endTime - startTime) / n;
+  }
+
+  private static long murmur(long key) {
+    long[] keyArr = { key };
+    return MurmurHash3.hash(keyArr, 0)[0];
+  }
+
+  private static void println(Object obj) { System.out.println(obj.toString()); }
+
+  private static void printf(String fmt, Object ... args) { System.out.printf(fmt, args); }
+
+}

--- a/src/test/java/org/apache/datasketches/frequencies2/ItemsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/ItemsSketchTest.java
@@ -1,0 +1,424 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static org.apache.datasketches.frequencies2.PreambleUtil.FAMILY_BYTE;
+import static org.apache.datasketches.frequencies2.PreambleUtil.FLAGS_BYTE;
+import static org.apache.datasketches.frequencies2.PreambleUtil.PREAMBLE_LONGS_BYTE;
+import static org.apache.datasketches.frequencies2.PreambleUtil.SER_VER_BYTE;
+import static org.apache.datasketches.frequencies2.Util.LG_MIN_MAP_SIZE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.lang.foreign.MemorySegment;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.datasketches.common.ArrayOfLongsSerDe2;
+import org.apache.datasketches.common.ArrayOfStringsSerDe2;
+import org.apache.datasketches.common.ArrayOfUtf16StringsSerDe2;
+import org.apache.datasketches.common.SketchesArgumentException;
+import org.apache.datasketches.frequencies2.ItemsSketch.Row;
+
+public class ItemsSketchTest {
+
+  @Test
+  public void empty() {
+    final ItemsSketch<String> sketch = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    Assert.assertTrue(sketch.isEmpty());
+    Assert.assertEquals(sketch.getNumActiveItems(), 0);
+    Assert.assertEquals(sketch.getStreamLength(), 0);
+    Assert.assertEquals(sketch.getLowerBound("a"), 0);
+    Assert.assertEquals(sketch.getUpperBound("a"), 0);
+  }
+
+  @Test
+  public void nullInput() {
+    final ItemsSketch<String> sketch = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch.update(null);
+    Assert.assertTrue(sketch.isEmpty());
+    Assert.assertEquals(sketch.getNumActiveItems(), 0);
+    Assert.assertEquals(sketch.getStreamLength(), 0);
+    Assert.assertEquals(sketch.getLowerBound(null), 0);
+    Assert.assertEquals(sketch.getUpperBound(null), 0);
+  }
+
+  @Test
+  public void oneItem() {
+    final ItemsSketch<String> sketch = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch.update("a");
+    Assert.assertFalse(sketch.isEmpty());
+    Assert.assertEquals(sketch.getNumActiveItems(), 1);
+    Assert.assertEquals(sketch.getStreamLength(), 1);
+    Assert.assertEquals(sketch.getEstimate("a"), 1);
+    Assert.assertEquals(sketch.getLowerBound("a"), 1);
+  }
+
+  @Test
+  public void severalItems() {
+    final ItemsSketch<String> sketch = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch.update("a");
+    sketch.update("b");
+    sketch.update("c");
+    sketch.update("d");
+    sketch.update("b");
+    sketch.update("c");
+    sketch.update("b");
+    Assert.assertFalse(sketch.isEmpty());
+    Assert.assertEquals(sketch.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch.getStreamLength(), 7);
+    Assert.assertEquals(sketch.getEstimate("a"), 1);
+    Assert.assertEquals(sketch.getEstimate("b"), 3);
+    Assert.assertEquals(sketch.getEstimate("c"), 2);
+    Assert.assertEquals(sketch.getEstimate("d"), 1);
+
+    ItemsSketch.Row<String>[] items = sketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+    Assert.assertEquals(items.length, 4);
+
+    items = sketch.getFrequentItems(3, ErrorType.NO_FALSE_POSITIVES);
+    Assert.assertEquals(items.length, 1);
+    Assert.assertEquals(items[0].getItem(), "b");
+
+    sketch.reset();
+    Assert.assertTrue(sketch.isEmpty());
+    Assert.assertEquals(sketch.getNumActiveItems(), 0);
+    Assert.assertEquals(sketch.getStreamLength(), 0);
+  }
+
+  @Test
+  public void estimationMode() {
+    final ItemsSketch<Integer> sketch = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch.update(1, 10);
+    sketch.update(2);
+    sketch.update(3);
+    sketch.update(4);
+    sketch.update(5);
+    sketch.update(6);
+    sketch.update(7, 15);
+    sketch.update(8);
+    sketch.update(9);
+    sketch.update(10);
+    sketch.update(11);
+    sketch.update(12);
+
+    Assert.assertFalse(sketch.isEmpty());
+    Assert.assertEquals(sketch.getStreamLength(), 35);
+
+    {
+      final ItemsSketch.Row<Integer>[] items =
+          sketch.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+      Assert.assertEquals(items.length, 2);
+      // only 2 items (1 and 7) should have counts more than 1
+      int count = 0;
+      for (final ItemsSketch.Row<Integer> item: items) {
+        if (item.getLowerBound() > 1) {
+          count++;
+        }
+      }
+      Assert.assertEquals(count, 2);
+    }
+
+    {
+      final ItemsSketch.Row<Integer>[] items =
+          sketch.getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
+      Assert.assertTrue(items.length >= 2);
+      // only 2 items (1 and 7) should have counts more than 1
+      int count = 0;
+      for (final ItemsSketch.Row<Integer> item: items) {
+        if (item.getLowerBound() > 5) {
+          count++;
+        }
+      }
+      Assert.assertEquals(count, 2);
+    }
+  }
+
+  @Test
+  public void serializeStringDeserializeEmpty() {
+    final ItemsSketch<String> sketch1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    final byte[] bytes = sketch1.toByteArray(new ArrayOfStringsSerDe2());
+    final ItemsSketch<String> sketch2 =
+        ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfStringsSerDe2());
+    Assert.assertTrue(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 0);
+    Assert.assertEquals(sketch2.getStreamLength(), 0);
+  }
+
+  @Test
+  public void serializeDeserializeUft8Strings() {
+    final ItemsSketch<String> sketch1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch1.update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    sketch1.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    sketch1.update("ccccccccccccccccccccccccccccc");
+    sketch1.update("ddddddddddddddddddddddddddddd");
+
+    final byte[] bytes = sketch1.toByteArray(new ArrayOfStringsSerDe2());
+    final ItemsSketch<String> sketch2 =
+        ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfStringsSerDe2());
+    sketch2.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    sketch2.update("ccccccccccccccccccccccccccccc");
+    sketch2.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    Assert.assertFalse(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch2.getStreamLength(), 7);
+    Assert.assertEquals(sketch2.getEstimate("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 1);
+    Assert.assertEquals(sketch2.getEstimate("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), 3);
+    Assert.assertEquals(sketch2.getEstimate("ccccccccccccccccccccccccccccc"), 2);
+    Assert.assertEquals(sketch2.getEstimate("ddddddddddddddddddddddddddddd"), 1);
+  }
+
+  @Test
+  public void serializeDeserializeUtf16Strings() {
+    final ItemsSketch<String> sketch1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch1.update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    sketch1.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    sketch1.update("ccccccccccccccccccccccccccccc");
+    sketch1.update("ddddddddddddddddddddddddddddd");
+
+    final byte[] bytes = sketch1.toByteArray(new ArrayOfUtf16StringsSerDe2());
+    final ItemsSketch<String> sketch2 =
+        ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfUtf16StringsSerDe2());
+    sketch2.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    sketch2.update("ccccccccccccccccccccccccccccc");
+    sketch2.update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    Assert.assertFalse(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch2.getStreamLength(), 7);
+    Assert.assertEquals(sketch2.getEstimate("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 1);
+    Assert.assertEquals(sketch2.getEstimate("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), 3);
+    Assert.assertEquals(sketch2.getEstimate("ccccccccccccccccccccccccccccc"), 2);
+    Assert.assertEquals(sketch2.getEstimate("ddddddddddddddddddddddddddddd"), 1);
+  }
+
+  @Test
+  public void forceResize() {
+    final ItemsSketch<String> sketch1 = new ItemsSketch<>(2 << LG_MIN_MAP_SIZE);
+    for (int i=0; i<32; i++) {
+      sketch1.update(Integer.toString(i), i*i);
+    }
+  }
+
+  @Test
+  public void getRowHeader() {
+    final String header = ItemsSketch.Row.getRowHeader();
+    Assert.assertNotNull(header);
+    Assert.assertTrue(header.length() > 0);
+  }
+
+  @Test
+  public void serializeLongDeserialize() {
+    final ItemsSketch<Long> sketch1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch1.update(1L);
+    sketch1.update(2L);
+    sketch1.update(3L);
+    sketch1.update(4L);
+
+    final String s = sketch1.toString();
+    println(s);
+
+    final byte[] bytes = sketch1.toByteArray(new ArrayOfLongsSerDe2());
+    final ItemsSketch<Long> sketch2 =
+        ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfLongsSerDe2());
+    sketch2.update(2L);
+    sketch2.update(3L);
+    sketch2.update(2L);
+
+    Assert.assertFalse(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch2.getStreamLength(), 7);
+    Assert.assertEquals(sketch2.getEstimate(1L), 1);
+    Assert.assertEquals(sketch2.getEstimate(2L), 3);
+    Assert.assertEquals(sketch2.getEstimate(3L), 2);
+    Assert.assertEquals(sketch2.getEstimate(4L), 1);
+  }
+
+  @Test
+  public void mergeExact() {
+    final ItemsSketch<String> sketch1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch1.update("a");
+    sketch1.update("b");
+    sketch1.update("c");
+    sketch1.update("d");
+
+    final ItemsSketch<String> sketch2 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch2.update("b");
+    sketch2.update("c");
+    sketch2.update("b");
+
+    sketch1.merge(sketch2);
+    Assert.assertFalse(sketch1.isEmpty());
+    Assert.assertEquals(sketch1.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch1.getStreamLength(), 7);
+    Assert.assertEquals(sketch1.getEstimate("a"), 1);
+    Assert.assertEquals(sketch1.getEstimate("b"), 3);
+    Assert.assertEquals(sketch1.getEstimate("c"), 2);
+    Assert.assertEquals(sketch1.getEstimate("d"), 1);
+  }
+
+  @Test
+  public void checkNullMapReturns() {
+    final ReversePurgeItemHashMap<Long> map = new ReversePurgeItemHashMap<>(1 << LG_MIN_MAP_SIZE);
+    Assert.assertNull(map.getActiveKeys());
+    Assert.assertNull(map.getActiveValues());
+  }
+
+  @SuppressWarnings("unlikely-arg-type")
+  @Test
+  public void checkMisc() {
+    final ItemsSketch<Long> sk1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    Assert.assertEquals(sk1.getCurrentMapCapacity(), 6);
+    Assert.assertEquals(sk1.getEstimate(Long.valueOf(1)), 0);
+    final ItemsSketch<Long> sk2 = new ItemsSketch<>(8);
+    Assert.assertEquals(sk1.merge(sk2), sk1 );
+    Assert.assertEquals(sk1.merge(null), sk1);
+    sk1.update(Long.valueOf(1));
+    final ItemsSketch.Row<Long>[] rows = sk1.getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
+    final ItemsSketch.Row<Long> row = rows[0];
+    Assert.assertTrue(row.hashCode() != 0);
+    Assert.assertTrue(row.equals(row));
+    Assert.assertFalse(row.equals(sk1));
+    Assert.assertEquals((long)row.getItem(), 1L);
+    Assert.assertEquals(row.getEstimate(), 1);
+    Assert.assertEquals(row.getUpperBound(), 1);
+    final String s = row.toString();
+    println(s);
+    final ItemsSketch.Row<Long> nullRow = null; //check equals(null)
+    Assert.assertFalse(row.equals(nullRow));
+  }
+
+  @Test
+  public void checkToString() {
+    final ItemsSketch<Long> sk = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sk.update(Long.valueOf(1));
+    println(ItemsSketch.toString(sk.toByteArray(new ArrayOfLongsSerDe2())));
+  }
+
+  @Test
+  public void checkGetFrequentItems1() {
+    final ItemsSketch<Long> fis = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    fis.update(1L);
+    final Row<Long>[] rowArr = fis.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+    final Row<Long> row = rowArr[0];
+    assertNotNull(row);
+    assertEquals(row.est, 1L);
+    assertEquals(row.item, Long.valueOf(1L));
+    assertEquals(row.lb, 1L);
+    assertEquals(row.ub, 1L);
+    Row<Long> newRow = new Row<>(row.item, row.est+1, row.ub, row.lb);
+    assertFalse(row.equals(newRow));
+    newRow = new Row<>(row.item, row.est, row.ub, row.lb);
+    assertTrue(row.equals(newRow));
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkUpdateException() {
+    final ItemsSketch<Long> sk1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sk1.update(Long.valueOf(1), -1);
+  }
+
+  @Test
+  public void checkMemExceptions() {
+    final ItemsSketch<Long> sk1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sk1.update(Long.valueOf(1), 1);
+    final ArrayOfLongsSerDe2 serDe = new ArrayOfLongsSerDe2();
+    final byte[] byteArr = sk1.toByteArray(serDe);
+    final MemorySegment mem = MemorySegment.ofArray(byteArr);
+    //FrequentItemsSketch<Long> sk2 = FrequentItemsSketch.getInstance(mem, serDe);
+    //println(sk2.toString());
+    final long pre0 = mem.get(JAVA_LONG_UNALIGNED, 0); //The correct first 8 bytes.
+    //Now start corrupting
+    tryBadMem(mem, PREAMBLE_LONGS_BYTE, 2); //Corrupt
+    mem.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+
+    tryBadMem(mem, SER_VER_BYTE, 2); //Corrupt
+    mem.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+
+    tryBadMem(mem, FAMILY_BYTE, 2); //Corrupt
+    mem.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+
+    tryBadMem(mem, FLAGS_BYTE, 4); //Corrupt to true
+    mem.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+  }
+
+  @Test
+  public void oneItemUtf8() {
+    final ItemsSketch<String> sketch1 = new ItemsSketch<>(1 << LG_MIN_MAP_SIZE);
+    sketch1.update("\u5fb5");
+    Assert.assertFalse(sketch1.isEmpty());
+    Assert.assertEquals(sketch1.getNumActiveItems(), 1);
+    Assert.assertEquals(sketch1.getStreamLength(), 1);
+    Assert.assertEquals(sketch1.getEstimate("\u5fb5"), 1);
+
+    final byte[] bytes = sketch1.toByteArray(new ArrayOfStringsSerDe2());
+    final ItemsSketch<String> sketch2 =
+        ItemsSketch.getInstance(MemorySegment.ofArray(bytes), new ArrayOfStringsSerDe2());
+    Assert.assertFalse(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 1);
+    Assert.assertEquals(sketch2.getStreamLength(), 1);
+    Assert.assertEquals(sketch2.getEstimate("\u5fb5"), 1);
+  }
+
+  @Test
+  public void checkGetEpsilon() {
+    assertEquals(ItemsSketch.getEpsilon(1024), 3.5 / 1024, 0.0);
+    try {
+      ItemsSketch.getEpsilon(1000);
+    } catch (final SketchesArgumentException e) { }
+  }
+
+  @Test
+  public void checkGetAprioriError() {
+    final double eps = 3.5 / 1024;
+    assertEquals(ItemsSketch.getAprioriError(1024, 10_000), eps * 10_000);
+  }
+
+  @Test
+  public void printlnTest() {
+    println("PRINTING: " + this.getClass().getName());
+  }
+
+  //Restricted methods
+
+  private static void tryBadMem(final MemorySegment mem, final int byteOffset, final int byteValue) {
+    final ArrayOfLongsSerDe2 serDe = new ArrayOfLongsSerDe2();
+    try {
+      mem.set(JAVA_BYTE, byteOffset, (byte) byteValue); //Corrupt
+      ItemsSketch.getInstance(mem, serDe);
+      fail();
+    } catch (final SketchesArgumentException e) {
+      //expected
+    }
+  }
+
+
+  /**
+   * @param s value to print
+   */
+  static void println(final String s) {
+    //System.out.println(s); //disable here
+  }
+}

--- a/src/test/java/org/apache/datasketches/frequencies2/LongsSketchTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/LongsSketchTest.java
@@ -1,0 +1,616 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static org.apache.datasketches.common.Util.LS;
+import static org.apache.datasketches.frequencies2.DistTest.randomGeometricDist;
+import static org.apache.datasketches.frequencies2.PreambleUtil.FAMILY_BYTE;
+import static org.apache.datasketches.frequencies2.PreambleUtil.FLAGS_BYTE;
+import static org.apache.datasketches.frequencies2.PreambleUtil.PREAMBLE_LONGS_BYTE;
+import static org.apache.datasketches.frequencies2.PreambleUtil.SER_VER_BYTE;
+import static org.apache.datasketches.frequencies2.Util.LG_MIN_MAP_SIZE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.lang.foreign.MemorySegment;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.apache.datasketches.common.SketchesArgumentException;
+import org.apache.datasketches.common.Util;
+import org.apache.datasketches.frequencies2.LongsSketch.Row;
+
+public class LongsSketchTest {
+
+  @Test
+  public void hashMapSerialTest() {
+    final ReversePurgeLongHashMap map = new ReversePurgeLongHashMap(8);
+    map.adjustOrPutValue(10, 15);
+    map.adjustOrPutValue(10, 5);
+    map.adjustOrPutValue(1, 1);
+    map.adjustOrPutValue(2, 3);
+    final String string = map.serializeToString();
+    //println(string);
+    //println(map.toString());
+    final ReversePurgeLongHashMap new_map =
+        ReversePurgeLongHashMap.getInstance(string);
+    final String new_string = new_map.serializeToString();
+    Assert.assertTrue(string.equals(new_string));
+  }
+
+  @Test
+  public void frequentItemsStringSerialTest() {
+    final LongsSketch sketch = new LongsSketch(8);
+    final LongsSketch sketch2 = new LongsSketch(128);
+    sketch.update(10, 100);
+    sketch.update(10, 100);
+    sketch.update(15, 3443);
+    sketch.update(1000001, 1010230);
+    sketch.update(1000002, 1010230);
+
+    final String string0 = sketch.serializeToString();
+    final LongsSketch new_sketch0 = LongsSketch.getInstance(string0);
+    final String new_string0 = new_sketch0.serializeToString();
+    Assert.assertTrue(string0.equals(new_string0));
+    Assert.assertTrue(new_sketch0.getMaximumMapCapacity() == sketch.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch0.getCurrentMapCapacity() == sketch.getCurrentMapCapacity());
+
+    sketch2.update(190, 12902390);
+    sketch2.update(191, 12902390);
+    sketch2.update(192, 12902390);
+    sketch2.update(193, 12902390);
+    sketch2.update(194, 12902390);
+    sketch2.update(195, 12902390);
+    sketch2.update(196, 12902390);
+    sketch2.update(197, 12902390);
+    sketch2.update(198, 12902390);
+    sketch2.update(199, 12902390);
+    sketch2.update(200, 12902390);
+    sketch2.update(201, 12902390);
+    sketch2.update(202, 12902390);
+    sketch2.update(203, 12902390);
+    sketch2.update(204, 12902390);
+    sketch2.update(205, 12902390);
+    sketch2.update(206, 12902390);
+    sketch2.update(207, 12902390);
+    sketch2.update(208, 12902390);
+
+    final String string2 = sketch2.serializeToString();
+    final LongsSketch new_sketch2 = LongsSketch.getInstance(string2);
+    final String new_string2 = new_sketch2.serializeToString();
+    Assert.assertTrue(string2.equals(new_string2));
+    Assert.assertTrue(new_sketch2.getMaximumMapCapacity() == sketch2.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch2.getCurrentMapCapacity() == sketch2.getCurrentMapCapacity());
+    Assert.assertTrue(new_sketch2.getStreamLength() == sketch2.getStreamLength());
+
+    final LongsSketch merged_sketch = sketch.merge(sketch2);
+
+    final String string = merged_sketch.serializeToString();
+    final LongsSketch new_sketch = LongsSketch.getInstance(string);
+    final String new_string = new_sketch.serializeToString();
+    Assert.assertTrue(string.equals(new_string));
+    Assert.assertTrue(new_sketch.getMaximumMapCapacity() == merged_sketch.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch.getCurrentMapCapacity() == merged_sketch.getCurrentMapCapacity());
+    Assert.assertTrue(new_sketch.getStreamLength() == merged_sketch.getStreamLength());
+  }
+
+  @Test
+  public void frequentItemsByteSerialTest() {
+    //Empty Sketch
+    final LongsSketch sketch = new LongsSketch(16);
+    final byte[] bytearray0 = sketch.toByteArray();
+    final MemorySegment seg0 = MemorySegment.ofArray(bytearray0);
+    final LongsSketch new_sketch0 = LongsSketch.getInstance(seg0);
+    final String str0 = LongsSketch.toString(seg0);
+    println(str0);
+    final String string0 = sketch.serializeToString();
+    final String new_string0 = new_sketch0.serializeToString();
+    Assert.assertTrue(string0.equals(new_string0));
+
+    final LongsSketch sketch2 = new LongsSketch(128);
+    sketch.update(10, 100);
+    sketch.update(10, 100);
+    sketch.update(15, 3443);
+    sketch.update(1000001, 1010230);
+    sketch.update(1000002, 1010230);
+
+    final byte[] bytearray1 = sketch.toByteArray();
+    final MemorySegment seg1 = MemorySegment.ofArray(bytearray1);
+    final LongsSketch new_sketch1 = LongsSketch.getInstance(seg1);
+    final String str1 = LongsSketch.toString(bytearray1);
+    println(str1);
+    final String string1 = sketch.serializeToString();
+    final String new_string1 = new_sketch1.serializeToString();
+    Assert.assertTrue(string1.equals(new_string1));
+    Assert.assertTrue(new_sketch1.getMaximumMapCapacity() == sketch.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch1.getCurrentMapCapacity() == sketch.getCurrentMapCapacity());
+
+    sketch2.update(190, 12902390);
+    sketch2.update(191, 12902390);
+    sketch2.update(192, 12902390);
+    sketch2.update(193, 12902390);
+    sketch2.update(194, 12902390);
+    sketch2.update(195, 12902390);
+    sketch2.update(196, 12902390);
+    sketch2.update(197, 12902390);
+    sketch2.update(198, 12902390);
+    sketch2.update(199, 12902390);
+    sketch2.update(200, 12902390);
+    sketch2.update(201, 12902390);
+    sketch2.update(202, 12902390);
+    sketch2.update(203, 12902390);
+    sketch2.update(204, 12902390);
+    sketch2.update(205, 12902390);
+    sketch2.update(206, 12902390);
+    sketch2.update(207, 12902390);
+    sketch2.update(208, 12902390);
+
+    final byte[] bytearray2 = sketch2.toByteArray();
+    final MemorySegment seg2 = MemorySegment.ofArray(bytearray2);
+    final LongsSketch new_sketch2 = LongsSketch.getInstance(seg2);
+
+    final String string2 = sketch2.serializeToString();
+    final String new_string2 = new_sketch2.serializeToString();
+
+    Assert.assertTrue(string2.equals(new_string2));
+    Assert.assertTrue(new_sketch2.getMaximumMapCapacity() == sketch2.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch2.getCurrentMapCapacity() == sketch2.getCurrentMapCapacity());
+    Assert.assertTrue(new_sketch2.getStreamLength() == sketch2.getStreamLength());
+
+    final LongsSketch merged_sketch = sketch.merge(sketch2);
+
+    final byte[] bytearray = sketch.toByteArray();
+    final MemorySegment seg = MemorySegment.ofArray(bytearray);
+    final LongsSketch new_sketch = LongsSketch.getInstance(seg);
+
+    final String string = sketch.serializeToString();
+    final String new_string = new_sketch.serializeToString();
+
+    Assert.assertTrue(string.equals(new_string));
+    Assert.assertTrue(new_sketch.getMaximumMapCapacity() == merged_sketch.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch.getCurrentMapCapacity() == merged_sketch.getCurrentMapCapacity());
+    Assert.assertTrue(new_sketch.getStreamLength() == merged_sketch.getStreamLength());
+  }
+
+  @Test
+  public void frequentItemsByteResetAndEmptySerialTest() {
+    final LongsSketch sketch = new LongsSketch(16);
+    sketch.update(10, 100);
+    sketch.update(10, 100);
+    sketch.update(15, 3443);
+    sketch.update(1000001, 1010230);
+    sketch.update(1000002, 1010230);
+    sketch.reset();
+
+    final byte[] bytearray0 = sketch.toByteArray();
+    final MemorySegment seg0 = MemorySegment.ofArray(bytearray0);
+    final LongsSketch new_sketch0 = LongsSketch.getInstance(seg0);
+
+    final String string0 = sketch.serializeToString();
+    final String new_string0 = new_sketch0.serializeToString();
+    Assert.assertTrue(string0.equals(new_string0));
+    Assert.assertTrue(new_sketch0.getMaximumMapCapacity() == sketch.getMaximumMapCapacity());
+    Assert.assertTrue(new_sketch0.getCurrentMapCapacity() == sketch.getCurrentMapCapacity());
+  }
+
+  @Test
+  public void checkFreqLongsSegSerDe() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch sk1 = new LongsSketch(minSize);
+    sk1.update(10, 100);
+    sk1.update(10, 100);
+    sk1.update(15, 3443); println(sk1.toString());
+    sk1.update(1000001, 1010230); println(sk1.toString());
+    sk1.update(1000002, 1010230); println(sk1.toString());
+
+    final byte[] bytearray0 = sk1.toByteArray();
+    final MemorySegment seg0 = MemorySegment.ofArray(bytearray0);
+    final LongsSketch sk2 = LongsSketch.getInstance(seg0);
+
+    checkEquality(sk1, sk2);
+  }
+
+  @Test
+  public void checkFreqLongsStringSerDe() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch sk1 = new LongsSketch(minSize);
+    sk1.update(10, 100);
+    sk1.update(10, 100);
+    sk1.update(15, 3443);
+    sk1.update(1000001, 1010230);
+    sk1.update(1000002, 1010230);
+
+    final String string1 = sk1.serializeToString();
+    final LongsSketch sk2 = LongsSketch.getInstance(string1);
+
+    checkEquality(sk1, sk2);
+  }
+
+  private static void checkEquality(final LongsSketch sk1, final LongsSketch sk2) {
+    assertEquals(sk1.getNumActiveItems(), sk2.getNumActiveItems());
+    assertEquals(sk1.getCurrentMapCapacity(), sk2.getCurrentMapCapacity());
+    assertEquals(sk1.getMaximumError(), sk2.getMaximumError());
+    assertEquals(sk1.getMaximumMapCapacity(), sk2.getMaximumMapCapacity());
+    assertEquals(sk1.getStorageBytes(), sk2.getStorageBytes());
+    assertEquals(sk1.getStreamLength(), sk2.getStreamLength());
+    assertEquals(sk1.isEmpty(), sk2.isEmpty());
+
+    final ErrorType NFN = ErrorType.NO_FALSE_NEGATIVES;
+    final ErrorType NFP = ErrorType.NO_FALSE_POSITIVES;
+    Row[] rowArr1 = sk1.getFrequentItems(NFN);
+    Row[] rowArr2 = sk2.getFrequentItems(NFN);
+    assertEquals(sk1.getFrequentItems(NFN).length, sk2.getFrequentItems(NFN).length);
+    for (int i=0; i<rowArr1.length; i++) {
+      final String s1 = rowArr1[i].toString();
+      final String s2 = rowArr2[i].toString();
+      assertEquals(s1, s2);
+    }
+    rowArr1 = sk1.getFrequentItems(NFP);
+    rowArr2 = sk2.getFrequentItems(NFP);
+    assertEquals(sk1.getFrequentItems(NFP).length, sk2.getFrequentItems(NFP).length);
+    for (int i=0; i<rowArr1.length; i++) {
+      final String s1 = rowArr1[i].toString();
+      final String s2 = rowArr2[i].toString();
+      assertEquals(s1, s2);
+    }
+  }
+
+  @Test
+  public void checkFreqLongsSegDeSerExceptions() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch sk1 = new LongsSketch(minSize);
+    sk1.update(1L);
+
+    final byte[] bytearray0 = sk1.toByteArray();
+    final MemorySegment seg = MemorySegment.ofArray(bytearray0);
+    final long pre0 = seg.get(JAVA_LONG_UNALIGNED, 0);
+
+    tryBadSeg(seg, PREAMBLE_LONGS_BYTE, 2); //Corrupt
+    seg.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+
+    tryBadSeg(seg, SER_VER_BYTE, 2); //Corrupt
+    seg.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+
+    tryBadSeg(seg, FAMILY_BYTE, 2); //Corrupt
+    seg.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+
+    tryBadSeg(seg, FLAGS_BYTE, 4); //Corrupt to true
+    seg.set(JAVA_LONG_UNALIGNED, 0, pre0); //restore
+  }
+
+  private static void tryBadSeg(final MemorySegment seg, final int byteOffset, final int byteValue) {
+    try {
+      seg.set(JAVA_BYTE, byteOffset, (byte) byteValue); //Corrupt
+      LongsSketch.getInstance(seg);
+      fail();
+    } catch (final SketchesArgumentException e) {
+      //expected
+    }
+  }
+
+  @Test
+  public void checkFreqLongsStringDeSerExceptions() {
+    //FrequentLongsSketch sk1 = new FrequentLongsSketch(8);
+    //String str1 = sk1.serializeToString();
+    //String correct   = "1,10,2,4,0,0,0,4,";
+
+    tryBadString("2,10,2,4,0,0,0,4,"); //bad SerVer of 2
+    tryBadString("1,10,2,0,0,0,0,4,"); //bad empty of 0
+    tryBadString(  "1,10,2,4,0,0,0,4,0,"); //one extra
+  }
+
+  private static void tryBadString(final String badString) {
+    try {
+      LongsSketch.getInstance(badString);
+      fail("Should have thrown SketchesArgumentException");
+    } catch (final SketchesArgumentException e) {
+      //expected
+    }
+  }
+
+  @Test
+  public void checkFreqLongs(){
+    final int numSketches = 1;
+    final int n = 2222;
+    final double error_tolerance = 1.0/100;
+
+    final LongsSketch[] sketches = new LongsSketch[numSketches];
+    for (int h = 0; h < numSketches; h++) {
+      sketches[h] = newFrequencySketch(error_tolerance);
+    }
+
+    long item;
+    final double prob = .001;
+    for (int i = 0; i < n; i++) {
+      item = randomGeometricDist(prob) + 1;
+      for (int h = 0; h < numSketches; h++) {
+        sketches[h].update(item);
+      }
+    }
+
+    for (int h = 0; h < numSketches; h++) {
+      final long threshold = sketches[h].getMaximumError();
+      Row[] rows = sketches[h].getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
+      for (int i = 0; i < rows.length; i++) {
+        Assert.assertTrue(rows[i].getUpperBound() > threshold);
+      }
+
+      rows = sketches[h].getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+      for (int i = 0; i < rows.length; i++) {
+        Assert.assertTrue(rows[i].getLowerBound() > threshold);
+      }
+
+      rows = sketches[h].getFrequentItems(Long.MAX_VALUE, ErrorType.NO_FALSE_POSITIVES);
+      Assert.assertEquals(rows.length, 0);
+    }
+  }
+
+  @Test
+  public void updateOneTime() {
+    final int size = 100;
+    final double error_tolerance = 1.0 / size;
+    //double delta = .01;
+    final int numSketches = 1;
+    for (int h = 0; h < numSketches; h++) {
+      final LongsSketch sketch = newFrequencySketch(error_tolerance);
+      Assert.assertEquals(sketch.getUpperBound(13L), 0);
+      Assert.assertEquals(sketch.getLowerBound(13L), 0);
+      Assert.assertEquals(sketch.getMaximumError(), 0);
+      Assert.assertEquals(sketch.getEstimate(13L), 0);
+      sketch.update(13L);
+      // Assert.assertEquals(sketch.getEstimate(13L), 1);
+    }
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkGetInstanceMemorySegment() {
+    final MemorySegment seg = MemorySegment.ofArray(new byte[4]);
+    LongsSketch.getInstance(seg);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkGetInstanceString() {
+    final String s = "";
+    LongsSketch.getInstance(s);
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkUpdateNegative() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch fls = new LongsSketch(minSize);
+    fls.update(1, 0);
+    fls.update(1, -1);
+  }
+
+  @SuppressWarnings("unlikely-arg-type")
+  @Test
+  public void checkGetFrequentItems1() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch fis = new LongsSketch(minSize);
+    fis.update(1);
+    final Row[] rowArr = fis.getFrequentItems(ErrorType.NO_FALSE_POSITIVES);
+    final Row row = rowArr[0];
+    assertTrue(row.hashCode() != 0);
+    assertTrue(row.equals(row));
+    assertFalse(row.equals(fis));
+    assertNotNull(row);
+    assertEquals(row.est, 1L);
+    assertEquals(row.item, 1L);
+    assertEquals(row.lb, 1L);
+    assertEquals(row.ub, 1L);
+    Row newRow = new Row(row.item, row.est+1, row.ub, row.lb);
+    assertFalse(row.equals(newRow));
+    newRow = new Row(row.item, row.est, row.ub, row.lb);
+    assertTrue(row.equals(newRow));
+
+  }
+
+  @Test
+  public void checkGetStorageBytes() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch fls = new LongsSketch(minSize);
+    assertEquals(fls.toByteArray().length, fls.getStorageBytes());
+    fls.update(1);
+    assertEquals(fls.toByteArray().length, fls.getStorageBytes());
+  }
+
+  @Test
+  public void checkDeSerFromStringArray() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch fls = new LongsSketch(minSize);
+    String ser = fls.serializeToString();
+    println(ser);
+    fls.update(1);
+    ser = fls.serializeToString();
+    println(ser);
+  }
+
+  @Test
+  public void checkMerge() {
+    final int minSize = 1 << LG_MIN_MAP_SIZE;
+    final LongsSketch fls1 = new LongsSketch(minSize);
+    LongsSketch fls2 = null;
+    LongsSketch fle = fls1.merge(fls2);
+    assertTrue(fle.isEmpty());
+
+    fls2 = new LongsSketch(minSize);
+    fle = fls1.merge(fls2);
+    assertTrue(fle.isEmpty());
+  }
+
+  @Test
+  public void checkSortItems() {
+    final int numSketches = 1;
+    final int n = 2222;
+    final double error_tolerance = 1.0/100;
+    final int sketchSize = Util.ceilingPowerOf2((int) (1.0 /(error_tolerance*ReversePurgeLongHashMap.getLoadFactor())));
+    //println("sketchSize: "+sketchSize);
+
+    final LongsSketch[] sketches = new LongsSketch[numSketches];
+    for (int h = 0; h < numSketches; h++) {
+      sketches[h] = new LongsSketch(sketchSize);
+    }
+
+    long item;
+    final double prob = .001;
+    for (int i = 0; i < n; i++) {
+      item = randomGeometricDist(prob) + 1;
+      for (int h = 0; h < numSketches; h++) {
+        sketches[h].update(item);
+      }
+    }
+
+    for(int h=0; h<numSketches; h++) {
+      final long threshold = sketches[h].getMaximumError();
+      final Row[] rows = sketches[h].getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
+      //println("ROWS: "+rows.length);
+      for (int i = 0; i < rows.length; i++) {
+        Assert.assertTrue(rows[i].ub > threshold);
+      }
+      final Row first = rows[0];
+      final long anItem = first.getItem();
+      final long anEst  = first.getEstimate();
+      final long aLB    = first.getLowerBound();
+      final String s = first.toString();
+      println(s);
+      assertTrue(anEst >= 0);
+      assertTrue(aLB >= 0);
+      assertEquals(anItem, anItem); //dummy test
+    }
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkGetAndCheckPreLongs() {
+    final byte[] byteArr = new byte[8];
+    byteArr[0] = (byte) 2;
+    PreambleUtil.checkPreambleSize(MemorySegment.ofArray(byteArr));
+  }
+
+  @Test
+  public void checkToString1() {
+    final int size = 1 << LG_MIN_MAP_SIZE;
+    printSketch(size, new long[] {1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5});
+    printSketch(size, new long[] {5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1});
+  }
+
+  @Test
+  public void checkStringDeserEmptyNotCorrupt() {
+    final int size = 1 << LG_MIN_MAP_SIZE;
+    final int thresh = (size * 3) / 4;
+    final String fmt = "%6d%10s%s";
+    final LongsSketch fls = new LongsSketch(size);
+    println("Sketch Size: " + size);
+    String s = null;
+    int i = 0;
+    for ( ; i <= thresh; i++) {
+      fls.update(i+1, 1);
+      s = fls.serializeToString();
+      println(String.format("SER   " + fmt, (i + 1), fls.isEmpty() + " : ", s ));
+      final LongsSketch fls2 = LongsSketch.getInstance(s);
+      println(String.format("DESER " + fmt, (i + 1), fls2.isEmpty() + " : ", s ));
+    }
+  }
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkStringDeserEmptyCorrupt() {
+    final String s = "1,"  //serVer
+             + "10," //FamID
+             + "3,"  //lgMaxMapSz
+             + "0,"  //Empty Flag = false ... corrupted, should be true
+             + "7,"  //stream Len so far
+             + "1,"  //error offset
+             + "0,"  //numActive ...conflict with empty
+             + "8,"; //curMapLen
+    LongsSketch.getInstance(s);
+  }
+
+  @Test
+  public void checkGetEpsilon() {
+    assertEquals(LongsSketch.getEpsilon(1024), 3.5 / 1024, 0.0);
+    try {
+      LongsSketch.getEpsilon(1000);
+    } catch (final SketchesArgumentException e) { }
+  }
+
+  @Test
+  public void checkGetAprioriError() {
+    final double eps = 3.5 / 1024;
+    assertEquals(LongsSketch.getAprioriError(1024, 10_000), eps * 10_000);
+  }
+
+  @Test
+  public void printlnTest() {
+    println("PRINTING: " + this.getClass().getName());
+  }
+
+  //Restricted methods
+
+  public void printSketch(final int size, final long[] freqArr) {
+    final LongsSketch fls = new LongsSketch(size);
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i<freqArr.length; i++) {
+      fls.update(i+1, freqArr[i]);
+    }
+    sb.append("Sketch Size: "+size).append(LS);
+    final String s = fls.toString();
+    sb.append(s);
+    println(sb.toString());
+    printRows(fls, ErrorType.NO_FALSE_NEGATIVES);
+    println("");
+    printRows(fls, ErrorType.NO_FALSE_POSITIVES);
+    println("");
+  }
+
+  private static void printRows(final LongsSketch fls, final ErrorType eType) {
+    final Row[] rows = fls.getFrequentItems(eType);
+    final String s1 = eType.toString();
+    println(s1);
+    final String hdr = Row.getRowHeader();
+    println(hdr);
+    for (int i=0; i<rows.length; i++) {
+      final Row row = rows[i];
+      final String s2 = row.toString();
+      println(s2);
+    }
+    if (rows.length > 0) { //check equals null case
+      final Row nullRow = null;
+      assertFalse(rows[0].equals(nullRow));
+    }
+  }
+
+  /**
+   * @param s value to print
+   */
+  static void println(final String s) {
+    //System.err.println(s); //disable here
+  }
+
+  private static LongsSketch newFrequencySketch(final double eps) {
+    final double loadFactor = ReversePurgeLongHashMap.getLoadFactor();
+    final int maxMapSize = Util.ceilingPowerOf2((int) (1.0 /(eps*loadFactor)));
+    return new LongsSketch(maxMapSize);
+  }
+
+}

--- a/src/test/java/org/apache/datasketches/frequencies2/ReversePurgeLongHashMapTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/ReversePurgeLongHashMapTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import static org.testng.Assert.assertNull;
+
+import org.apache.datasketches.common.SketchesArgumentException;
+import org.testng.annotations.Test;
+
+public class ReversePurgeLongHashMapTest {
+
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void checkgetInstanceString() {
+    ReversePurgeLongHashMap.getInstance("");
+  }
+
+  @Test
+  public void checkActiveNull() {
+    ReversePurgeLongHashMap map = new ReversePurgeLongHashMap(4);
+    assertNull(map.getActiveKeys());
+    assertNull(map.getActiveValues());
+  }
+
+}

--- a/src/test/java/org/apache/datasketches/frequencies2/SerDeCompatibilityTest.java
+++ b/src/test/java/org/apache/datasketches/frequencies2/SerDeCompatibilityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.frequencies2;
+
+import java.lang.foreign.MemorySegment;
+
+import org.apache.datasketches.common.ArrayOfItemsSerDe2;
+import org.apache.datasketches.common.ArrayOfLongsSerDe2;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SerDeCompatibilityTest {
+
+  static final ArrayOfItemsSerDe2<Long> serDe = new ArrayOfLongsSerDe2();
+
+  @Test
+  public void itemsToLongs() {
+    final ItemsSketch<Long> sketch1 = new ItemsSketch<>(8);
+    sketch1.update(1L);
+    sketch1.update(2L);
+    sketch1.update(3L);
+    sketch1.update(4L);
+
+    final byte[] bytes = sketch1.toByteArray(serDe);
+    final LongsSketch sketch2 = LongsSketch.getInstance(MemorySegment.ofArray(bytes));
+    sketch2.update(2L);
+    sketch2.update(3L);
+    sketch2.update(2L);
+
+    Assert.assertFalse(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch2.getStreamLength(), 7);
+    Assert.assertEquals(sketch2.getEstimate(1L), 1);
+    Assert.assertEquals(sketch2.getEstimate(2L), 3);
+    Assert.assertEquals(sketch2.getEstimate(3L), 2);
+    Assert.assertEquals(sketch2.getEstimate(4L), 1);
+  }
+
+  @Test
+  public void longsToItems() {
+    final LongsSketch sketch1 = new LongsSketch(8);
+    sketch1.update(1L);
+    sketch1.update(2L);
+    sketch1.update(3L);
+    sketch1.update(4L);
+
+    final byte[] bytes = sketch1.toByteArray();
+    final ItemsSketch<Long> sketch2 = ItemsSketch.getInstance(MemorySegment.ofArray(bytes), serDe);
+    sketch2.update(2L);
+    sketch2.update(3L);
+    sketch2.update(2L);
+
+    Assert.assertFalse(sketch2.isEmpty());
+    Assert.assertEquals(sketch2.getNumActiveItems(), 4);
+    Assert.assertEquals(sketch2.getStreamLength(), 7);
+    Assert.assertEquals(sketch2.getEstimate(1L), 1);
+    Assert.assertEquals(sketch2.getEstimate(2L), 3);
+    Assert.assertEquals(sketch2.getEstimate(3L), 2);
+    Assert.assertEquals(sketch2.getEstimate(4L), 1);
+  }
+
+}


### PR DESCRIPTION
## Pull Request Overview

This PR continues migrating various packages to the Java FFM API by replacing the legacy Memory/WritableMemory usage with MemorySegment and PositionalSegment. It updates both implementation and test code across multiple modules to use the new API.

### Sketch Families and helper classes moved to FFM Included in this PR:
- Sketch Family **Frequencies**
- common/
    - ArrayOfItemsSerDe
    - ArrayOfLongsSerDe
    - ArrayOfStringsSerDe
    - ArrayOfUtf16StringsSerDe 

### Completed Sketch Families and helper classes moved to FFM with previous PRs:
- theta
- tuple
- tuple/adouble
- tuple/aninteger
- tuple/arrayofdoubles
- tuple/strings
- thetacommon
- hll
- cpc
- filters/bloomfilter
- common/positional