### PR TITLE
Made detection of BigEndian consistent throughout.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,7 @@ Copyright 2025 The Apache Software Foundation
 
 Copyright 2015-2018 Yahoo Inc.
 Copyright 2019-2020 Verizon Media
-Copyright 2021-     Yahoo Inc.
+Copyright 2021-2025 Yahoo Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This is the core Java component of the DataSketches library.  It contains all of
 
 This component is also a dependency of other components of the library that create adaptors for target systems, such as the [Apache Pig adaptor](https://github.com/apache/datasketches-pig), the [Apache Hive adaptor](https://github.com/apache/datasketches-hive), and others.
 
-Note that we have a parallel core component for C++ and Python implementations of many of the same sketch algorithms, 
-[datasketches-cpp](https://github.com/apache/datasketches-cpp) and [datasketches-python](https://github.com/apache/datasketches-python)
+Note that we have a parallel core component for C++, Python and GO implementations of many of the same sketch algorithms, 
+[datasketches-cpp](https://github.com/apache/datasketches-cpp), [datasketches-python](https://github.com/apache/datasketches-python), and 
+[datasketches-go](https://github.com/apache/datasketches-go).
 
 Please visit the main [DataSketches website](https://datasketches.apache.org) for more information.
 
@@ -41,28 +42,19 @@ If you are interested in making contributions to this site please see our [Commu
 ### Installation Directory Path
 **NOTE:** This component accesses resource files for testing. As a result, the directory elements of the full absolute path of the target installation directory must qualify as Java identifiers. In other words, the directory elements must not have any space characters (or non-Java identifier characters) in any of the path elements. This is required by the Oracle Java Specification in order to ensure location-independent access to resources: [See Oracle Location-Independent Access to Resources](https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html)
 
-### OpenJDK Version 21
-An OpenJDK-compatible build of Java 21, provided by one of the Open-Source providers, such as Azul Systems, Red Hat, SAP, Eclipse Temurin, etc, is required.
+### OpenJDK Version 24
+An OpenJDK-compatible build of Java 24, provided by one of the Open-Source JVM providers, such as Azul Systems, Red Hat, SAP, Eclipse Temurin, etc, is required.
 All of the testing of this release has been performed with an Eclipse Temurin build.
 
-This release uses the new Java Foreign Function & Memory (FFM) features that are in "preview" in Java 21.
-As a result, the JVM flag <nobr>**--enable-preview**</nobr> must be set at compile and at runtime.
-
-**NOTE:** OpenJDK versions greater than 21 do not support running Java 21 class files (Class ID 65) with preview code. The runtime JVM version must be 21.
-
-**NOTE:** The Eclipse Compiler for Java (ECJ) version 21, used by default in both the Eclipse JDT IDE and the VScode IDE, will not allow compilation of preview code for Java version 21. Both Eclipse and VScode can be configured to use an OpenJDK compiler instead, but you will loose the incremental build capability of the ECJ.
-
-### DataSketches Memory 6.0.0
-
-This component depends on the [datasketches-memory-6.0.0](https://github.com/apache/datasketches-memory/tree/6.0.0) component, 
+This release uses the new Java Foreign Function & Memory (FFM) features that were made part of the Java Language in in Java 22.
 
 ## Compilation and Test using Maven
 This DataSketches component is structured as a Maven project and Maven is the recommended tool for compile and test.
 
 #### A Toolchain is required
 
-* You must have a JDK type toolchain defined in location *~/.m2/toolchains.xml* that specifies where to find a locally installed OpenJDK-compatible version 21.
-* Your default \$JAVA\_HOME compiler must be OpenJDK compatible, specified in the toolchain, and may be a version greater than 21. Note that if your \$JAVA\_HOME is set to a Java version greater than 21, Maven will automatically use the Java 21 version specified in the toolchain instead. The included pom.xml specifies the necessary JVM flags, so no further action should be required.
+* You must have a JDK type toolchain defined in location *~/.m2/toolchains.xml* that specifies where to find a locally installed OpenJDK-compatible version 24.
+* Your default \$JAVA\_HOME compiler must be OpenJDK compatible, specified in the toolchain, and may be a version greater than 24. Note that if your \$JAVA\_HOME is set to a Java version greater than 24, Maven will automatically use the Java 24 version specified in the toolchain instead. The included pom.xml specifies the necessary JVM flags, so no further action should be required.
 * Note that the paths specified in the toolchain must be fully qualified direct paths to the OpenJDK version locations. Using environment variables will not work.
 
 #### To run normal unit tests:

--- a/pom.xml
+++ b/pom.xml
@@ -96,10 +96,9 @@ under the License.
     <!-- System-wide properties -->
     <maven.version>3.9.10</maven.version>
     <java.version>24</java.version>
-    <jvm-arguments>-Xmx10g -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8</jvm-arguments>
+    <jvm-arguments>-Xmx4g -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8</jvm-arguments>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <argLine>${jvm-arguments}</argLine>
     <charset.encoding>UTF-8</charset.encoding>
     <project.build.sourceEncoding>${charset.encoding}</project.build.sourceEncoding>
     <project.build.resourceEncoding>${charset.encoding}</project.build.resourceEncoding>
@@ -159,7 +158,7 @@ under the License.
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
             <compilerArgs>
-              <arg>${jvm-arguments}</arg>
+              <arg></arg>
             </compilerArgs>
           </configuration>
         </plugin>

--- a/src/main/java/org/apache/datasketches/common/BigEndianNativeOrderNotSupportedException.java
+++ b/src/main/java/org/apache/datasketches/common/BigEndianNativeOrderNotSupportedException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.common;
+
+/**
+ * The DataSketches Library is not supported on Big Endian machines.
+ */
+public class BigEndianNativeOrderNotSupportedException extends SketchesException {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Constructs a new runtime exception with the message:
+   * "The DataSketches Library is not supported on Big Endian machines."
+   */
+  public BigEndianNativeOrderNotSupportedException() {
+    super("The DataSketches Library is not supported on Big Endian machines.");
+  }
+}

--- a/src/main/java/org/apache/datasketches/common/Family.java
+++ b/src/main/java/org/apache/datasketches/common/Family.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.common;
 
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -165,19 +166,22 @@ public enum Family {
 
   private static final Map<Integer, Family> lookupID = new HashMap<>();
   private static final Map<String, Family> lookupFamName = new HashMap<>();
-  private int id_;
-  private String famName_;
-  private int minPreLongs_;
-  private int maxPreLongs_;
+  private final int id_;
+  private final String famName_;
+  private final int minPreLongs_;
+  private final int maxPreLongs_;
 
   static {
     for (final Family f : values()) {
       lookupID.put(f.getID(), f);
       lookupFamName.put(f.getFamilyName().toUpperCase(Locale.US), f);
     }
+    if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+      throw new BigEndianNativeOrderNotSupportedException();
+    }
   }
 
-  private Family(final int id, final String famName, final int minPreLongs, final int maxPreLongs) {
+  Family(final int id, final String famName, final int minPreLongs, final int maxPreLongs) {
     id_ = id;
     famName_ = famName.toUpperCase(Locale.US);
     minPreLongs_ = minPreLongs;

--- a/src/main/java/org/apache/datasketches/common/Util.java
+++ b/src/main/java/org/apache/datasketches/common/Util.java
@@ -28,6 +28,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static org.apache.datasketches.hash.MurmurHash3.hash;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
 import java.util.Comparator;
 
 /**
@@ -37,6 +38,12 @@ import java.util.Comparator;
  */
 @SuppressWarnings("unchecked")
 public final class Util {
+
+  static {
+    if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+      throw new BigEndianNativeOrderNotSupportedException();
+    }
+  }
 
   /**
    * The java line separator character as a String.
@@ -812,7 +819,7 @@ public final class Util {
   }
 
   /**
-   * Is item1 Less-Than item2
+   * Is item1 Less-Than item2?
    * @param <T> the type
    * @param item1 item one
    * @param item2 item two
@@ -824,7 +831,7 @@ public final class Util {
   }
 
   /**
-   * Is item1 Less-Than-Or-Equal-To item2
+   * Is item1 Less-Than-Or-Equal-To item2?
    * @param <T> the type
    * @param item1 item one
    * @param item2 item two

--- a/src/main/java/org/apache/datasketches/cpc/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/cpc/PreambleUtil.java
@@ -31,7 +31,6 @@ import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssert;
 import static org.apache.datasketches.cpc.RuntimeAsserts.rtAssertEquals;
 
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 import java.util.Objects;
 
 import org.apache.datasketches.common.Family;
@@ -142,12 +141,6 @@ final class PreambleUtil {
 
   private PreambleUtil() {}
 
-  static {
-    if (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN) {
-      throw new SketchesStateException("This sketch will not work on Big Endian CPUs.");
-    }
-  }
-
   private static final String fmt = "%10d%10x";
 
   /**
@@ -156,7 +149,7 @@ final class PreambleUtil {
   static final byte SER_VER = 1;
 
   //Flag bit masks, Byte 5
-  static final int BIG_ENDIAN_FLAG_MASK     = 1; //Reserved.
+  static final int RESERVED_FLAG_MASK       = 1; //Reserved.
   static final int COMPRESSED_FLAG_MASK     = 2;
   static final int HIP_FLAG_MASK            = 4;
   static final int SUP_VAL_FLAG_MASK        = 8; //num Suprising Values > 0
@@ -584,7 +577,6 @@ final class PreambleUtil {
 
     //Flags of the Flags byte
     final String flagsStr = zeroPad(Integer.toBinaryString(flags), 8) + ", " + (flags);
-    final boolean bigEndian = (flags & BIG_ENDIAN_FLAG_MASK) > 0;
     final boolean compressed = (flags & COMPRESSED_FLAG_MASK) > 0;
     final boolean hasHip = (flags & HIP_FLAG_MASK) > 0;
     final boolean hasSV = (flags & SUP_VAL_FLAG_MASK) > 0;
@@ -592,8 +584,6 @@ final class PreambleUtil {
 
     final int formatOrdinal = (flags >>> 2) & 0x7;
     final Format format = Format.ordinalToFormat(formatOrdinal);
-
-    final String nativeOrderStr = ByteOrder.nativeOrder().toString();
 
     long numCoupons = 0;
     long numSv = 0;
@@ -616,8 +606,6 @@ final class PreambleUtil {
     sb.append("Byte 3: lgK                     : ").append(lgK).append(LS);
     sb.append("Byte 4: First Interesting Col   : ").append(fiCol).append(LS);
     sb.append("Byte 5: Flags                   : ").append(flagsStr).append(LS);
-    sb.append("  BIG_ENDIAN_STORAGE            : ").append(bigEndian).append(LS);
-    sb.append("  (Native Byte Order)           : ").append(nativeOrderStr).append(LS);
     sb.append("  Compressed                    : ").append(compressed).append(LS);
     sb.append("  Has HIP                       : ").append(hasHip).append(LS);
     sb.append("  Has Surprising Values         : ").append(hasSV).append(LS);

--- a/src/main/java/org/apache/datasketches/hll/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/hll/PreambleUtil.java
@@ -32,7 +32,6 @@ import static org.apache.datasketches.hll.HllUtil.RESIZE_DENOM;
 import static org.apache.datasketches.hll.HllUtil.RESIZE_NUMER;
 
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 
 import org.apache.datasketches.common.Family;
 
@@ -133,7 +132,7 @@ final class PreambleUtil {
   static int HLL_BYTE_ARR_START             = 40;
 
   //Flag bit masks
-  static final int BIG_ENDIAN_FLAG_MASK     = 1; //Set but not read. Reserved.
+  static final int RESERVED_FLAG_MASK       = 1; //Set to 0 but not read.
   static final int READ_ONLY_FLAG_MASK      = 2; //Set but not read. Reserved.
   static final int EMPTY_FLAG_MASK          = 4;
   static final int COMPACT_FLAG_MASK        = 8;
@@ -150,8 +149,6 @@ final class PreambleUtil {
   static final int LIST_PREINTS             = 2;
   static final int HASH_SET_PREINTS         = 3;
   static final int HLL_PREINTS              = 10;
-  static final boolean NATIVE_ORDER_IS_BIG_ENDIAN  =
-      (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN);
 
   static String toString(final byte[] byteArr) {
     final MemorySegment seg = MemorySegment.ofArray(byteArr);
@@ -168,8 +165,6 @@ final class PreambleUtil {
     final int flags = seg.get(JAVA_BYTE, FLAGS_BYTE);
     //Flags
     final String flagsStr = zeroPad(Integer.toBinaryString(flags), 8) + ", " + (flags);
-    final boolean bigEndian = (flags & BIG_ENDIAN_FLAG_MASK) > 0;
-    final String nativeOrder = ByteOrder.nativeOrder().toString();
     final boolean compact = (flags & COMPACT_FLAG_MASK) > 0;
     final boolean oooFlag = (flags & OUT_OF_ORDER_FLAG_MASK) > 0;
     final boolean readOnly = (flags & READ_ONLY_FLAG_MASK) > 0;
@@ -219,8 +214,6 @@ final class PreambleUtil {
     }
     //expand byte 5: Flags
     sb.append("Byte 5: Flags:                : ").append(flagsStr).append(LS);
-    sb.append("  BIG_ENDIAN_STORAGE          : ").append(bigEndian).append(LS);
-    sb.append("  (Native Byte Order)         : ").append(nativeOrder).append(LS);
     sb.append("  READ_ONLY                   : ").append(readOnly).append(LS);
     sb.append("  EMPTY                       : ").append(empty).append(LS);
     sb.append("  COMPACT                     : ").append(compact).append(LS);
@@ -286,8 +279,7 @@ final class PreambleUtil {
   }
 
   static int extractLgArr(final MemorySegment seg) {
-    final int lgArr = seg.get(JAVA_BYTE, LG_ARR_BYTE) & 0XFF;
-    return lgArr;
+    return seg.get(JAVA_BYTE, LG_ARR_BYTE) & 0XFF;
   }
 
   static void insertLgArr(final MemorySegment wseg, final int lgArr) {

--- a/src/main/java/org/apache/datasketches/quantiles/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/quantiles/PreambleUtil.java
@@ -28,7 +28,6 @@ import static org.apache.datasketches.common.Util.LS;
 import static org.apache.datasketches.quantiles.ClassicUtil.computeRetainedItems;
 
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 
 //@formatter:off
 
@@ -92,14 +91,11 @@ final class PreambleUtil {
   static final int COMBINED_BUFFER            = 32; //to 39 (Only for DoublesSketch)
 
   // flag bit masks
-  static final int BIG_ENDIAN_FLAG_MASK       = 1;
+  static final int RESERVED_FLAG_MASK         = 1;
   static final int READ_ONLY_FLAG_MASK        = 2;
   static final int EMPTY_FLAG_MASK            = 4;
   static final int COMPACT_FLAG_MASK          = 8;
   static final int ORDERED_FLAG_MASK          = 16;
-
-  static final boolean NATIVE_ORDER_IS_BIG_ENDIAN  =
-      (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN);
 
   /**
    * Default K for about 1.7% normalized rank accuracy
@@ -143,8 +139,6 @@ final class PreambleUtil {
     final int familyID = extractFamilyID(srcSeg);
     final String famName = idToFamily(familyID).toString();
     final int flags = extractFlags(srcSeg);
-    final boolean bigEndian = (flags & BIG_ENDIAN_FLAG_MASK) > 0;
-    final String nativeOrder = ByteOrder.nativeOrder().toString();
     final boolean readOnly  = (flags & READ_ONLY_FLAG_MASK) > 0;
     final boolean empty = (flags & EMPTY_FLAG_MASK) > 0;
     final boolean compact = (flags & COMPACT_FLAG_MASK) > 0;
@@ -166,8 +160,7 @@ final class PreambleUtil {
     sb.append("Byte  1: Serialization Version: ").append(serVer).append(LS);
     sb.append("Byte  2: Family               : ").append(famName).append(LS);
     sb.append("Byte  3: Flags Field          : ").append(String.format("%02o", flags)).append(LS);
-    sb.append("  BIG ENDIAN                  : ").append(bigEndian).append(LS);
-    sb.append("  (Native Byte Order)         : ").append(nativeOrder).append(LS);
+    sb.append("  RESERVED                    : ").append(LS);
     sb.append("  READ ONLY                   : ").append(readOnly).append(LS);
     sb.append("  EMPTY                       : ").append(empty).append(LS);
     sb.append("  COMPACT                     : ").append(compact).append(LS);

--- a/src/main/java/org/apache/datasketches/sampling/PreambleUtil.java
+++ b/src/main/java/org/apache/datasketches/sampling/PreambleUtil.java
@@ -28,7 +28,6 @@ import static org.apache.datasketches.common.Util.LS;
 import static org.apache.datasketches.common.Util.zeroPad;
 
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 import java.util.Locale;
 
 import org.apache.datasketches.common.Family;
@@ -210,8 +209,6 @@ final class PreambleUtil {
   static final int EBPPS_RHO_DOUBLE      = 32;
 
   // flag bit masks
-  //static final int BIG_ENDIAN_FLAG_MASK = 1;
-  //static final int READ_ONLY_FLAG_MASK  = 2;
   static final int EMPTY_FLAG_MASK      = 4;
   static final int HAS_PARTIAL_ITEM_MASK = 8; // EBPPS only
   static final int GADGET_FLAG_MASK     = 128;
@@ -220,9 +217,6 @@ final class PreambleUtil {
   static final int RESERVOIR_SER_VER    = 2;
   static final int VAROPT_SER_VER       = 2;
   static final int EBPPS_SER_VER        = 1;
-
-  static final boolean NATIVE_ORDER_IS_BIG_ENDIAN  =
-      (ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN);
 
   // STRINGS
 
@@ -274,8 +268,6 @@ final class PreambleUtil {
     // Flags
     final int flags = extractFlags(seg);
     final String flagsStr = zeroPad(Integer.toBinaryString(flags), 8) + ", " + (flags);
-    //final boolean bigEndian = (flags & BIG_ENDIAN_FLAG_MASK) > 0;
-    //final String nativeOrder = ByteOrder.nativeOrder().toString();
     //final boolean readOnly = (flags & READ_ONLY_FLAG_MASK) > 0;
     final boolean isEmpty = (flags & EMPTY_FLAG_MASK) > 0;
     final boolean isGadget = (flags & GADGET_FLAG_MASK) > 0;
@@ -304,8 +296,6 @@ final class PreambleUtil {
       .append("Byte  1: Serialization Version: ").append(serVer).append(LS)
       .append("Byte  2: Family               : ").append(family.toString()).append(LS)
       .append("Byte  3: Flags Field          : ").append(flagsStr).append(LS)
-      //.append("  BIG_ENDIAN_STORAGE          : ").append(bigEndian).append(LS)
-      //.append("  (Native Byte Order)         : ").append(nativeOrder).append(LS)
       //.append("  READ_ONLY                   : ").append(readOnly).append(LS)
       .append("  EMPTY                       : ").append(isEmpty).append(LS);
     if (family == Family.VAROPT) {
@@ -344,8 +334,6 @@ final class PreambleUtil {
     // Flags
     final int flags = extractFlags(seg);
     final String flagsStr = zeroPad(Integer.toBinaryString(flags), 8) + ", " + (flags);
-    //final boolean bigEndian = (flags & BIG_ENDIAN_FLAG_MASK) > 0;
-    //final String nativeOrder = ByteOrder.nativeOrder().toString();
     //final boolean readOnly = (flags & READ_ONLY_FLAG_MASK) > 0;
     final boolean isEmpty = (flags & EMPTY_FLAG_MASK) > 0;
 
@@ -366,8 +354,6 @@ final class PreambleUtil {
             + "Byte  1: Serialization Version    : " + serVer + LS
             + "Byte  2: Family                   : " + family.toString() + LS
             + "Byte  3: Flags Field              : " + flagsStr + LS
-            //+ "  BIG_ENDIAN_STORAGE              : " + bigEndian + LS
-            //+ "  (Native Byte Order)             : " + nativeOrder + LS
             //+ "  READ_ONLY                       : " + readOnly + LS
             + "  EMPTY                           : " + isEmpty + LS
             + "Bytes  4-7: Max Sketch Size (maxK): " + k + LS

--- a/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/DirectQuickSelectSketch.java
@@ -151,7 +151,6 @@ class DirectQuickSelectSketch extends DirectQuickSelectSketchR {
     insertFamilyID(dstSeg, family.getID());                //byte 2
     insertLgNomLongs(dstSeg, lgNomLongs);                  //byte 3
     insertLgArrLongs(dstSeg, lgArrLongs);                  //byte 4
-    //flags: bigEndian = readOnly = compact = ordered = false; empty = true : 00100 = 4
     insertFlags(dstSeg, EMPTY_FLAG_MASK);                  //byte 5
     insertSeedHash(dstSeg, Util.computeSeedHash(seed));    //bytes 6,7
     insertCurCount(dstSeg, 0);                             //bytes 8-11
@@ -250,7 +249,6 @@ class DirectQuickSelectSketch extends DirectQuickSelectSketchR {
     final int preambleLongs = wseg_.get(JAVA_BYTE, PREAMBLE_LONGS_BYTE) & 0X3F;
     final int preBytes = preambleLongs << 3;
     wseg_.asSlice(preBytes, arrLongs * 8L).fill((byte)0);
-    //flags: bigEndian = readOnly = compact = ordered = false; empty = true.
     wseg_.set(JAVA_BYTE, FLAGS_BYTE, (byte) EMPTY_FLAG_MASK);
     wseg_.set(JAVA_INT_UNALIGNED, RETAINED_ENTRIES_INT, 0);
     final float p = wseg_.get(JAVA_FLOAT_UNALIGNED, P_FLOAT);

--- a/src/main/java/org/apache/datasketches/theta/HeapQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/HeapQuickSelectSketch.java
@@ -96,7 +96,7 @@ class HeapQuickSelectSketch extends HeapUpdateSketch {
     hashTableThreshold_ = getHashTableThreshold(lgNomLongs, lgArrLongs_);
     curCount_ = 0;
     thetaLong_ = (long)(p * LONG_MAX_VALUE_AS_DOUBLE);
-    empty_ = true; //other flags: bigEndian = readOnly = compact = ordered = false;
+    empty_ = true; //other flags: reserved = readOnly = compact = ordered = false;
     cache_ = new long[1 << lgArrLongs_];
   }
 

--- a/src/main/java/org/apache/datasketches/theta/IntersectionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/IntersectionImpl.java
@@ -154,7 +154,7 @@ final class IntersectionImpl extends Intersection {
     insertFamilyID(dstSeg, Family.INTERSECTION.getID());
     //lgNomLongs not used by Intersection
     //lgArrLongs set by hardReset
-    //flags are already 0: bigEndian = readOnly = compact = ordered = empty = false;
+    //flags are already 0: reserved = readOnly = compact = ordered = empty = false;
     //seedHash loaded and checked in IntersectionImpl constructor
     //Pre1
     //CurCount set by hardReset

--- a/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/SingleItemSketch.java
@@ -384,14 +384,14 @@ final class SingleItemSketch extends CompactSketch {
     return (short) (pre0_ >>> 48);
   }
 
-  static final boolean otherCheckForSingleItem(final MemorySegment seg) {
+  static boolean otherCheckForSingleItem(final MemorySegment seg) {
     return otherCheckForSingleItem(extractPreLongs(seg), extractSerVer(seg),
         extractFamilyID(seg), extractFlags(seg) );
   }
 
-  static final boolean otherCheckForSingleItem(final int preLongs, final int serVer,
+  static boolean otherCheckForSingleItem(final int preLongs, final int serVer,
       final int famId, final int flags) {
-    // Flags byte: SI=X, Ordered=T, Compact=T, Empty=F, ReadOnly=T, BigEndian=F = X11010 = 0x1A.
+    // Flags byte: SI=X, Ordered=T, Compact=T, Empty=F, ReadOnly=T, Reserved=F = X11010 = 0x1A.
     // Flags mask will be 0x1F.
     // SingleItem flag may not be set due to a historical bug, so we can't depend on it for now.
     // However, if the above flags are correct, preLongs == 1, SerVer >= 3, FamilyID == 3,

--- a/src/main/java/org/apache/datasketches/theta/UpdateSketch.java
+++ b/src/main/java/org/apache/datasketches/theta/UpdateSketch.java
@@ -25,7 +25,6 @@ import static org.apache.datasketches.common.Util.LONG_MAX_VALUE_AS_DOUBLE;
 import static org.apache.datasketches.common.Util.checkBounds;
 import static org.apache.datasketches.hash.MurmurHash3.hash;
 import static org.apache.datasketches.theta.CompactOperations.componentsToCompact;
-import static org.apache.datasketches.theta.PreambleUtil.BIG_ENDIAN_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.FAMILY_BYTE;
 import static org.apache.datasketches.theta.PreambleUtil.ORDERED_FLAG_MASK;
@@ -433,11 +432,10 @@ public abstract class UpdateSketch extends Sketch {
 
     //Check flags
     final int flags = extractFlags(srcSeg);                             //byte 5
-    final int flagsMask =
-        ORDERED_FLAG_MASK | COMPACT_FLAG_MASK | READ_ONLY_FLAG_MASK | BIG_ENDIAN_FLAG_MASK;
-    if ((flags & flagsMask) > 0) {
+    final int badFlagsMask = ORDERED_FLAG_MASK | COMPACT_FLAG_MASK | READ_ONLY_FLAG_MASK;
+    if ((flags & badFlagsMask) > 0) {
       throw new SketchesArgumentException(
-        "Possible corruption: Input srcSeg cannot be: big-endian, compact, ordered, nor read-only");
+        "Possible corruption: Input srcSeg cannot be: compact, ordered, nor read-only");
     }
 
     //Check seed hashes

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/ArrayOfDoublesSketch.java
@@ -39,7 +39,7 @@ public abstract class ArrayOfDoublesSketch {
   // So a sketch can be non-empty, and have no entries.
   // For example, as a result of a sampling, when some data was presented to the sketch, but no
   //  entries were retained.
-  static enum Flags { IS_BIG_ENDIAN, IS_IN_SAMPLING_MODE, IS_EMPTY, HAS_ENTRIES }
+  enum Flags { IS_RESERVED, IS_IN_SAMPLING_MODE, IS_EMPTY, HAS_ENTRIES }
 
   static final int SIZE_OF_KEY_BYTES = Long.BYTES;
   static final int SIZE_OF_VALUE_BYTES = Double.BYTES;

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesCompactSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/DirectArrayOfDoublesCompactSketch.java
@@ -26,7 +26,6 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT_UNALIGNED;
 
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -43,7 +42,7 @@ import org.apache.datasketches.tuple.SerializerDeserializer;
 final class DirectArrayOfDoublesCompactSketch extends ArrayOfDoublesCompactSketch {
 
   // this value exists only on heap, never serialized
-  private MemorySegment seg_;
+  private final MemorySegment seg_;
 
   /**
    * Converts the given UpdatableArrayOfDoublesSketch to this compact form.
@@ -72,12 +71,10 @@ final class DirectArrayOfDoublesCompactSketch extends ArrayOfDoublesCompactSketc
     dstSeg.set(JAVA_BYTE, FAMILY_ID_BYTE, (byte) Family.TUPLE.getID());
     dstSeg.set(JAVA_BYTE, SKETCH_TYPE_BYTE, (byte)
         SerializerDeserializer.SketchType.ArrayOfDoublesCompactSketch.ordinal());
-    final boolean isBigEndian = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
     isEmpty_ = sketch.isEmpty();
     final int count = sketch.getRetainedEntries();
     dstSeg.set(JAVA_BYTE, FLAGS_BYTE, (byte) (
-      (isBigEndian ? 1 << Flags.IS_BIG_ENDIAN.ordinal() : 0)
-      | (isEmpty_ ? 1 << Flags.IS_EMPTY.ordinal() : 0)
+        (isEmpty_ ? 1 << Flags.IS_EMPTY.ordinal() : 0)
       | (count > 0 ? 1 << Flags.HAS_ENTRIES.ordinal() : 0)
     ));
     dstSeg.set(JAVA_BYTE, NUM_VALUES_BYTE, (byte) numValues_);
@@ -115,12 +112,10 @@ final class DirectArrayOfDoublesCompactSketch extends ArrayOfDoublesCompactSketc
     dstSeg.set(JAVA_BYTE, FAMILY_ID_BYTE, (byte) Family.TUPLE.getID());
     dstSeg.set(JAVA_BYTE, SKETCH_TYPE_BYTE, (byte)
         SerializerDeserializer.SketchType.ArrayOfDoublesCompactSketch.ordinal());
-    final boolean isBigEndian = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
     isEmpty_ = isEmpty;
     final int count = keys.length;
     dstSeg.set(JAVA_BYTE, FLAGS_BYTE, (byte) (
-      (isBigEndian ? 1 << Flags.IS_BIG_ENDIAN.ordinal() : 0)
-      | (isEmpty_ ? 1 << Flags.IS_EMPTY.ordinal() : 0)
+        (isEmpty_ ? 1 << Flags.IS_EMPTY.ordinal() : 0)
       | (count > 0 ? 1 << Flags.HAS_ENTRIES.ordinal() : 0)
     ));
     dstSeg.set(JAVA_BYTE, NUM_VALUES_BYTE, (byte) numValues_);
@@ -150,11 +145,6 @@ final class DirectArrayOfDoublesCompactSketch extends ArrayOfDoublesCompactSketc
       throw new SketchesArgumentException("Serial version mismatch. Expected: " + serialVersionUID
           + ", actual: " + version);
     }
-    final boolean isBigEndian =
-        (seg.get(JAVA_BYTE, FLAGS_BYTE) & (1 << Flags.IS_BIG_ENDIAN.ordinal())) != 0;
-    if (isBigEndian ^ ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)) {
-      throw new SketchesArgumentException("Byte order mismatch");
-    }
 
     isEmpty_ = (seg_.get(JAVA_BYTE, FLAGS_BYTE) & (1 << Flags.IS_EMPTY.ordinal())) != 0;
     thetaLong_ = seg_.get(JAVA_LONG_UNALIGNED, THETA_LONG);
@@ -176,11 +166,6 @@ final class DirectArrayOfDoublesCompactSketch extends ArrayOfDoublesCompactSketc
     if (version != serialVersionUID) {
       throw new SketchesArgumentException("Serial version mismatch. Expected: " + serialVersionUID
           + ", actual: " + version);
-    }
-    final boolean isBigEndian =
-        (seg.get(JAVA_BYTE, FLAGS_BYTE) & (1 << Flags.IS_BIG_ENDIAN.ordinal())) != 0;
-    if (isBigEndian ^ ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)) {
-      throw new SketchesArgumentException("Byte order mismatch");
     }
     Util.checkSeedHashes(seg.get(JAVA_SHORT_UNALIGNED, SEED_HASH_SHORT), Util.computeSeedHash(seed));
     isEmpty_ = (seg_.get(JAVA_BYTE, FLAGS_BYTE) & (1 << Flags.IS_EMPTY.ordinal())) != 0;

--- a/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/HeapArrayOfDoublesQuickSelectSketch.java
+++ b/src/main/java/org/apache/datasketches/tuple/arrayofdoubles/HeapArrayOfDoublesQuickSelectSketch.java
@@ -31,7 +31,6 @@ import static org.apache.datasketches.common.Util.computeSeedHash;
 import static org.apache.datasketches.common.Util.exactLog2OfLong;
 
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.datasketches.common.Family;
@@ -101,10 +100,6 @@ final class HeapArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelec
         + serialVersionUID + ", actual: " + version);
     }
     final byte flags = seg.get(JAVA_BYTE, FLAGS_BYTE);
-    final boolean isBigEndian = (flags & (1 << Flags.IS_BIG_ENDIAN.ordinal())) > 0;
-    if (isBigEndian ^ ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN)) {
-      throw new SketchesArgumentException("Byte order mismatch");
-    }
     checkSeedHashes(seg.get(JAVA_SHORT_UNALIGNED, SEED_HASH_SHORT), computeSeedHash(seed));
     isEmpty_ = (flags & (1 << Flags.IS_EMPTY.ordinal())) > 0;
     lgNomEntries_ = seg.get(JAVA_BYTE, LG_NOM_ENTRIES_BYTE);
@@ -238,10 +233,8 @@ final class HeapArrayOfDoublesQuickSelectSketch extends ArrayOfDoublesQuickSelec
     seg.set(JAVA_BYTE, FAMILY_ID_BYTE, (byte) Family.TUPLE.getID());
     seg.set(JAVA_BYTE, SKETCH_TYPE_BYTE,
         (byte) SerializerDeserializer.SketchType.ArrayOfDoublesQuickSelectSketch.ordinal());
-    final boolean isBigEndian = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN);
     seg.set(JAVA_BYTE, FLAGS_BYTE, (byte)(
-      (isBigEndian ? 1 << Flags.IS_BIG_ENDIAN.ordinal() : 0)
-      | (isInSamplingMode() ? 1 << Flags.IS_IN_SAMPLING_MODE.ordinal() : 0)
+        (isInSamplingMode() ? 1 << Flags.IS_IN_SAMPLING_MODE.ordinal() : 0)
       | (isEmpty_ ? 1 << Flags.IS_EMPTY.ordinal() : 0)
       | (count_ > 0 ? 1 << Flags.HAS_ENTRIES.ordinal() : 0)
     ));

--- a/src/test/java/org/apache/datasketches/count/CountMinSketchTest.java
+++ b/src/test/java/org/apache/datasketches/count/CountMinSketchTest.java
@@ -34,7 +34,6 @@ public class CountMinSketchTest {
   @Test
   public void createNewCountMinSketchTest() throws Exception {
     assertThrows(SketchesArgumentException.class, () -> new CountMinSketch((byte) 5, 1, 123));
-    //2^28 buckets and 4 hashes -> a long[] of 8GB! Set JVM -Xmx > 8g
     assertThrows(SketchesArgumentException.class, () -> new CountMinSketch((byte) 4, (1 << 28), 123));
     final byte numHashes = 3;
     final int numBuckets = 5;
@@ -204,7 +203,7 @@ public class CountMinSketchTest {
     final long seed = 123456;
     final CountMinSketch c = new CountMinSketch(numHashes, numBuckets, seed);
 
-    byte[] b = c.toByteArray();
+    final byte[] b = c.toByteArray();
     assertThrows(SketchesArgumentException.class, () -> CountMinSketch.deserialize(b, seed - 1));
 
     final CountMinSketch d = CountMinSketch.deserialize(b, seed);
@@ -226,10 +225,10 @@ public class CountMinSketchTest {
       c.update(i, 10*i*i);
     }
 
-    byte[] b = c.toByteArray();
+    final byte[] b = c.toByteArray();
 
     assertThrows(SketchesArgumentException.class, () -> CountMinSketch.deserialize(b, seed - 1));
-    CountMinSketch d = CountMinSketch.deserialize(b, seed);
+    final CountMinSketch d = CountMinSketch.deserialize(b, seed);
 
     assertEquals(d.getNumHashes_(), c.getNumHashes_());
     assertEquals(d.getNumBuckets_(), c.getNumBuckets_());

--- a/src/test/java/org/apache/datasketches/hash/MurmurHash3FFM21bTest.java
+++ b/src/test/java/org/apache/datasketches/hash/MurmurHash3FFM21bTest.java
@@ -26,9 +26,7 @@ import static org.testng.Assert.fail;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 
-import org.apache.datasketches.common.MemorySegmentRequest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/src/test/java/org/apache/datasketches/hll/HllSketchMergeOrderTest.java
+++ b/src/test/java/org/apache/datasketches/hll/HllSketchMergeOrderTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.hll;
+
+import static org.apache.datasketches.common.Util.pwr2SeriesNext;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+/**
+ * This test demonstrates that DataSketch HLL merging is not order-dependent if you use the Composite estimator.
+ */
+public class HllSketchMergeOrderTest {
+
+    private static final int LgK = 11;
+
+    @Test
+    public void testDataSketchHLLMergeOrderDependency() {
+        final int ppo = 1 << 17; //= 131,072 unique Points Per Octave.
+
+        // Create 3 sketches with fractional powers of 2 series
+        final HllSketch sketchA = createUniquePowerSeriesSketch(1L << 59, ppo, 1L << 60);
+        final HllSketch sketchB = createUniquePowerSeriesSketch(1L << 60, ppo, 1L << 61);
+        final HllSketch sketchC = createUniquePowerSeriesSketch(1L << 61, ppo, 1L << 62);
+
+        final double skAEst = sketchA.getCompositeEstimate();
+        final double skBEst = sketchB.getCompositeEstimate();
+        final double skCEst = sketchC.getCompositeEstimate();
+
+        final double skA_RE = (skAEst/ppo) - 1.0;
+        final double skB_RE = (skBEst/ppo) - 1.0;
+        final double skC_RE = (skCEst/ppo) - 1.0;
+
+        //Print individual composite estimates and Relative Error:
+        println("");
+        println("SketchA estimate: " + skAEst + ", RE%: " + (skA_RE * 100));
+        println("SketchB estimate: " + skBEst + ", RE%: " + (skB_RE * 100));
+        println("SketchC estimate: " + skCEst + ", RE%: " + (skC_RE * 100));
+
+        println("\nNOTE: Sketch Relative Error for Composite Estimator for LgK = 11 is +/- 4.6% at 95% confidence.\n");
+
+        // Test six different merge orders:
+        final double estABC = mergeThreeSketches(sketchA, sketchB, sketchC);
+        final double estACB = mergeThreeSketches(sketchA, sketchC, sketchB);
+        final double estBAC = mergeThreeSketches(sketchB, sketchA, sketchC);
+        final double estBCA = mergeThreeSketches(sketchB, sketchC, sketchA);
+        final double estCAB = mergeThreeSketches(sketchC, sketchA, sketchB);
+        final double estCBA = mergeThreeSketches(sketchC, sketchB, sketchA);
+
+        println("Merge order ABC: " + estABC);
+        println("Merge order ACB: " + estACB);
+        println("Merge order BAC: " + estBAC);
+        println("Merge order BCA: " + estBCA);
+        println("Merge order CAB: " + estCAB);
+        println("Merge order CBA: " + estCBA);
+
+        assertTrue((estABC == estACB) && (estABC == estBAC) && (estABC == estBCA) && (estABC == estCAB) && (estABC == estCBA));
+    }
+
+    /**
+     * Generates a power series based on fractional powers of 2 where the separation between successive values is 2^(1/ppo).
+     * @param baseValue starting value, inclusive
+     * @param ppo number of unique points per octave
+     * @param limit the upper limit, exclusive
+     * @return the loaded sketch
+     */
+    private HllSketch createUniquePowerSeriesSketch(final long baseValue, final int ppo, final long limit) {
+      final HllSketch sketch = new HllSketch(LgK);
+      int count = 0;
+      long lastp = 0;
+      for (long p = baseValue; p < limit; p = pwr2SeriesNext(ppo, p)) {
+        sketch.update(p);
+        count++;
+        lastp = p;
+      }
+      println("BaseValue: " + baseValue + ", limit: " + limit + ", Count: " + count + ", lastPt: " + lastp);
+      return sketch;
+    }
+
+    /**
+     * Merges three sketches in the specified order and returns the composite estimate
+     */
+    private double mergeThreeSketches(final HllSketch s1, final HllSketch s2, final HllSketch s3) {
+        final Union union = new Union(LgK);
+
+        union.update(s1);
+        union.update(s2);
+        union.update(s3);
+
+        return union.getCompositeEstimate();
+    }
+
+    //@Test
+    /**
+     * Used for tweaking the generator algorithm
+     */
+    public void checkNewGenerator() {
+      final long baseValue = 1L << 59;
+      final int ppo = 1 << 10;
+      final long limit = 1L << 60;
+      int count = 0;
+      long lastp = 0;
+      for (long p = baseValue; p < limit; p = pwr2SeriesNext(ppo, p)) {
+        count++;
+        println(count + ", " + p);
+        lastp = p;
+      }
+      println("\nPPO:       " + ppo);
+      println("Count:     " + count);
+      println("baseValue: " + baseValue);
+      println("last p:    " + lastp);
+      println("limit:     " + limit);
+    }
+
+    private static void println(final Object o) {
+      System.out.println(o.toString());
+    }
+
+}

--- a/src/test/java/org/apache/datasketches/hll/HllSketchMergeOrderTest.java
+++ b/src/test/java/org/apache/datasketches/hll/HllSketchMergeOrderTest.java
@@ -130,7 +130,7 @@ public class HllSketchMergeOrderTest {
     }
 
     private static void println(final Object o) {
-      System.out.println(o.toString());
+      //System.out.println(o.toString());
     }
 
 }

--- a/src/test/java/org/apache/datasketches/kll/KllMemorySegmentRequestApp.java
+++ b/src/test/java/org/apache/datasketches/kll/KllMemorySegmentRequestApp.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.datasketches.kll;
 
 import static org.apache.datasketches.kll.KllSketch.getMaxSerializedSizeBytes;

--- a/src/test/java/org/apache/datasketches/quantiles/ClassicQuantilesMemorySegmentRequestApp.java
+++ b/src/test/java/org/apache/datasketches/quantiles/ClassicQuantilesMemorySegmentRequestApp.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.datasketches.quantiles;
 
 import static org.testng.Assert.assertEquals;

--- a/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
+++ b/src/test/java/org/apache/datasketches/theta/DirectQuickSelectSketchTest.java
@@ -23,7 +23,6 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
 import static org.apache.datasketches.common.Family.QUICKSELECT;
 import static org.apache.datasketches.common.Util.clear;
-import static org.apache.datasketches.theta.PreambleUtil.BIG_ENDIAN_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.COMPACT_FLAG_MASK;
 import static org.apache.datasketches.theta.PreambleUtil.FAMILY_BYTE;
 import static org.apache.datasketches.theta.PreambleUtil.FLAGS_BYTE;
@@ -43,7 +42,6 @@ import static org.testng.Assert.fail;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import org.apache.datasketches.common.Family;
@@ -51,11 +49,6 @@ import org.apache.datasketches.common.ResizeFactor;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.SketchesReadOnlyException;
 import org.apache.datasketches.common.Util;
-import org.apache.datasketches.theta.CompactSketch;
-import org.apache.datasketches.theta.DirectQuickSelectSketch;
-import org.apache.datasketches.theta.Sketch;
-import org.apache.datasketches.theta.Sketches;
-import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.datasketches.thetacommon.HashOperations;
 import org.testng.annotations.Test;
 
@@ -807,7 +800,7 @@ public class DirectQuickSelectSketchTest {
     }
     seg1.set(JAVA_LONG_UNALIGNED, THETA_LONG, Long.MAX_VALUE); //fix theta and
     seg1.set(JAVA_BYTE, LG_ARR_LONGS_BYTE, (byte) 11); //fix lgArrLongs
-    final byte badFlags = (byte) (BIG_ENDIAN_FLAG_MASK | COMPACT_FLAG_MASK | READ_ONLY_FLAG_MASK | ORDERED_FLAG_MASK);
+    final byte badFlags = (byte) (COMPACT_FLAG_MASK | READ_ONLY_FLAG_MASK | ORDERED_FLAG_MASK);
     seg1.set(JAVA_BYTE, FLAGS_BYTE, badFlags);
     try {
       usk2 = DirectQuickSelectSketch.writableWrap(seg1, Util.DEFAULT_UPDATE_SEED);

--- a/src/test/java/org/apache/datasketches/theta/ReadOnlyMemorySegmentTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ReadOnlyMemorySegmentTest.java
@@ -28,12 +28,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.common.SketchesReadOnlyException;
-import org.apache.datasketches.theta.Intersection;
-import org.apache.datasketches.theta.SetOperation;
-import org.apache.datasketches.theta.Sketch;
-import org.apache.datasketches.theta.Sketches;
-import org.apache.datasketches.theta.Union;
-import org.apache.datasketches.theta.UpdateSketch;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,18 +35,18 @@ public class ReadOnlyMemorySegmentTest {
 
   @Test
   public void wrapAndTryUpdatingUpdateSketch() {
-    UpdateSketch updateSketch = UpdateSketch.builder().build();
+    final UpdateSketch updateSketch = UpdateSketch.builder().build();
     updateSketch.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(updateSketch.toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    UpdateSketch sketch = (UpdateSketch) Sketch.wrap(seg);
+    final UpdateSketch sketch = (UpdateSketch) Sketch.wrap(seg);
     assertEquals(sketch.getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
 
     boolean thrown = false;
     try {
       sketch.update(2);
-    } catch (SketchesReadOnlyException e) {
+    } catch (final SketchesReadOnlyException e) {
       thrown = true;
     }
     Assert.assertTrue(thrown);
@@ -60,34 +54,34 @@ public class ReadOnlyMemorySegmentTest {
 
   @Test
   public void wrapCompactUnorderedSketch() {
-    UpdateSketch updateSketch = UpdateSketch.builder().build();
+    final UpdateSketch updateSketch = UpdateSketch.builder().build();
     updateSketch.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(updateSketch.compact(false, null).toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Sketch sketch = Sketch.wrap(seg);
+    final Sketch sketch = Sketch.wrap(seg);
     assertEquals(sketch.getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
   }
 
   @Test
   public void wrapCompactOrderedSketch() {
-    UpdateSketch updateSketch = UpdateSketch.builder().build();
+    final UpdateSketch updateSketch = UpdateSketch.builder().build();
     updateSketch.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(ByteBuffer.wrap(updateSketch.compact().toByteArray())
+    final MemorySegment seg = MemorySegment.ofBuffer(ByteBuffer.wrap(updateSketch.compact().toByteArray())
         .asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Sketch sketch = Sketch.wrap(seg);
+    final Sketch sketch = Sketch.wrap(seg);
     assertEquals(sketch.getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
   }
 
   @Test
   public void heapifyUpdateSketch() {
-    UpdateSketch us1 = UpdateSketch.builder().build();
+    final UpdateSketch us1 = UpdateSketch.builder().build();
     us1.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(us1.toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
     // downcasting is not recommended, for testing only
-    UpdateSketch us2 = (UpdateSketch) Sketch.heapify(seg);
+    final UpdateSketch us2 = (UpdateSketch) Sketch.heapify(seg);
     us2.update(2);
     assertEquals(us2.getEstimate(), 2.0);
     assertTrue(seg.isReadOnly());
@@ -95,33 +89,33 @@ public class ReadOnlyMemorySegmentTest {
 
   @Test
   public void heapifyCompactUnorderedSketch() {
-    UpdateSketch updateSketch = UpdateSketch.builder().build();
+    final UpdateSketch updateSketch = UpdateSketch.builder().build();
     updateSketch.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(updateSketch.compact(false, null).toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Sketch sketch = Sketch.heapify(seg);
+    final Sketch sketch = Sketch.heapify(seg);
     assertEquals(sketch.getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
   }
 
   @Test
   public void heapifyCompactOrderedSketch() {
-    UpdateSketch updateSketch = UpdateSketch.builder().build();
+    final UpdateSketch updateSketch = UpdateSketch.builder().build();
     updateSketch.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(updateSketch.compact().toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Sketch sketch = Sketch.heapify(seg);
+    final Sketch sketch = Sketch.heapify(seg);
     assertEquals(sketch.getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
   }
 
   @Test
   public void heapifyUnion() {
-    Union u1 = SetOperation.builder().buildUnion();
+    final Union u1 = SetOperation.builder().buildUnion();
     u1.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(u1.toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Union u2 = (Union) SetOperation.heapify(seg);
+    final Union u2 = (Union) SetOperation.heapify(seg);
     u2.update(2);
     Assert.assertEquals(u2.getResult().getEstimate(), 2.0);
     assertTrue(seg.isReadOnly());
@@ -129,13 +123,13 @@ public class ReadOnlyMemorySegmentTest {
 
   @Test
   public void wrapAndTryUpdatingUnion() {
-    Union u1 = SetOperation.builder().buildUnion();
+    final Union u1 = SetOperation.builder().buildUnion();
     u1.update(1);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(u1.toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
 
-    Union u2 = (Union) Sketches.wrapSetOperation(seg);
-    Union u3 = Sketches.wrapUnion(seg);
+    final Union u2 = (Union) Sketches.wrapSetOperation(seg);
+    final Union u3 = Sketches.wrapUnion(seg);
     Assert.assertEquals(u2.getResult().getEstimate(), 1.0);
     Assert.assertEquals(u3.getResult().getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
@@ -143,33 +137,33 @@ public class ReadOnlyMemorySegmentTest {
     try {
       u2.update(2);
       fail();
-    } catch (SketchesReadOnlyException e) {
+    } catch (final SketchesReadOnlyException e) {
       //expected
     }
 
     try {
       u3.update(2);
       fail();
-    } catch (SketchesReadOnlyException e) {
+    } catch (final SketchesReadOnlyException e) {
       //expected
     }
   }
 
   @Test
   public void heapifyIntersection() {
-    UpdateSketch us1 = UpdateSketch.builder().build();
+    final UpdateSketch us1 = UpdateSketch.builder().build();
     us1.update(1);
     us1.update(2);
-    UpdateSketch us2 = UpdateSketch.builder().build();
+    final UpdateSketch us2 = UpdateSketch.builder().build();
     us2.update(2);
     us2.update(3);
 
-    Intersection i1 = SetOperation.builder().buildIntersection();
+    final Intersection i1 = SetOperation.builder().buildIntersection();
     i1.intersect(us1);
     i1.intersect(us2);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(i1.toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Intersection i2 = (Intersection) SetOperation.heapify(seg);
+    final Intersection i2 = (Intersection) SetOperation.heapify(seg);
     i2.intersect(us1);
     Assert.assertEquals(i2.getResult().getEstimate(), 1.0);
     assertTrue(seg.isReadOnly());
@@ -177,25 +171,25 @@ public class ReadOnlyMemorySegmentTest {
 
   @Test
   public void wrapIntersection() {
-    UpdateSketch us1 = UpdateSketch.builder().build();
+    final UpdateSketch us1 = UpdateSketch.builder().build();
     us1.update(1);
     us1.update(2);
-    UpdateSketch us2 = UpdateSketch.builder().build();
+    final UpdateSketch us2 = UpdateSketch.builder().build();
     us2.update(2);
     us2.update(3);
 
-    Intersection i1 = SetOperation.builder().buildIntersection();
+    final Intersection i1 = SetOperation.builder().buildIntersection();
     i1.intersect(us1);
     i1.intersect(us2);
-    MemorySegment seg = MemorySegment.ofBuffer(
+    final MemorySegment seg = MemorySegment.ofBuffer(
         ByteBuffer.wrap(i1.toByteArray()).asReadOnlyBuffer().order(ByteOrder.nativeOrder()));
-    Intersection i2 = (Intersection) SetOperation.wrap(seg);
+    final Intersection i2 = (Intersection) SetOperation.wrap(seg);
     Assert.assertEquals(i2.getResult().getEstimate(), 1.0);
 
     boolean thrown = false;
     try {
       i2.intersect(us1);
-    } catch (SketchesReadOnlyException e) {
+    } catch (final SketchesReadOnlyException e) {
       thrown = true;
     }
     Assert.assertTrue(thrown);
@@ -210,7 +204,7 @@ public class ReadOnlyMemorySegmentTest {
   /**
    * @param s value to print
    */
-  static void println(String s) {
+  static void println(final String s) {
     //System.out.println(s); //disable here
   }
 

--- a/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
+++ b/src/test/java/org/apache/datasketches/theta/UnionImplTest.java
@@ -20,7 +20,6 @@
 package org.apache.datasketches.theta;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
-import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
 import static org.apache.datasketches.theta.BackwardConversions.convertSerVer3toSerVer1;
 import static org.apache.datasketches.theta.BackwardConversions.convertSerVer3toSerVer2;
 import static org.testng.Assert.assertEquals;
@@ -28,23 +27,11 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.foreign.Arena;
-import java.nio.ByteOrder;
-
 import java.lang.foreign.MemorySegment;
 
 import org.apache.datasketches.common.MemorySegmentStatus;
 import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.common.Util;
-import org.apache.datasketches.theta.CompactSketch;
-import org.apache.datasketches.theta.PreambleUtil;
-import org.apache.datasketches.theta.SetOperation;
-import org.apache.datasketches.theta.SetOperationBuilder;
-import org.apache.datasketches.theta.Sketch;
-import org.apache.datasketches.theta.Sketches;
-import org.apache.datasketches.theta.Union;
-import org.apache.datasketches.theta.UnionImpl;
-import org.apache.datasketches.theta.UpdateSketch;
-import org.apache.datasketches.theta.UpdateSketchBuilder;
 import org.testng.annotations.Test;
 
 public class UnionImplTest {

--- a/tools/testng.xml
+++ b/tools/testng.xml
@@ -1,4 +1,24 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 <suite name="AllTestsSuite">
   <test name="AllTests">
     <packages>


### PR DESCRIPTION
### Major Goal: Make detection of Big Endian consistent throughout
- Created static initializers in **/common/Family** and **/common/Util** that check for _Native Endianness_ and throws an error if _BigEndian_ is detected.  
- All sketches should use **Family** when serializing, and many classes depend on **/common/Util**.
- This library does not support _BigEndian_ machines for several reasons.
    - Cross platform compatibility
    - Compression algorithms are byte order dependent
    - Hashing is byte order dependent.
 - This involved 
     - Removing unnecessary code that detected BigEndian
     - Redefining bit 0 of the Flags field as "Reserved" and not set or read.

### Minor Goal: cleanup of above files that were touched:
- Added finals (automatically) where possible.
- Added parentheses (automatic) to reduce ambiguity
- Fixed some missing license headers.
- Organized inputs
### Misc
- Added a HllSketch Merge Order Test (based on discussion with @freakyzoidberg )