### PR TITLE
Fix check-go-files to actually enable go test (and not cpp ones)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@ under the License.
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <configuration>
-                <groups>${testng.check-cpp-files}</groups>
+                <groups>${testng.check-go-files}</groups>
                 <excludedGroups>${testng.generate-java-files},${testng.check-cpp-files},${testng.check-cpp-historical-files}</excludedGroups>
               </configuration>
             </plugin>


### PR DESCRIPTION
This pull request updates the `pom.xml` file to adjust the test groups configuration for the Maven Surefire Plugin. 

* Updated the `<groups>` configuration for check-go-files to use `${testng.check-go-files}` instead of `${testng.check-cpp-files}`. (`[pom.xmlL666-R666](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L666-R666)`)