### PR TITLE
Choose the QuickSelect pivot by median of three

### DIFF
--- a/src/main/java/org/apache/datasketches/common/QuickSelect.java
+++ b/src/main/java/org/apache/datasketches/common/QuickSelect.java
@@ -107,20 +107,14 @@ public final class QuickSelect {
    * @return the next partition value.  Ultimately, the desired pivot.
    */
   private static int partition(final long[] arr, final int lo, final int hi) {
-    int i = lo, j = hi + 1; //left and right scan indices
+    medianOfThreeToLo(arr, lo, hi);
+    int i = lo, j = hi; //left and right scan indices
     final long v = arr[lo]; //partitioning item value
     while (true) {
       //Scan right, scan left, check for scan complete, and exchange
-      while (arr[ ++i] < v) {
-        if (i == hi) {
-          break;
-        }
-      }
-      while (v < arr[ --j]) {
-        if (j == lo) {
-          break;
-        }
-      }
+      //arr[hi] >= v and arr[lo] == v bound the scans
+      while (arr[ ++i] < v) { }
+      while (v < arr[ --j]) { }
       if (i >= j) {
         break;
       }
@@ -133,6 +127,21 @@ public final class QuickSelect {
     arr[lo] = arr[j];
     arr[j] = x;
     return j;
+  }
+
+  //A pivot taken from a fixed position is quadratic on ordered input; a median of three is not.
+  private static void medianOfThreeToLo(final long[] arr, final int lo, final int hi) {
+    final int mid = lo + ((hi - lo) >>> 1);
+    if (arr[mid] < arr[lo]) { swap(arr, mid, lo); }
+    if (arr[hi] < arr[lo]) { swap(arr, hi, lo); }
+    if (arr[hi] < arr[mid]) { swap(arr, hi, mid); }
+    swap(arr, lo, mid);
+  }
+
+  private static void swap(final long[] arr, final int i, final int j) {
+    final long x = arr[i];
+    arr[i] = arr[j];
+    arr[j] = x;
   }
 
   //For double arrays
@@ -211,20 +220,14 @@ public final class QuickSelect {
    * @return the next partition value.  Ultimately, the desired pivot.
    */
   private static int partition(final double[] arr, final int lo, final int hi) {
-    int i = lo, j = hi + 1; //left and right scan indices
+    medianOfThreeToLo(arr, lo, hi);
+    int i = lo, j = hi; //left and right scan indices
     final double v = arr[lo]; //partitioning item value
     while (true) {
       //Scan right, scan left, check for scan complete, and exchange
-      while (arr[ ++i] < v) {
-        if (i == hi) {
-          break;
-        }
-      }
-      while (v < arr[ --j]) {
-        if (j == lo) {
-          break;
-        }
-      }
+      //arr[hi] >= v and arr[lo] == v bound the scans
+      while (arr[ ++i] < v) { }
+      while (v < arr[ --j]) { }
       if (i >= j) {
         break;
       }
@@ -237,6 +240,20 @@ public final class QuickSelect {
     arr[lo] = arr[j];
     arr[j] = x;
     return j;
+  }
+
+  private static void medianOfThreeToLo(final double[] arr, final int lo, final int hi) {
+    final int mid = lo + ((hi - lo) >>> 1);
+    if (arr[mid] < arr[lo]) { swap(arr, mid, lo); }
+    if (arr[hi] < arr[lo]) { swap(arr, hi, lo); }
+    if (arr[hi] < arr[mid]) { swap(arr, hi, mid); }
+    swap(arr, lo, mid);
+  }
+
+  private static void swap(final double[] arr, final int i, final int j) {
+    final double x = arr[i];
+    arr[i] = arr[j];
+    arr[j] = x;
   }
 
 }

--- a/src/test/java/org/apache/datasketches/thetacommon/QuickSelectTest.java
+++ b/src/test/java/org/apache/datasketches/thetacommon/QuickSelectTest.java
@@ -53,7 +53,27 @@ public class QuickSelectTest {
         final long retVal = select(arr, 0, len - 1, pivot);
         Assert.assertEquals(retVal, trueVal);
       }
+      Assert.assertEquals(select(ascending(len), 0, len - 1, pivot), trueVal);
+      Assert.assertEquals(select(descending(len), 0, len - 1, pivot), trueVal);
     }
+  }
+
+  @Test
+  public void checkQuickSelect0BasedAllEqual() {
+    final int len = 64;
+    for (int pivot = 0; pivot < len; pivot++ ) {
+      final long[] arr = new long[len];
+      java.util.Arrays.fill(arr, 7L);
+      Assert.assertEquals(select(arr, 0, len - 1, pivot), 7L);
+    }
+  }
+
+  //Quadratic work still returns the right value, so only the time limit can fail here.
+  @Test(timeOut = 10_000)
+  public void checkOrderedInputIsNotQuadratic() {
+    final int len = 1 << 19;
+    Assert.assertEquals(select(ascending(len), 0, len - 1, len / 2), len / 2);
+    Assert.assertEquals(select(descending(len), 0, len - 1, len / 2), len / 2);
   }
 
   @Test
@@ -116,7 +136,26 @@ public class QuickSelectTest {
         final double retVal = select(arr, 0, len - 1, pivot);
         Assert.assertEquals(retVal, trueVal, 0.0);
       }
+      Assert.assertEquals(select(ascendingDbl(len), 0, len - 1, pivot), trueVal, 0.0);
+      Assert.assertEquals(select(descendingDbl(len), 0, len - 1, pivot), trueVal, 0.0);
     }
+  }
+
+  @Test
+  public void checkQuickSelectDbl0BasedAllEqual() {
+    final int len = 64;
+    for (int pivot = 0; pivot < len; pivot++ ) {
+      final double[] arr = new double[len];
+      java.util.Arrays.fill(arr, 7.0);
+      Assert.assertEquals(select(arr, 0, len - 1, pivot), 7.0, 0.0);
+    }
+  }
+
+  @Test(timeOut = 10_000)
+  public void checkOrderedInputIsNotQuadraticDbl() {
+    final int len = 1 << 19;
+    Assert.assertEquals(select(ascendingDbl(len), 0, len - 1, len / 2), len / 2, 0.0);
+    Assert.assertEquals(select(descendingDbl(len), 0, len - 1, len / 2), len / 2, 0.0);
   }
 
   @Test
@@ -163,6 +202,39 @@ public class QuickSelectTest {
     Assert.assertEquals(retVal, trueVal, 0.0);
   }
 
+
+  //select rearranges its input, so each call needs a fresh array
+  private static long[] ascending(final int len) {
+    final long[] a = new long[len];
+    for (int i = 0; i < len; i++ ) {
+      a[i] = i;
+    }
+    return a;
+  }
+
+  private static long[] descending(final int len) {
+    final long[] a = new long[len];
+    for (int i = 0; i < len; i++ ) {
+      a[i] = (len - 1) - i;
+    }
+    return a;
+  }
+
+  private static double[] ascendingDbl(final int len) {
+    final double[] a = new double[len];
+    for (int i = 0; i < len; i++ ) {
+      a[i] = i;
+    }
+    return a;
+  }
+
+  private static double[] descendingDbl(final int len) {
+    final double[] a = new double[len];
+    for (int i = 0; i < len; i++ ) {
+      a[i] = (len - 1) - i;
+    }
+    return a;
+  }
 
   /**
    * Rearrange the elements of an array in random order.


### PR DESCRIPTION
## The problem

`partition` takes its pivot from a fixed position, `arr[lo]`. On an ordered range that is the
smallest element, so each partition strips one element instead of about half and `select` becomes
quadratic:

| array size | comparisons | needed |
| --- | --- | --- |
| 1,024 | 393,471 | 2,019 |
| 4,096 | 6,292,479 | 8,157 |
| 16,384 | 100,667,391 | 32,727 |

Per-element cost doubles as `n` doubles. Reverse-ordered input is worse: 33,550,336 comparisons
against 2.

## Where it bites

No sketch reaches this today. Every internal caller passes an array read out of a hash table, and
theta indexes slots by the low bits of the hash, which are independent of its magnitude — feeding a
union gadget strictly ascending hashes still yields a table whose ascending-adjacent-pair fraction
is 0.51.

The exposure is that `QuickSelect` is public API, where ordered input is unremarkable. A compact
ordered sketch's hashes are sorted, and they are the natural thing for a caller to have in hand.
The current safety of this class rests on an incidental property of `HashOperations` probing that
`QuickSelect` neither documents nor requires.

## The change

Pivot on the median of `arr[lo]`, the middle element and `arr[hi]`. The middle element of an
ordered range is its true median, so that input becomes the best case rather than the worst. It also
leaves `arr[hi] >=` the pivot, which bounds the ascending scan, so both scans drop their
per-element bound check.

Speed on hash-table input is unchanged, within 6% in both directions depending on table fill.
All-equal input costs ~1.7x more, on an operation taking microseconds.

## Tests

The existing tests shuffle before every assertion, so ordered input was never covered. They now
also run ascending, descending and all-equal input. The quadratic path returns the *correct* value,
so it can only be caught by work done, hence a large ordered array under a time limit — that test
takes 10,008 ms before this change and 13 ms after.
