### PR TITLE
CMS and CPCxLangTest move to FFM, Build fix 

### DIFF
--- a/src/main/java/org/apache/datasketches/count/CountMinSketch.java
+++ b/src/main/java/org/apache/datasketches/count/CountMinSketch.java
@@ -31,9 +31,9 @@ import java.nio.charset.StandardCharsets;
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import java.util.Random;
 
-import static org.apache.datasketches.common.SpecialValueLayouts.JAVA_INT_UNALIGNED_BIG_ENDIAN;
-import static org.apache.datasketches.common.SpecialValueLayouts.JAVA_LONG_UNALIGNED_BIG_ENDIAN;
-import static org.apache.datasketches.common.SpecialValueLayouts.JAVA_SHORT_UNALIGNED_BIG_ENDIAN;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_SHORT_UNALIGNED;
 
 
 public class CountMinSketch {
@@ -113,7 +113,7 @@ public class CountMinSketch {
    */
   private static byte[] longToBytes(final long value) {
     final MemorySegment segment = LONG_SEGMENT.get();
-    segment.set(JAVA_LONG_UNALIGNED_BIG_ENDIAN, 0, value);
+    segment.set(JAVA_LONG_UNALIGNED, 0, value);
     return segment.toArray(JAVA_BYTE);
   }
 
@@ -393,9 +393,9 @@ public class CountMinSketch {
   public byte[] toByteArray() {
     final int serializedSizeBytes = getSerializedSizeBytes();
     final MemorySegment wseg = MemorySegment.ofArray(new byte[serializedSizeBytes]);
-    
+
     long offset = 0;
-    
+
     // Long 0
     final int preambleLongs = Family.COUNTMIN.getMinPreLongs();
     wseg.set(JAVA_BYTE, offset++, (byte) preambleLongs);
@@ -406,31 +406,31 @@ public class CountMinSketch {
     final int flagsByte = isEmpty() ? Flag.IS_EMPTY.mask() : 0;
     wseg.set(JAVA_BYTE, offset++, (byte) flagsByte);
     final int NULL_32 = 0;
-    wseg.set(JAVA_INT_UNALIGNED_BIG_ENDIAN, offset, NULL_32);
+    wseg.set(JAVA_INT_UNALIGNED, offset, NULL_32);
     offset += 4;
 
     // Long 1
-    wseg.set(JAVA_INT_UNALIGNED_BIG_ENDIAN, offset, numBuckets_);
+    wseg.set(JAVA_INT_UNALIGNED, offset, numBuckets_);
     offset += 4;
     wseg.set(JAVA_BYTE, offset++, numHashes_);
     short hashSeed = Util.computeSeedHash(seed_);
-    wseg.set(JAVA_SHORT_UNALIGNED_BIG_ENDIAN, offset, hashSeed);
+    wseg.set(JAVA_SHORT_UNALIGNED, offset, hashSeed);
     offset += 2;
     final byte NULL_8 = 0;
     wseg.set(JAVA_BYTE, offset++, NULL_8);
-    
+
     if (isEmpty()) {
       return wseg.toArray(JAVA_BYTE);
     }
 
-    wseg.set(JAVA_LONG_UNALIGNED_BIG_ENDIAN, offset, totalWeight_);
+    wseg.set(JAVA_LONG_UNALIGNED, offset, totalWeight_);
     offset += 8;
 
     for (long w: sketchArray_) {
-      wseg.set(JAVA_LONG_UNALIGNED_BIG_ENDIAN, offset, w);
+      wseg.set(JAVA_LONG_UNALIGNED, offset, w);
       offset += 8;
     }
-    
+
     return wseg.toArray(JAVA_BYTE);
   }
 
@@ -448,13 +448,13 @@ public class CountMinSketch {
     final byte serialVersion = buf.get(JAVA_BYTE, offset++);
     final byte familyId = buf.get(JAVA_BYTE, offset++);
     final byte flagsByte = buf.get(JAVA_BYTE, offset++);
-    final int NULL_32 = buf.get(JAVA_INT_UNALIGNED_BIG_ENDIAN, offset);
+    final int NULL_32 = buf.get(JAVA_INT_UNALIGNED, offset);
     offset += 4;
 
-    final int numBuckets = buf.get(JAVA_INT_UNALIGNED_BIG_ENDIAN, offset);
+    final int numBuckets = buf.get(JAVA_INT_UNALIGNED, offset);
     offset += 4;
     final byte numHashes = buf.get(JAVA_BYTE, offset++);
-    final short seedHash = buf.get(JAVA_SHORT_UNALIGNED_BIG_ENDIAN, offset);
+    final short seedHash = buf.get(JAVA_SHORT_UNALIGNED, offset);
     offset += 2;
     final byte NULL_8 = buf.get(JAVA_BYTE, offset++);
 
@@ -468,12 +468,12 @@ public class CountMinSketch {
     if (empty) {
       return cms;
     }
-    long w = buf.get(JAVA_LONG_UNALIGNED_BIG_ENDIAN, offset);
+    long w = buf.get(JAVA_LONG_UNALIGNED, offset);
     offset += 8;
     cms.totalWeight_ = w;
 
     for (int i = 0; i < cms.sketchArray_.length; i++) {
-      cms.sketchArray_[i] = buf.get(JAVA_LONG_UNALIGNED_BIG_ENDIAN, offset);
+      cms.sketchArray_[i] = buf.get(JAVA_LONG_UNALIGNED, offset);
       offset += 8;
     }
 

--- a/src/main/java/org/apache/datasketches/count/CountMinSketch.java
+++ b/src/main/java/org/apache/datasketches/count/CountMinSketch.java
@@ -36,6 +36,16 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT_UNALIGNED;
 
 
+/**
+ * Java implementation of the CountMin sketch data structure of Cormode and Muthukrishnan.
+ * This implementation is inspired by and compatible with the datasketches-cpp version by Charlie Dickens.
+ *
+ * The CountMin sketch is a probabilistic data structure that provides frequency estimates for items
+ * in a data stream. It uses multiple hash functions to distribute items across a two-dimensional array,
+ * providing approximate counts with configurable error bounds.
+ *
+ * Reference: http://dimacs.rutgers.edu/~graham/pubs/papers/cm-full.pdf
+ */
 public class CountMinSketch {
   private final byte numHashes_;
   private final int numBuckets_;

--- a/src/test/java/org/apache/datasketches/count/CountMinSketchTest.java
+++ b/src/test/java/org/apache/datasketches/count/CountMinSketchTest.java
@@ -203,10 +203,7 @@ public class CountMinSketchTest {
     final long seed = 123456;
     CountMinSketch c = new CountMinSketch(numHashes, numBuckets, seed);
 
-    ByteArrayOutputStream buf = new ByteArrayOutputStream();
-    c.serialize(buf);
-
-    byte[] b = buf.toByteArray();
+    byte[] b = c.toByteArray();
     assertThrows(SketchesArgumentException.class, () -> CountMinSketch.deserialize(b, seed - 1));
 
     CountMinSketch d = CountMinSketch.deserialize(b, seed);
@@ -228,11 +225,10 @@ public class CountMinSketchTest {
       c.update(i, 10*i*i);
     }
 
-    ByteArrayOutputStream buf = new ByteArrayOutputStream();
-    c.serialize(buf);
+    byte[] b = c.toByteArray();
 
-    assertThrows(SketchesArgumentException.class, () -> CountMinSketch.deserialize(buf.toByteArray(), seed - 1));
-    CountMinSketch d = CountMinSketch.deserialize(buf.toByteArray(), seed);
+    assertThrows(SketchesArgumentException.class, () -> CountMinSketch.deserialize(b, seed - 1));
+    CountMinSketch d = CountMinSketch.deserialize(b, seed);
 
     assertEquals(d.getNumHashes_(), c.getNumHashes_());
     assertEquals(d.getNumBuckets_(), c.getNumBuckets_());

--- a/src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java
@@ -31,6 +31,7 @@ import java.lang.foreign.MemorySegment;
 import java.io.IOException;
 import java.nio.file.Files;
 
+import org.apache.datasketches.memory.Memory;
 import org.testng.annotations.Test;
 
 /**
@@ -89,7 +90,7 @@ public class CpcSketchCrossLanguageTest {
     int flavorIdx = 0;
     for (int n: nArr) {
       final byte[] bytes = Files.readAllBytes(goPath.resolve("cpc_n" + n + "_go.sk"));
-      final CpcSketch sketch = CpcSketch.heapify(Memory.wrap(bytes));
+      final CpcSketch sketch = CpcSketch.heapify(MemorySegment.ofArray(bytes));
       assertEquals(sketch.getFlavor(), flavorArr[flavorIdx++]);
       assertEquals(sketch.getEstimate(), n, n * 0.02);
     }

--- a/src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java
@@ -31,7 +31,6 @@ import java.lang.foreign.MemorySegment;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.apache.datasketches.memory.Memory;
 import org.testng.annotations.Test;
 
 /**


### PR DESCRIPTION
Fix build following conflict introduced by concurrent change in https://github.com/apache/datasketches-java/pull/667 and https://github.com/apache/datasketches-java/pull/666

This pull request introduces uniformisation with the rest of the library to the `CountMinSketch` implementation, including improved serialization, memory efficiency, and validation checks. It also updates test cases to reflect these changes. The most important changes are grouped below by theme:

### Core Improvements to `CountMinSketch`:
* Added a thread-local `MemorySegment` for efficient long-to-byte conversions, reducing allocations in hot paths (`src/main/java/org/apache/datasketches/count/CountMinSketch.java`, [[1]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6R57-R59) [[2]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L60-R135).
* Introduced robust validation for `numHashes` and `numBuckets` parameters, including checks for overflow and better error messages (`src/main/java/org/apache/datasketches/count/CountMinSketch.java`, [src/main/java/org/apache/datasketches/count/CountMinSketch.javaL60-R135](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L60-R135)).
* Replaced `ByteBuffer` usage with `MemorySegment` for serialization/deserialization, improving performance and simplifying code (`src/main/java/org/apache/datasketches/count/CountMinSketch.java`, [src/main/java/org/apache/datasketches/count/CountMinSketch.javaL387-R492](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L387-R492)).
* Added a new `toByteArray` method for serialization and refactored the deserialization logic for better maintainability (`src/main/java/org/apache/datasketches/count/CountMinSketch.java`, [[1]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L345-R438) [[2]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L387-R492).

### Code Simplifications and Optimizations:
* Refactored methods like `getHashes`, `update`, and `getEstimate` to use `MemorySegment` for byte array conversions and improved readability with consistent use of `final` variables (`src/main/java/org/apache/datasketches/count/CountMinSketch.java`, [[1]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L174-R221) [[2]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L202-R249) [[3]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L214-R260) [[4]](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L242-R291).
* Simplified loop logic in methods like `getEstimate` to avoid redundant processing (`src/main/java/org/apache/datasketches/count/CountMinSketch.java`, [src/main/java/org/apache/datasketches/count/CountMinSketch.javaL242-R291](diffhunk://#diff-a27b2c7ae95edb924c40143bf39f23acc3cab7f6a03b674262849f067b6ac2d6L242-R291)).

### Test Case Updates:
* Updated test cases to use the new `toByteArray` method for serialization and adjusted assertions for compatibility with the refactored deserialization logic (`src/test/java/org/apache/datasketches/count/CountMinSketchTest.java`, [[1]](diffhunk://#diff-c921c46151597199d049e4cd7ad310ae129befa8b0f9eadddd469c8708c965c5L206-R206) [[2]](diffhunk://#diff-c921c46151597199d049e4cd7ad310ae129befa8b0f9eadddd469c8708c965c5L231-R231).
* Modified cross-language test in `CpcSketchCrossLanguageTest` to use `MemorySegment` for consistency with the updated serialization approach (`src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.java`, [src/test/java/org/apache/datasketches/cpc/CpcSketchCrossLanguageTest.javaL92-R92](diffhunk://#diff-74cb379136cdd3e590dd47ceed651a002e8cc2d1a581adb6260f4dc065140b75L92-R92)).