### PR TITLE
Avoid copying the union gadget's hash table when it will not be mutated

### DIFF
--- a/src/main/java/org/apache/datasketches/theta/ThetaUnionImpl.java
+++ b/src/main/java/org/apache/datasketches/theta/ThetaUnionImpl.java
@@ -196,12 +196,15 @@ final class ThetaUnionImpl extends ThetaUnion {
   public CompactThetaSketch getResult(final boolean dstOrdered, final MemorySegment dstSeg) {
     final int gadgetCurCount = gadget_.getRetainedEntries(true);
     final int k = 1 << gadget_.getLgNomLongs();
-    final long[] gadgetCacheCopy =
-        gadget_.hasMemorySegment() ? gadget_.getCache() : gadget_.getCache().clone();
+    //selectExcludingZeros permutes its input, so the gadget's own table may only be read in
+    //place when it does not run. Everything else here (count, compactCache) only reads.
+    final boolean willQuickSelect = gadgetCurCount > k;
+    final long[] gadgetCacheCopy = (gadget_.hasMemorySegment() || !willQuickSelect)
+        ? gadget_.getCache() : gadget_.getCache().clone();
 
     //Pull back to k
     final long curGadgetThetaLong = gadget_.getThetaLong();
-    final long adjGadgetThetaLong = gadgetCurCount > k
+    final long adjGadgetThetaLong = willQuickSelect
         ? selectExcludingZeros(gadgetCacheCopy, gadgetCurCount, k + 1) : curGadgetThetaLong;
 
     //Finalize Theta and curCount

--- a/src/test/java/org/apache/datasketches/theta/ThetaUnionGetResultNonDestructiveTest.java
+++ b/src/test/java/org/apache/datasketches/theta/ThetaUnionGetResultNonDestructiveTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.theta;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.foreign.MemorySegment;
+
+import org.testng.annotations.Test;
+
+/**
+ * getResult() reads the gadget's hash table in place unless it needs to run quickSelect,
+ * so it must leave the union usable afterwards.
+ */
+public class ThetaUnionGetResultNonDestructiveTest {
+
+  private static ThetaUnion heapUnion(final int k) {
+    return ThetaSetOperation.builder().setNominalEntries(k).buildUnion();
+  }
+
+  private static ThetaUnion segUnion(final int k) {
+    return ThetaSetOperation.builder().setNominalEntries(k)
+        .buildUnion(MemorySegment.ofArray(new byte[ThetaSetOperation.getMaxUnionBytes(k)]));
+  }
+
+  @Test
+  public void checkReturnedSketchIsIndependentOfLaterUpdates() {
+    final int k = 1 << 10;
+    for (final boolean seg : new boolean[] {false, true}) {
+      final ThetaUnion u = seg ? segUnion(k) : heapUnion(k);
+      for (int i = 0; i < (k / 4); i++) { u.update(i); }
+      final CompactThetaSketch snapshot = u.getResult(true, null);
+      final byte[] snapshotBytes = snapshot.toByteArray();
+      final double snapshotEstimate = snapshot.getEstimate();
+
+      for (int i = k; i < (16 * k); i++) { u.update(i); }
+
+      assertEquals(snapshot.toByteArray(), snapshotBytes, "seg=" + seg);
+      assertEquals(snapshot.getEstimate(), snapshotEstimate, 0.0);
+      assertTrue(u.getResult().getEstimate() > snapshotEstimate);
+    }
+  }
+
+  /** Probing part way through must not change what the union goes on to produce. */
+  @Test
+  public void checkUnionStillCorrectAfterGetResult() {
+    final int k = 1 << 10;
+    for (final int firstBatch : new int[] {1, k / 2, k, 2 * k}) {
+      for (final boolean seg : new boolean[] {false, true}) {
+        final ThetaUnion probed = seg ? segUnion(k) : heapUnion(k);
+        final ThetaUnion control = seg ? segUnion(k) : heapUnion(k);
+
+        for (int i = 0; i < firstBatch; i++) {
+          probed.update(i);
+          control.update(i);
+        }
+        probed.getResult(true, null);
+        probed.getResult(false, null);
+
+        for (int i = firstBatch; i < (firstBatch + (4 * k)); i++) {
+          probed.update(i);
+          control.update(i);
+        }
+        // Any divergence means getResult mutated state it shouldn't have
+        assertEquals(probed.getResult(true, null).toByteArray(),
+            control.getResult(true, null).toByteArray(),
+            "firstBatch=" + firstBatch + " seg=" + seg);
+      }
+    }
+  }
+
+  /**
+   * quickSelect permutes the table it is given. Were that the gadget's own table, the only
+   * symptom would be that values the sketch already holds stop counting as duplicates.
+   */
+  @Test
+  public void checkDuplicatesStillDetectedAfterGetResultRanQuickSelect() {
+    final int k = 1 << 10;
+    for (final boolean seg : new boolean[] {false, true}) {
+      final ThetaUnion u = seg ? segUnion(k) : heapUnion(k);
+      final int n = (2 * k) - 10; //above k, so getResult must run quickSelect
+      for (int i = 0; i < n; i++) { u.update(i); }
+
+      final CompactThetaSketch res = u.getResult(true, null);
+      final int countBefore = res.getRetainedEntries(true);
+      assertTrue(countBefore > 0);
+
+      for (int i = 0; i < n; i++) { u.update(i); }
+
+      assertEquals(u.getResult(true, null).getRetainedEntries(true), countBefore, "seg=" + seg);
+      assertEquals(u.getResult(true, null).toByteArray(), res.toByteArray(), "seg=" + seg);
+    }
+  }
+}


### PR DESCRIPTION
`getResult()` clones the gadget's whole hash table on every call for an on-heap gadget.
The clone is there because `selectExcludingZeros` permutes the array it is given, but that
only runs when the gadget holds more than `k`. Below that, `count()` and `compactCache()`
only read, so the gadget's table can be read in place.

For a union that ends in exact mode this removes the dominant allocation of `getResult()`:
73,800 to 8,248 bytes per call at lgK=12, and 294,984 to 32,824 at lgK=14. Estimation mode
is unchanged.

Added `ThetaUnionGetResultNonDestructiveTest`. The case that matters is
`checkDuplicatesStillDetectedAfterGetResultRanQuickSelect`: permuting the gadget's table
does not change what `getResult` returns and it heals at the gadget's next rebuild, so the
only observable symptom is that known values stop counting as duplicates.
