### PR TITLE
Fix swapped interpolation weights and tail branches in TDigestDouble

### DIFF
--- a/src/main/java/org/apache/datasketches/tdigest/TDigestDouble.java
+++ b/src/main/java/org/apache/datasketches/tdigest/TDigestDouble.java
@@ -256,7 +256,7 @@ public final class TDigestDouble {
     }
     final double lastWeight = centroidWeights_[numCentroids_ - 1];
     if ((lastWeight > 1) && ((centroidsWeight_ - weight) <= (lastWeight / 2.0))) {
-      return maxValue_ + (((centroidsWeight_ - weight - 1.0) / ((lastWeight / 2.0) - 1.0))
+      return maxValue_ - (((centroidsWeight_ - weight - 1.0) / ((lastWeight / 2.0) - 1.0))
           * (maxValue_ - centroidMeans_[numCentroids_ - 1]));
     }
 
@@ -278,7 +278,7 @@ public final class TDigestDouble {
         }
         final double w1 = weight - weightSoFar - leftWeight;
         final double w2 = (weightSoFar + dw) - weight - rightWeight;
-        return weightedAverage(centroidMeans_[i], w1, centroidMeans_[i + 1], w2);
+        return weightedAverage(centroidMeans_[i], w2, centroidMeans_[i + 1], w1);
       }
       weightSoFar += dw;
     }

--- a/src/main/java/org/apache/datasketches/tdigest/TDigestDouble.java
+++ b/src/main/java/org/apache/datasketches/tdigest/TDigestDouble.java
@@ -192,7 +192,8 @@ public final class TDigestDouble {
     if (value < firstMean) {
       if ((firstMean - minValue_) > 0) {
         if (value == minValue_) { return 0.5 / centroidsWeight_; }
-        return (1.0 + (((value - minValue_) / (firstMean - minValue_)) * ((centroidWeights_[0] / 2.0) - 1.0)));
+        return (1.0 + (((value - minValue_) / (firstMean - minValue_))
+            * ((centroidWeights_[0] / 2.0) - 1.0))) / centroidsWeight_;
       }
       return 0; // should never happen
     }

--- a/src/test/java/org/apache/datasketches/tdigest/TDigestDoubleTest.java
+++ b/src/test/java/org/apache/datasketches/tdigest/TDigestDoubleTest.java
@@ -234,5 +234,24 @@ public class TDigestDoubleTest {
     assertThrows(SketchesArgumentException.class, () -> TDigestDouble.heapify(MemorySegment.ofArray(bytes)));
   }
 
+  @Test
+  public void rankBelowFirstCentroidMean() {
+    // the format allows a first centroid of weight greater than 1, so the left tail of
+    // getRank() must stay normalized just like the right tail
+    final byte[] bytes = serializeNonEmpty();
+    MemorySegment.ofArray(bytes).set(ValueLayout.JAVA_DOUBLE_UNALIGNED, 16, -1); // min
+    MemorySegment.ofArray(bytes).set(ValueLayout.JAVA_LONG_UNALIGNED, 40, 100L); // first weight
+    final TDigestDouble td = TDigestDouble.heapify(MemorySegment.ofArray(bytes));
+    final double totalWeight = td.getTotalWeight();
+    assertEquals(td.getRank(-1), 0.5 / totalWeight);
+    assertEquals(td.getRank(-0.5), (1.0 + (((100 / 2.0) - 1.0) * 0.5)) / totalWeight);
+    double previous = 0;
+    for (int i = 0; i <= 100; i++) {
+      final double rank = td.getRank(-1 + (i / 100.0));
+      assertTrue((rank >= 0) && (rank <= 1), "rank out of [0, 1]: " + rank);
+      assertTrue(rank >= previous, "rank not monotonic: " + rank + " after " + previous);
+      previous = rank;
+    }
+  }
 
 }

--- a/src/test/java/org/apache/datasketches/tdigest/TDigestDoubleTest.java
+++ b/src/test/java/org/apache/datasketches/tdigest/TDigestDoubleTest.java
@@ -254,4 +254,36 @@ public class TDigestDoubleTest {
     }
   }
 
+  @Test
+  public void quantilesAreMonotonic() {
+    final TDigestDouble td = new TDigestDouble((short) 100);
+    for (int i = 0; i < 10000; i++) {
+      td.update(i);
+    }
+    double previous = td.getMinValue();
+    for (int i = 0; i <= 1000; i++) {
+      final double quantile = td.getQuantile(i / 1000.0);
+      assertTrue(quantile >= previous, "quantile not monotonic: " + quantile + " after " + previous);
+      assertTrue((quantile >= td.getMinValue()) && (quantile <= td.getMaxValue()),
+          "quantile out of [min, max]: " + quantile);
+      previous = quantile;
+    }
+  }
+
+  @Test
+  public void quantileAboveLastCentroidMean() {
+    final byte[] bytes = serializeNonEmpty();
+    final MemorySegment seg = MemorySegment.ofArray(bytes);
+    final int numCentroids = seg.get(ValueLayout.JAVA_INT_UNALIGNED, 8);
+    final long lastWeightOffset = 40 + ((numCentroids - 1) * 16L);
+    seg.set(ValueLayout.JAVA_LONG_UNALIGNED, lastWeightOffset, 100L);
+    final TDigestDouble td = TDigestDouble.heapify(seg);
+    double previous = td.getMinValue();
+    for (int i = 0; i <= 1000; i++) {
+      final double quantile = td.getQuantile(i / 1000.0);
+      assertTrue(quantile >= previous, "quantile not monotonic: " + quantile + " after " + previous);
+      assertTrue(quantile <= td.getMaxValue(), "quantile above max: " + quantile);
+      previous = quantile;
+    }
+  }
 }


### PR DESCRIPTION
Three spots in `TDigestDouble` differ from the reference implementation ([MergingDigest](https://github.com/tdunning/t-digest/blob/main/core/src/main/java/com/tdunning/math/stats/MergingDigest.java)). The first affects ordinary use, the other two need `heapify`.

I originally opened this for the third one only, then found the first while checking whether that fix was partial.

### 1. getQuantile() passes the interpolation weights in the wrong order

Reference:

```java
double z1 = index - weightSoFar - leftUnit;
double z2 = weightSoFar + dw - index - rightUnit;
return weightedAverage(mean[i], z2, mean[i + 1], z1);
```

We compute the same two quantities as `w1`/`w2` and then call `weightedAverage(centroidMeans_[i], w1, centroidMeans_[i + 1], w2)`. The weight on `mean[i]` should be the distance to the far end, not the near one. As the rank rises inside a bracket the estimate moves toward the lower centroid instead of the upper one.

That makes `getQuantile()` non-monotonic from a plain `update()` sequence. 1999 of 2000 random digests (k in {10, 20, 50, 100, 200}, n in [100, 50000], gaussian / uniform / lognormal / sequential) return some `getQuantile(r2) < getQuantile(r1)` with `r2 > r1`. Worst seen: rank 0.9995 gives 16799.3 after rank 0.9990 gave 36135.9.

It costs accuracy too. Rank error against exact quantiles, 29700 queries at k=100, n=20000:

```
          mean       max
before    0.011966   0.042300
after     0.000675   0.004250
```

### 2. getQuantile() right tail has the wrong sign

Reference is `max - (...)`, we have `maxValue_ + (...)`, so the branch returns quantiles above `getMaxValue()`. On min 0, centroids (10,100),(20,100),(30,100), max 40, rank 0.90 returns 45.92 where the reference gives 34.08.

### 3. getRank() left tail is not normalized

It omits the `/ centroidsWeight_` that both the mirror-image right tail below it and the reference have, so `getRank()` leaves its documented [0, 1] range. Same digest, `getRank(9.0)` returns 45.1 instead of 0.1503. `getCDF([5, 20, 35])` returns `[25.5, 0.5, 0.915, 1.0]`, and `getPMF` returns a negative mass of `-25.0`.

2 and 3 are not reachable from `update()` or `merge()`, because `compress()` leaves both tail centroids singletons. They are reachable from `heapify()`, which accepts a first or last centroid of weight greater than 1.

Three named tests, each verified failing before its own fix. Full suite is 39 failures before and after, all `*CrossLanguageTest` with empty `cpp_generated_files` fixtures, unrelated to this.

C++ has all three the same way, and I reproduced the non-monotonic quantiles through the Python binding on the C++ core, 200 of 200 trials, so it probably wants the same changes.

I used Claude Code on this. The oracles were tdunning's `MergingDigest` and monotonicity, which needs no second implementation.
